### PR TITLE
fix: GCS認証情報の自動検出とエラーハンドリングを追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,11 @@ GCP_PROJECT_ID=your-project-id
 # デフォルトリージョン
 GCP_REGION=asia-northeast1
 
+# GCP認証情報
+# サービスアカウントキーファイルのパス（オプション）
+# 設定しない場合は gcloud auth application-default login で認証してください
+# GOOGLE_APPLICATION_CREDENTIALS=/path/to/your-service-account-key.json
+
 # サービスアカウント名（オプション、デフォルト: keiba-prediction-sa）
 SERVICE_ACCOUNT_NAME=keiba-prediction-sa
 

--- a/scripts/sync_to_gcs.sh
+++ b/scripts/sync_to_gcs.sh
@@ -38,6 +38,24 @@ if [ ! -f ".env" ]; then
     exit 1
 fi
 
+# GCP認証情報の設定
+# 1. 環境変数GOOGLE_APPLICATION_CREDENTIALSが既に設定されている場合はそれを使用
+# 2. プロジェクトルートにkey.jsonがある場合はそれを使用
+# 3. どちらもない場合はgcloud auth application-default loginが必要
+if [ -z "$GOOGLE_APPLICATION_CREDENTIALS" ]; then
+    if [ -f "$PROJECT_ROOT/key.json" ]; then
+        export GOOGLE_APPLICATION_CREDENTIALS="$PROJECT_ROOT/key.json"
+        echo "認証情報: $PROJECT_ROOT/key.json を使用"
+    else
+        echo "注意: サービスアカウントキーが見つかりません。"
+        echo "gcloud auth application-default login で認証するか、"
+        echo "key.json をプロジェクトルートに配置してください。"
+        echo ""
+    fi
+else
+    echo "認証情報: $GOOGLE_APPLICATION_CREDENTIALS を使用"
+fi
+
 # Pythonスクリプトを実行
 echo "========================================"
 echo "GCSアップロードスクリプト"


### PR DESCRIPTION
## Summary

- GCSアップロードスクリプト実行時に認証情報が見つからないエラーを修正
- `sync_to_gcs.sh`がプロジェクトルートの`key.json`を自動的に検出して使用
- 認証エラー時にわかりやすい日本語メッセージとセットアップ手順を表示

## 変更内容

### upload_to_gcs.py
- `_create_client`メソッドを追加し、認証の優先順位を明確化
  1. `--credentials`引数で指定されたファイル
  2. `GOOGLE_APPLICATION_CREDENTIALS`環境変数
  3. Application Default Credentials
- 認証エラー時に詳細なセットアップ手順を表示

### sync_to_gcs.sh
- `key.json`が存在する場合は自動的に`GOOGLE_APPLICATION_CREDENTIALS`を設定
- 認証情報の使用状況をログ出力

### .env.example
- `GOOGLE_APPLICATION_CREDENTIALS`の説明を追加

## Test plan

- [x] 既存テスト23件がすべてパス
- [ ] `key.json`が存在する状態で`./scripts/sync_to_gcs.sh --dry-run`を実行

🤖 Generated with [Claude Code](https://claude.com/claude-code)