### PR TITLE
fix: BigQueryへの保存時の型変換エラーを修正

### DIFF
--- a/src/features/feature_pipeline.py
+++ b/src/features/feature_pipeline.py
@@ -308,8 +308,7 @@ class FeaturePipeline:
         output_df = features[output_columns].copy()
 
         # データ型を調整
-        if "race_date" in output_df.columns:
-            output_df["race_date"] = pd.to_datetime(output_df["race_date"]).dt.date
+        output_df = self._convert_column_types(output_df)
 
         job_config = bigquery.LoadJobConfig(
             write_disposition=bigquery.WriteDisposition.WRITE_APPEND,
@@ -319,6 +318,101 @@ class FeaturePipeline:
         job.result()
 
         logger.info(f"Saved {len(output_df)} rows to {table_id}")
+
+    def _convert_column_types(self, df: pd.DataFrame) -> pd.DataFrame:
+        """BigQueryスキーマに合わせてカラムの型を変換"""
+        import numpy as np
+
+        # 日付型
+        if "race_date" in df.columns:
+            df["race_date"] = pd.to_datetime(df["race_date"]).dt.date
+
+        # 文字列型として保存すべきカラム
+        string_columns = [
+            "race_id",
+            "horse_id",
+            "venue_code",
+            "course_type",
+            "track_condition",
+            "jockey_id",
+            "trainer_id",
+        ]
+        for col in string_columns:
+            if col in df.columns:
+                df[col] = df[col].astype(str).replace("nan", None).replace("None", None)
+
+        # 整数型として保存すべきカラム
+        int_columns = [
+            "race_number",
+            "num_horses",
+            "bracket_number",
+            "horse_number",
+            "finish_position",
+            "career_races",
+            "career_wins",
+            "career_places",
+            "days_since_last_race",
+            "distance",
+            "distance_change",
+        ]
+        for col in int_columns:
+            if col in df.columns:
+                # NaNを含む可能性があるため、Int64を使用
+                df[col] = pd.to_numeric(df[col], errors="coerce").astype("Int64")
+
+        # 浮動小数点型として保存すべきカラム
+        float_columns = [
+            "weight",
+            "finish_time",
+            "last_3f_time",
+            "past_3_avg_position",
+            "past_5_avg_position",
+            "past_10_avg_position",
+            "past_3_avg_last3f",
+            "past_5_avg_last3f",
+            "past_3_win_rate",
+            "past_5_win_rate",
+            "past_3_place_rate",
+            "past_5_place_rate",
+            "position_trend_3",
+            "distance_change_ratio",
+            "turf_win_rate",
+            "turf_place_rate",
+            "dirt_win_rate",
+            "dirt_place_rate",
+            "dist_sprint_place_rate",
+            "dist_mile_place_rate",
+            "dist_intermediate_place_rate",
+            "dist_long_place_rate",
+            "track_good_place_rate",
+            "track_heavy_place_rate",
+            "current_course_aptitude",
+            "current_distance_aptitude",
+            "current_track_aptitude",
+            "current_venue_aptitude",
+            "avg_corner4_position",
+            "avg_corner4_ratio",
+            "front_rate",
+            "closer_rate",
+        ]
+        for col in float_columns:
+            if col in df.columns:
+                df[col] = pd.to_numeric(df[col], errors="coerce").astype("Float64")
+
+        # ブール型
+        if "target_place" in df.columns:
+            df["target_place"] = df["target_place"].astype(bool)
+
+        # distance_category_change は文字列
+        if "distance_category_change" in df.columns:
+            df["distance_category_change"] = (
+                df["distance_category_change"]
+                .astype(str)
+                .replace("nan", None)
+                .replace("None", None)
+            )
+
+        return df
 
     def _get_output_columns(self, features: pd.DataFrame) -> list[str]:
         """出力するカラムを決定"""

--- a/src/features/past_performance.py
+++ b/src/features/past_performance.py
@@ -229,11 +229,17 @@ class PastPerformanceFeatures:
 
             # トレンド指標 (直近3走の着順トレンド)
             if len(horse_data) >= 3:
-                recent_3 = horse_data.head(3)["finish_position"].values
-                # 改善傾向: 負の傾きは改善 (着順が下がっている)
-                x = np.array([0, 1, 2])
-                slope, _ = np.polyfit(x, recent_3, 1)
-                feature_row["position_trend_3"] = slope
+                recent_3 = horse_data.head(3)["finish_position"]
+                # 数値型に変換（object型の場合のエラーを防ぐ）
+                recent_3_numeric = pd.to_numeric(recent_3, errors="coerce").dropna()
+                if len(recent_3_numeric) >= 3:
+                    recent_3_values = recent_3_numeric.values[:3].astype(float)
+                    # 改善傾向: 負の傾きは改善 (着順が下がっている)
+                    x = np.array([0, 1, 2], dtype=float)
+                    slope, _ = np.polyfit(x, recent_3_values, 1)
+                    feature_row["position_trend_3"] = float(slope)
+                else:
+                    feature_row["position_trend_3"] = None
             else:
                 feature_row["position_trend_3"] = None
 


### PR DESCRIPTION
## Summary
- feature_pipeline実行時のBigQueryスキーマ不一致エラーを修正
- `track_condition`がINTEGERとして送信されていた問題を修正
- `position_trend_3`計算時のdtype変換エラーを修正

## 修正内容

### 1. 型変換メソッドの追加 (`_convert_column_types`)
BigQueryに保存する前に、各カラムを適切な型に変換するメソッドを追加：
- 文字列カラム: `track_condition`, `venue_code`, `course_type`等 → STRING
- 整数カラム: `race_number`, `finish_position`等 → Int64 (NULL許容)
- 浮動小数点カラム: `win_rate`, `place_rate`等 → Float64

### 2. position_trend_3計算の修正
- `finish_position`がobject型の場合に`np.polyfit`でエラーになる問題を修正
- 明示的に`pd.to_numeric()`で数値変換を行うよう修正

## 修正されるエラー
```
google.api_core.exceptions.BadRequest: 400 Field track_condition has changed type from STRING to INTEGER
```
```
Cannot cast ufunc 'lstsq_n' input 1 from dtype('O') to dtype('float64')
```

## Test plan
- [x] 既存の19テストすべてパス
- [ ] `python3 -m src.features.feature_pipeline --start-date 2024-01-01 --end-date 2024-12-31` の実行確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)