### PR TITLE
feat: GCSアップロード処理のCloud Run対応 (#54)

### DIFF
--- a/src/data/upload_to_gcs.py
+++ b/src/data/upload_to_gcs.py
@@ -6,25 +6,29 @@ GCSアップロードスクリプト
 - 重複チェック（MD5ハッシュ比較）
 - 差分アップロード
 - リトライ処理
+- Cloud Run環境対応
 
 Issue #6: ローカル→GCS自動アップロードスクリプトの実装
+Issue #54: GCSアップロード処理のCloud Run対応
 """
 
 import base64
 import hashlib
+import logging
 import os
-import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
-from dotenv import load_dotenv
 from google.api_core import retry
+from google.auth import default as auth_default
 from google.auth.exceptions import DefaultCredentialsError
 from google.cloud import storage
 from google.cloud.exceptions import NotFound
 from google.oauth2 import service_account
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -89,7 +93,10 @@ class GCSUploader:
         認証の優先順位:
         1. credentials_path引数で指定されたサービスアカウントキー
         2. GOOGLE_APPLICATION_CREDENTIALS環境変数
-        3. Application Default Credentials (gcloud auth application-default login)
+        3. Application Default Credentials (Cloud Run/gcloud auth)
+
+        Cloud Run環境では、サービスアカウントが自動的に
+        アタッチされるため、追加の認証設定は不要。
 
         Args:
             project_id: GCPプロジェクトID
@@ -99,55 +106,50 @@ class GCSUploader:
             GCS Client
 
         Raises:
-            SystemExit: 認証に失敗した場合
+            RuntimeError: 認証に失敗した場合
         """
         # 1. 引数で指定されたサービスアカウントキーを使用
         if credentials_path:
             if not os.path.exists(credentials_path):
-                print(f"エラー: サービスアカウントキーファイルが見つかりません: {credentials_path}")
-                sys.exit(1)
+                raise RuntimeError(
+                    f"サービスアカウントキーファイルが見つかりません: {credentials_path}"
+                )
             credentials = service_account.Credentials.from_service_account_file(
                 credentials_path
             )
+            logger.info("サービスアカウントキーファイルで認証しました")
             return storage.Client(project=project_id, credentials=credentials)
 
         # 2. 環境変数で指定されたサービスアカウントキーを使用
         env_credentials_path = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
-        if env_credentials_path:
-            if not os.path.exists(env_credentials_path):
-                print(
-                    f"エラー: GOOGLE_APPLICATION_CREDENTIALS で指定されたファイルが見つかりません: "
-                    f"{env_credentials_path}"
-                )
-                sys.exit(1)
+        if env_credentials_path and os.path.exists(env_credentials_path):
             credentials = service_account.Credentials.from_service_account_file(
                 env_credentials_path
             )
+            logger.info("GOOGLE_APPLICATION_CREDENTIALS で認証しました")
             return storage.Client(project=project_id, credentials=credentials)
 
-        # 3. Application Default Credentialsを使用
+        # 3. Application Default Credentials を使用（Cloud Run環境向け）
         try:
-            return storage.Client(project=project_id)
-        except DefaultCredentialsError:
-            print("エラー: GCP認証情報が見つかりません。")
-            print("")
-            print("以下のいずれかの方法で認証を設定してください:")
-            print("")
-            print("方法1: gcloud CLIでログイン（開発環境向け）")
-            print("  $ gcloud auth application-default login")
-            print("")
-            print("方法2: サービスアカウントキーを環境変数で指定")
-            print("  $ export GOOGLE_APPLICATION_CREDENTIALS=/path/to/keyfile.json")
-            print("")
-            print("方法3: .envファイルにGOOGLE_APPLICATION_CREDENTIALSを設定")
-            print("  GOOGLE_APPLICATION_CREDENTIALS=/path/to/keyfile.json")
-            print("")
-            print("サービスアカウントキーの作成方法:")
-            print("  1. GCPコンソール > IAMと管理 > サービスアカウント")
-            print("  2. サービスアカウントを作成または選択")
-            print("  3. キー > 鍵を追加 > 新しい鍵を作成 > JSON")
-            print("  4. ダウンロードしたJSONファイルを安全な場所に保存")
-            sys.exit(1)
+            credentials, detected_project = auth_default()
+            logger.info(
+                f"Application Default Credentials で認証しました "
+                f"(検出されたプロジェクト: {detected_project})"
+            )
+            return storage.Client(project=project_id, credentials=credentials)
+        except DefaultCredentialsError as e:
+            error_msg = (
+                "GCP認証情報が見つかりません。\n"
+                "以下のいずれかの方法で認証を設定してください:\n\n"
+                "方法1: gcloud CLIでログイン（開発環境向け）\n"
+                "  $ gcloud auth application-default login\n\n"
+                "方法2: サービスアカウントキーを環境変数で指定\n"
+                "  $ export GOOGLE_APPLICATION_CREDENTIALS=/path/to/keyfile.json\n\n"
+                "方法3: Cloud Run環境では、サービスアカウントを設定\n"
+                "  --service-account オプションでデプロイ時に指定"
+            )
+            logger.error(error_msg)
+            raise RuntimeError(error_msg) from e
 
     def _calculate_md5(self, file_path: Path) -> str:
         """
@@ -234,10 +236,13 @@ class GCSUploader:
             except Exception as e:
                 if attempt < max_retries - 1:
                     wait_time = 2**attempt
-                    print(f"  リトライ {attempt + 1}/{max_retries}: {wait_time}秒後に再試行...")
+                    logger.warning(
+                        f"リトライ {attempt + 1}/{max_retries}: "
+                        f"{wait_time}秒後に再試行... ({blob_name})"
+                    )
                     time.sleep(wait_time)
                 else:
-                    print(f"  エラー: {e}")
+                    logger.error(f"アップロード失敗 {blob_name}: {e}")
                     return False
 
         return False
@@ -262,7 +267,7 @@ class GCSUploader:
         local_dir = self.local_base_dir / data_type
 
         if not local_dir.exists():
-            print(f"ディレクトリが見つかりません: {local_dir}")
+            logger.warning(f"ディレクトリが見つかりません: {local_dir}")
             return UploadResult(
                 total_files=0,
                 uploaded_files=0,
@@ -284,10 +289,7 @@ class GCSUploader:
         failed_files = 0
         uploaded_bytes = 0
 
-        print(f"\n{'=' * 60}")
-        print(f"データタイプ: {data_type}")
-        print(f"対象ファイル数: {total_files}")
-        print(f"{'=' * 60}")
+        logger.info(f"データタイプ: {data_type}, 対象ファイル数: {total_files}")
 
         for i, file_path in enumerate(sorted(files), 1):
             blob_name = f"{data_type}/{file_path.name}"
@@ -296,11 +298,14 @@ class GCSUploader:
             if not force and not self._should_upload(file_path, blob_name):
                 skipped_files += 1
                 if i % 100 == 0:
-                    print(f"  進捗: {i}/{total_files} (スキップ: {skipped_files})")
+                    logger.debug(
+                        f"進捗: {i}/{total_files} "
+                        f"(スキップ: {skipped_files})"
+                    )
                 continue
 
             if dry_run:
-                print(f"  [DRY RUN] アップロード: {file_path.name}")
+                logger.info(f"[DRY RUN] アップロード: {file_path.name}")
                 uploaded_files += 1
                 uploaded_bytes += file_path.stat().st_size
                 continue
@@ -310,10 +315,13 @@ class GCSUploader:
                 uploaded_files += 1
                 uploaded_bytes += file_path.stat().st_size
                 if i % 100 == 0 or i == total_files:
-                    print(f"  進捗: {i}/{total_files} (アップロード: {uploaded_files})")
+                    logger.info(
+                        f"進捗: {i}/{total_files} "
+                        f"(アップロード: {uploaded_files})"
+                    )
             else:
                 failed_files += 1
-                print(f"  失敗: {file_path.name}")
+                logger.error(f"失敗: {file_path.name}")
 
         return UploadResult(
             total_files=total_files,
@@ -347,13 +355,17 @@ class GCSUploader:
         )
 
         # ダウンロードディレクトリ内のサブディレクトリを取得
+        if not self.local_base_dir.exists():
+            logger.warning(f"ベースディレクトリが見つかりません: {self.local_base_dir}")
+            return total_result
+
         data_types = [
             d.name
             for d in self.local_base_dir.iterdir()
             if d.is_dir() and not d.name.startswith(".")
         ]
 
-        print(f"\n検出されたデータタイプ: {', '.join(sorted(data_types))}")
+        logger.info(f"検出されたデータタイプ: {', '.join(sorted(data_types))}")
 
         for data_type in sorted(data_types):
             result = self.upload_directory(data_type, force=force, dry_run=dry_run)
@@ -364,6 +376,33 @@ class GCSUploader:
             total_result.uploaded_bytes += result.uploaded_bytes
 
         return total_result
+
+    def upload_file(
+        self,
+        local_path: Path,
+        blob_name: str,
+        force: bool = False,
+    ) -> bool:
+        """
+        単一ファイルをアップロード
+
+        Args:
+            local_path: ローカルファイルパス
+            blob_name: GCS上のファイル名
+            force: 強制アップロード
+
+        Returns:
+            アップロード成功の場合True
+        """
+        if not local_path.exists():
+            logger.error(f"ファイルが見つかりません: {local_path}")
+            return False
+
+        if not force and not self._should_upload(local_path, blob_name):
+            logger.info(f"スキップ（既存・同一）: {blob_name}")
+            return True
+
+        return self._upload_file_with_retry(local_path, blob_name)
 
     def verify_bucket_exists(self) -> bool:
         """
@@ -388,9 +427,57 @@ def format_bytes(size: int) -> str:
     return f"{size:.2f} TB"
 
 
+def create_uploader_from_env(
+    local_base_dir: Optional[Path] = None,
+) -> Optional[GCSUploader]:
+    """
+    環境変数からGCSUploaderを作成
+
+    環境変数:
+        GCP_PROJECT_ID: GCPプロジェクトID
+        GCS_BUCKET_RAW: バケット名のサフィックス（デフォルト: keiba-raw-data）
+        GOOGLE_APPLICATION_CREDENTIALS: サービスアカウントキーファイルのパス（オプション）
+
+    Args:
+        local_base_dir: ローカルの基準ディレクトリ
+
+    Returns:
+        GCSUploaderインスタンス（設定が不足している場合はNone）
+    """
+    project_id = os.environ.get("GCP_PROJECT_ID")
+    if not project_id:
+        logger.error("GCP_PROJECT_ID環境変数が設定されていません")
+        return None
+
+    bucket_suffix = os.environ.get("GCS_BUCKET_RAW", "keiba-raw-data")
+    bucket_name = f"{project_id}-{bucket_suffix}"
+
+    logger.info(f"GCPプロジェクトID: {project_id}")
+    logger.info(f"GCSバケット名: {bucket_name}")
+
+    try:
+        return GCSUploader(
+            project_id=project_id,
+            bucket_name=bucket_name,
+            local_base_dir=local_base_dir,
+        )
+    except RuntimeError as e:
+        logger.error(f"GCSUploaderの作成に失敗: {e}")
+        return None
+
+
 def main():
     """メイン処理"""
     import argparse
+    import sys
+
+    from dotenv import load_dotenv
+
+    # ロギング設定
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
 
     parser = argparse.ArgumentParser(description="GCSアップロードスクリプト")
     parser.add_argument(
@@ -415,6 +502,12 @@ def main():
         default=None,
         help="サービスアカウントキーファイルのパス",
     )
+    parser.add_argument(
+        "--local-dir",
+        type=str,
+        default=None,
+        help="ローカルの基準ディレクトリ",
+    )
     args = parser.parse_args()
 
     # .envファイルを読み込み
@@ -425,22 +518,34 @@ def main():
     bucket_suffix = os.getenv("GCS_BUCKET_RAW", "keiba-raw-data")
 
     if not project_id:
-        print("エラー: GCP_PROJECT_ID環境変数が設定されていません。")
+        logger.error("GCP_PROJECT_ID環境変数が設定されていません。")
         sys.exit(1)
 
     # バケット名を構築
     bucket_name = f"{project_id}-{bucket_suffix}"
 
-    print(f"GCPプロジェクトID: {project_id}")
-    print(f"GCSバケット名: {bucket_name}")
+    logger.info(f"GCPプロジェクトID: {project_id}")
+    logger.info(f"GCSバケット名: {bucket_name}")
+
+    # ローカルディレクトリの設定
+    local_base_dir = Path(args.local_dir) if args.local_dir else None
 
     # アップローダーを作成
-    uploader = GCSUploader(project_id, bucket_name, credentials_path=args.credentials)
+    try:
+        uploader = GCSUploader(
+            project_id,
+            bucket_name,
+            local_base_dir=local_base_dir,
+            credentials_path=args.credentials,
+        )
+    except RuntimeError as e:
+        logger.error(str(e))
+        sys.exit(1)
 
     # バケットの存在確認
     if not uploader.verify_bucket_exists():
-        print(f"\nエラー: バケット {bucket_name} が見つかりません。")
-        print("scripts/setup_gcp.sh を実行してバケットを作成してください。")
+        logger.error(f"バケット {bucket_name} が見つかりません。")
+        logger.error("scripts/setup_gcp.sh を実行してバケットを作成してください。")
         sys.exit(1)
 
     # アップロード実行
@@ -461,15 +566,15 @@ def main():
     elapsed_time = time.time() - start_time
 
     # 結果を表示
-    print(f"\n{'=' * 60}")
-    print("アップロード結果")
-    print(f"{'=' * 60}")
-    print(f"総ファイル数: {result.total_files}")
-    print(f"アップロード: {result.uploaded_files}")
-    print(f"スキップ: {result.skipped_files}")
-    print(f"失敗: {result.failed_files}")
-    print(f"アップロードサイズ: {format_bytes(result.uploaded_bytes)}")
-    print(f"処理時間: {elapsed_time:.2f}秒")
+    logger.info("=" * 60)
+    logger.info("アップロード結果")
+    logger.info("=" * 60)
+    logger.info(f"総ファイル数: {result.total_files}")
+    logger.info(f"アップロード: {result.uploaded_files}")
+    logger.info(f"スキップ: {result.skipped_files}")
+    logger.info(f"失敗: {result.failed_files}")
+    logger.info(f"アップロードサイズ: {format_bytes(result.uploaded_bytes)}")
+    logger.info(f"処理時間: {elapsed_time:.2f}秒")
 
     if result.failed_files > 0:
         sys.exit(1)

--- a/tests/test_upload_to_gcs.py
+++ b/tests/test_upload_to_gcs.py
@@ -3,16 +3,23 @@
 upload_to_gcs.pyのテスト
 
 GCSアップローダークラスの単体テスト
+Issue #54: GCSアップロード処理のCloud Run対応
 """
 
 import hashlib
+import os
 import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from src.data.upload_to_gcs import GCSUploader, UploadResult, format_bytes
+from src.data.upload_to_gcs import (
+    GCSUploader,
+    UploadResult,
+    create_uploader_from_env,
+    format_bytes,
+)
 
 
 class TestUploadResult:
@@ -59,6 +66,103 @@ class TestFormatBytes:
         assert "1.00 TB" == format_bytes(1024 * 1024 * 1024 * 1024)
 
 
+class TestGCSUploaderCreation:
+    """GCSUploaderの初期化テスト"""
+
+    def test_create_with_credentials_path(self):
+        """サービスアカウントキーファイルで初期化"""
+        with tempfile.NamedTemporaryFile(
+            mode="w", delete=False, suffix=".json"
+        ) as f:
+            f.write('{"type": "service_account"}')
+            credentials_path = f.name
+
+        try:
+            with patch(
+                "src.data.upload_to_gcs.service_account.Credentials"
+                ".from_service_account_file"
+            ) as mock_creds, patch(
+                "src.data.upload_to_gcs.storage.Client"
+            ) as mock_client:
+                mock_creds.return_value = MagicMock()
+                uploader = GCSUploader(
+                    project_id="test-project",
+                    bucket_name="test-bucket",
+                    credentials_path=credentials_path,
+                )
+                assert uploader.project_id == "test-project"
+                assert uploader.bucket_name == "test-bucket"
+                mock_creds.assert_called_once_with(credentials_path)
+        finally:
+            os.unlink(credentials_path)
+
+    def test_create_with_missing_credentials_path_raises_error(self):
+        """存在しないサービスアカウントキーファイルを指定した場合はエラー"""
+        with pytest.raises(RuntimeError, match="サービスアカウントキーファイルが見つかりません"):
+            GCSUploader(
+                project_id="test-project",
+                bucket_name="test-bucket",
+                credentials_path="/nonexistent/path.json",
+            )
+
+    def test_create_with_adc(self):
+        """Application Default Credentialsで初期化"""
+        with patch(
+            "src.data.upload_to_gcs.auth_default"
+        ) as mock_auth_default, patch(
+            "src.data.upload_to_gcs.storage.Client"
+        ) as mock_client:
+            mock_auth_default.return_value = (MagicMock(), "detected-project")
+            uploader = GCSUploader(
+                project_id="test-project",
+                bucket_name="test-bucket",
+            )
+            assert uploader.project_id == "test-project"
+            mock_auth_default.assert_called_once()
+
+    def test_create_with_env_credentials(self):
+        """環境変数のサービスアカウントキーで初期化"""
+        with tempfile.NamedTemporaryFile(
+            mode="w", delete=False, suffix=".json"
+        ) as f:
+            f.write('{"type": "service_account"}')
+            credentials_path = f.name
+
+        try:
+            with patch.dict(
+                os.environ, {"GOOGLE_APPLICATION_CREDENTIALS": credentials_path}
+            ), patch(
+                "src.data.upload_to_gcs.service_account.Credentials"
+                ".from_service_account_file"
+            ) as mock_creds, patch(
+                "src.data.upload_to_gcs.storage.Client"
+            ) as mock_client:
+                mock_creds.return_value = MagicMock()
+                uploader = GCSUploader(
+                    project_id="test-project",
+                    bucket_name="test-bucket",
+                )
+                assert uploader.project_id == "test-project"
+        finally:
+            os.unlink(credentials_path)
+
+    def test_create_without_credentials_raises_error(self):
+        """認証情報がない場合はエラー"""
+        from google.auth.exceptions import DefaultCredentialsError
+
+        with patch.dict(os.environ, {}, clear=True), patch(
+            "src.data.upload_to_gcs.auth_default"
+        ) as mock_auth_default:
+            mock_auth_default.side_effect = DefaultCredentialsError(
+                "Could not automatically determine credentials"
+            )
+            with pytest.raises(RuntimeError, match="GCP認証情報が見つかりません"):
+                GCSUploader(
+                    project_id="test-project",
+                    bucket_name="test-bucket",
+                )
+
+
 class TestGCSUploaderMD5:
     """GCSUploaderのMD5計算テスト"""
 
@@ -69,7 +173,10 @@ class TestGCSUploaderMD5:
             temp_path = Path(f.name)
 
         try:
-            with patch("src.data.upload_to_gcs.storage.Client"):
+            with patch("src.data.upload_to_gcs.storage.Client"), patch(
+                "src.data.upload_to_gcs.auth_default",
+                return_value=(MagicMock(), "project"),
+            ):
                 uploader = GCSUploader(
                     project_id="test-project",
                     bucket_name="test-bucket",
@@ -94,7 +201,10 @@ class TestGCSUploaderMD5:
             temp_path = Path(f.name)
 
         try:
-            with patch("src.data.upload_to_gcs.storage.Client"):
+            with patch("src.data.upload_to_gcs.storage.Client"), patch(
+                "src.data.upload_to_gcs.auth_default",
+                return_value=(MagicMock(), "project"),
+            ):
                 uploader = GCSUploader(
                     project_id="test-project",
                     bucket_name="test-bucket",
@@ -119,7 +229,10 @@ class TestGCSUploaderShouldUpload:
             temp_path = Path(f.name)
 
         try:
-            with patch("src.data.upload_to_gcs.storage.Client"):
+            with patch("src.data.upload_to_gcs.storage.Client"), patch(
+                "src.data.upload_to_gcs.auth_default",
+                return_value=(MagicMock(), "project"),
+            ):
                 uploader = GCSUploader(
                     project_id="test-project",
                     bucket_name="test-bucket",
@@ -139,7 +252,10 @@ class TestGCSUploaderShouldUpload:
             temp_path = Path(f.name)
 
         try:
-            with patch("src.data.upload_to_gcs.storage.Client"):
+            with patch("src.data.upload_to_gcs.storage.Client"), patch(
+                "src.data.upload_to_gcs.auth_default",
+                return_value=(MagicMock(), "project"),
+            ):
                 uploader = GCSUploader(
                     project_id="test-project",
                     bucket_name="test-bucket",
@@ -161,7 +277,10 @@ class TestGCSUploaderShouldUpload:
             temp_path = Path(f.name)
 
         try:
-            with patch("src.data.upload_to_gcs.storage.Client"):
+            with patch("src.data.upload_to_gcs.storage.Client"), patch(
+                "src.data.upload_to_gcs.auth_default",
+                return_value=(MagicMock(), "project"),
+            ):
                 uploader = GCSUploader(
                     project_id="test-project",
                     bucket_name="test-bucket",
@@ -178,13 +297,112 @@ class TestGCSUploaderShouldUpload:
             temp_path.unlink()
 
 
+class TestGCSUploaderUploadFile:
+    """GCSUploaderのupload_fileテスト"""
+
+    def test_upload_file_success(self):
+        """単一ファイルのアップロード成功"""
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".csv") as f:
+            f.write("test data")
+            temp_path = Path(f.name)
+
+        try:
+            with patch("src.data.upload_to_gcs.storage.Client"), patch(
+                "src.data.upload_to_gcs.auth_default",
+                return_value=(MagicMock(), "project"),
+            ):
+                uploader = GCSUploader(
+                    project_id="test-project",
+                    bucket_name="test-bucket",
+                )
+
+            with patch.object(
+                uploader, "_should_upload", return_value=True
+            ), patch.object(uploader, "_upload_file_with_retry", return_value=True):
+                result = uploader.upload_file(temp_path, "test/file.csv")
+
+            assert result is True
+        finally:
+            temp_path.unlink()
+
+    def test_upload_file_skipped(self):
+        """単一ファイルがスキップされる場合"""
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".csv") as f:
+            f.write("test data")
+            temp_path = Path(f.name)
+
+        try:
+            with patch("src.data.upload_to_gcs.storage.Client"), patch(
+                "src.data.upload_to_gcs.auth_default",
+                return_value=(MagicMock(), "project"),
+            ):
+                uploader = GCSUploader(
+                    project_id="test-project",
+                    bucket_name="test-bucket",
+                )
+
+            with patch.object(uploader, "_should_upload", return_value=False):
+                result = uploader.upload_file(temp_path, "test/file.csv")
+
+            assert result is True  # スキップも成功扱い
+        finally:
+            temp_path.unlink()
+
+    def test_upload_file_not_found(self):
+        """存在しないファイルをアップロードしようとした場合"""
+        with patch("src.data.upload_to_gcs.storage.Client"), patch(
+            "src.data.upload_to_gcs.auth_default",
+            return_value=(MagicMock(), "project"),
+        ):
+            uploader = GCSUploader(
+                project_id="test-project",
+                bucket_name="test-bucket",
+            )
+
+        result = uploader.upload_file(Path("/nonexistent/file.csv"), "test/file.csv")
+
+        assert result is False
+
+    def test_upload_file_force(self):
+        """force=Trueで強制アップロード"""
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".csv") as f:
+            f.write("test data")
+            temp_path = Path(f.name)
+
+        try:
+            with patch("src.data.upload_to_gcs.storage.Client"), patch(
+                "src.data.upload_to_gcs.auth_default",
+                return_value=(MagicMock(), "project"),
+            ):
+                uploader = GCSUploader(
+                    project_id="test-project",
+                    bucket_name="test-bucket",
+                )
+
+            with patch.object(
+                uploader, "_should_upload"
+            ) as mock_should_upload, patch.object(
+                uploader, "_upload_file_with_retry", return_value=True
+            ):
+                result = uploader.upload_file(temp_path, "test/file.csv", force=True)
+
+            # force=Trueの場合は_should_uploadは呼ばれない
+            mock_should_upload.assert_not_called()
+            assert result is True
+        finally:
+            temp_path.unlink()
+
+
 class TestGCSUploaderUploadDirectory:
     """GCSUploaderのupload_directoryテスト"""
 
     def test_upload_directory_empty(self):
         """存在しないディレクトリの場合は空の結果を返す"""
         with tempfile.TemporaryDirectory() as temp_dir:
-            with patch("src.data.upload_to_gcs.storage.Client"):
+            with patch("src.data.upload_to_gcs.storage.Client"), patch(
+                "src.data.upload_to_gcs.auth_default",
+                return_value=(MagicMock(), "project"),
+            ):
                 uploader = GCSUploader(
                     project_id="test-project",
                     bucket_name="test-bucket",
@@ -212,7 +430,10 @@ class TestGCSUploaderUploadDirectory:
             (data_dir / "file3.json").write_text("{}")
             (data_dir / "file4.py").write_text("code")
 
-            with patch("src.data.upload_to_gcs.storage.Client"):
+            with patch("src.data.upload_to_gcs.storage.Client"), patch(
+                "src.data.upload_to_gcs.auth_default",
+                return_value=(MagicMock(), "project"),
+            ):
                 uploader = GCSUploader(
                     project_id="test-project",
                     bucket_name="test-bucket",
@@ -240,6 +461,9 @@ class TestGCSUploaderUploadDirectory:
 
             with patch(
                 "src.data.upload_to_gcs.storage.Client", return_value=mock_client
+            ), patch(
+                "src.data.upload_to_gcs.auth_default",
+                return_value=(MagicMock(), "project"),
             ):
                 uploader = GCSUploader(
                     project_id="test-project",
@@ -262,7 +486,10 @@ class TestGCSUploaderUploadDirectory:
             (data_dir / "file1.csv").write_text("data1")
             (data_dir / "file2.csv").write_text("data2")
 
-            with patch("src.data.upload_to_gcs.storage.Client"):
+            with patch("src.data.upload_to_gcs.storage.Client"), patch(
+                "src.data.upload_to_gcs.auth_default",
+                return_value=(MagicMock(), "project"),
+            ):
                 uploader = GCSUploader(
                     project_id="test-project",
                     bucket_name="test-bucket",
@@ -286,7 +513,10 @@ class TestGCSUploaderUploadDirectory:
             data_dir.mkdir()
             (data_dir / "file1.csv").write_text("data1")
 
-            with patch("src.data.upload_to_gcs.storage.Client"):
+            with patch("src.data.upload_to_gcs.storage.Client"), patch(
+                "src.data.upload_to_gcs.auth_default",
+                return_value=(MagicMock(), "project"),
+            ):
                 uploader = GCSUploader(
                     project_id="test-project",
                     bucket_name="test-bucket",
@@ -317,16 +547,19 @@ class TestGCSUploaderUploadAll:
                 data_dir.mkdir()
                 (data_dir / "file1.csv").write_text("data1")
 
-            with patch("src.data.upload_to_gcs.storage.Client"):
+            with patch("src.data.upload_to_gcs.storage.Client"), patch(
+                "src.data.upload_to_gcs.auth_default",
+                return_value=(MagicMock(), "project"),
+            ):
                 uploader = GCSUploader(
                     project_id="test-project",
                     bucket_name="test-bucket",
                     local_base_dir=Path(temp_dir),
                 )
 
-            with patch.object(uploader, "_should_upload", return_value=True), patch.object(
-                uploader, "_upload_file_with_retry", return_value=True
-            ):
+            with patch.object(
+                uploader, "_should_upload", return_value=True
+            ), patch.object(uploader, "_upload_file_with_retry", return_value=True):
                 result = uploader.upload_all()
 
             # 2ディレクトリ x 1ファイル = 2ファイル
@@ -346,20 +579,40 @@ class TestGCSUploaderUploadAll:
             hidden_dir.mkdir()
             (hidden_dir / "secret.csv").write_text("secret")
 
-            with patch("src.data.upload_to_gcs.storage.Client"):
+            with patch("src.data.upload_to_gcs.storage.Client"), patch(
+                "src.data.upload_to_gcs.auth_default",
+                return_value=(MagicMock(), "project"),
+            ):
                 uploader = GCSUploader(
                     project_id="test-project",
                     bucket_name="test-bucket",
                     local_base_dir=Path(temp_dir),
                 )
 
-            with patch.object(uploader, "_should_upload", return_value=True), patch.object(
-                uploader, "_upload_file_with_retry", return_value=True
-            ):
+            with patch.object(
+                uploader, "_should_upload", return_value=True
+            ), patch.object(uploader, "_upload_file_with_retry", return_value=True):
                 result = uploader.upload_all()
 
             # 隠しディレクトリのファイルは含まれない
             assert result.total_files == 1
+
+    def test_upload_all_nonexistent_base_dir(self):
+        """ベースディレクトリが存在しない場合は空の結果を返す"""
+        with patch("src.data.upload_to_gcs.storage.Client"), patch(
+            "src.data.upload_to_gcs.auth_default",
+            return_value=(MagicMock(), "project"),
+        ):
+            uploader = GCSUploader(
+                project_id="test-project",
+                bucket_name="test-bucket",
+                local_base_dir=Path("/nonexistent/path"),
+            )
+
+        result = uploader.upload_all()
+
+        assert result.total_files == 0
+        assert result.uploaded_files == 0
 
 
 class TestGCSUploaderVerifyBucket:
@@ -371,6 +624,9 @@ class TestGCSUploaderVerifyBucket:
 
         with patch(
             "src.data.upload_to_gcs.storage.Client", return_value=mock_client
+        ), patch(
+            "src.data.upload_to_gcs.auth_default",
+            return_value=(MagicMock(), "project"),
         ):
             uploader = GCSUploader(
                 project_id="test-project",
@@ -389,6 +645,9 @@ class TestGCSUploaderVerifyBucket:
 
         with patch(
             "src.data.upload_to_gcs.storage.Client", return_value=mock_client
+        ), patch(
+            "src.data.upload_to_gcs.auth_default",
+            return_value=(MagicMock(), "project"),
         ):
             uploader = GCSUploader(
                 project_id="test-project",
@@ -416,6 +675,9 @@ class TestGCSUploaderRetry:
 
             with patch(
                 "src.data.upload_to_gcs.storage.Client", return_value=mock_client
+            ), patch(
+                "src.data.upload_to_gcs.auth_default",
+                return_value=(MagicMock(), "project"),
             ):
                 uploader = GCSUploader(
                     project_id="test-project",
@@ -450,7 +712,12 @@ class TestGCSUploaderRetry:
 
             with patch(
                 "src.data.upload_to_gcs.storage.Client", return_value=mock_client
-            ), patch("src.data.upload_to_gcs.time.sleep"):
+            ), patch(
+                "src.data.upload_to_gcs.auth_default",
+                return_value=(MagicMock(), "project"),
+            ), patch(
+                "src.data.upload_to_gcs.time.sleep"
+            ):
                 uploader = GCSUploader(
                     project_id="test-project",
                     bucket_name="test-bucket",
@@ -481,7 +748,12 @@ class TestGCSUploaderRetry:
 
             with patch(
                 "src.data.upload_to_gcs.storage.Client", return_value=mock_client
-            ), patch("src.data.upload_to_gcs.time.sleep"):
+            ), patch(
+                "src.data.upload_to_gcs.auth_default",
+                return_value=(MagicMock(), "project"),
+            ), patch(
+                "src.data.upload_to_gcs.time.sleep"
+            ):
                 uploader = GCSUploader(
                     project_id="test-project",
                     bucket_name="test-bucket",
@@ -495,3 +767,67 @@ class TestGCSUploaderRetry:
             assert mock_blob.upload_from_filename.call_count == 3
         finally:
             temp_path.unlink()
+
+
+class TestCreateUploaderFromEnv:
+    """create_uploader_from_env関数のテスト"""
+
+    def test_create_uploader_from_env_success(self):
+        """環境変数から正常にUploaderを作成"""
+        with patch.dict(
+            os.environ, {"GCP_PROJECT_ID": "test-project", "GCS_BUCKET_RAW": "raw-data"}
+        ), patch("src.data.upload_to_gcs.storage.Client"), patch(
+            "src.data.upload_to_gcs.auth_default",
+            return_value=(MagicMock(), "project"),
+        ):
+            uploader = create_uploader_from_env()
+
+        assert uploader is not None
+        assert uploader.project_id == "test-project"
+        assert uploader.bucket_name == "test-project-raw-data"
+
+    def test_create_uploader_from_env_default_bucket(self):
+        """デフォルトのバケットサフィックスを使用"""
+        with patch.dict(
+            os.environ, {"GCP_PROJECT_ID": "test-project"}, clear=True
+        ), patch("src.data.upload_to_gcs.storage.Client"), patch(
+            "src.data.upload_to_gcs.auth_default",
+            return_value=(MagicMock(), "project"),
+        ):
+            uploader = create_uploader_from_env()
+
+        assert uploader is not None
+        assert uploader.bucket_name == "test-project-keiba-raw-data"
+
+    def test_create_uploader_from_env_missing_project_id(self):
+        """プロジェクトIDがない場合はNoneを返す"""
+        with patch.dict(os.environ, {}, clear=True):
+            uploader = create_uploader_from_env()
+
+        assert uploader is None
+
+    def test_create_uploader_from_env_with_local_base_dir(self):
+        """local_base_dirを指定してUploaderを作成"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with patch.dict(
+                os.environ, {"GCP_PROJECT_ID": "test-project"}
+            ), patch("src.data.upload_to_gcs.storage.Client"), patch(
+                "src.data.upload_to_gcs.auth_default",
+                return_value=(MagicMock(), "project"),
+            ):
+                uploader = create_uploader_from_env(local_base_dir=Path(temp_dir))
+
+            assert uploader is not None
+            assert uploader.local_base_dir == Path(temp_dir)
+
+    def test_create_uploader_from_env_auth_failure(self):
+        """認証失敗時はNoneを返す"""
+        from google.auth.exceptions import DefaultCredentialsError
+
+        with patch.dict(os.environ, {"GCP_PROJECT_ID": "test-project"}), patch(
+            "src.data.upload_to_gcs.auth_default"
+        ) as mock_auth:
+            mock_auth.side_effect = DefaultCredentialsError("No credentials")
+            uploader = create_uploader_from_env()
+
+        assert uploader is None


### PR DESCRIPTION
## Summary
- GCSアップロード処理をCloud Run環境で動作するように修正
- ログ出力をloggerに統一してCloud Run環境でのモニタリングを改善
- Application Default Credentials (ADC) のサポートを強化

## 変更内容
- `print`文から`logger`への移行
- Cloud Run環境での自動認証対応（サービスアカウント）
- `create_uploader_from_env()`関数を追加（環境変数からの初期化を簡素化）
- `upload_file()`メソッドを追加（単一ファイルアップロード対応）
- `--local-dir`オプションを追加（ローカルディレクトリの動的指定）
- 認証失敗時の詳細なエラーメッセージを追加

## Test plan
- [x] 既存テストがすべてパス（38テスト）
- [x] Cloud Run認証のテストを追加
- [x] `create_uploader_from_env`のテストを追加
- [x] `upload_file`のテストを追加

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)