### PR TITLE
fix: db-dtypes依存関係を追加

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 google-cloud-bigquery==3.14.1
 google-cloud-storage==2.14.0
 google-cloud-functions==1.15.0
+db-dtypes==1.2.0  # BigQuery to_dataframe()に必要
 
 # Data Processing
 pandas==2.1.4


### PR DESCRIPTION
## Summary
- BigQueryの`to_dataframe()`メソッドに必要な`db-dtypes`パッケージをrequirements.txtに追加

## 問題
特徴量パイプライン実行時に以下のエラーが発生：
```
ValueError: Please install the 'db-dtypes' package to use this function.
```

## 修正
`db-dtypes==1.2.0`をrequirements.txtに追加

## Test plan
- [x] 全テストがパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)