### PR TITLE
feat: BigQuery重複スキップ機能の実装 (#56)

### DIFF
--- a/config/bq_schema_load_history.json
+++ b/config/bq_schema_load_history.json
@@ -1,0 +1,56 @@
+[
+  {
+    "name": "file_name",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "ロードされたファイル名 (GCS上のパス)"
+  },
+  {
+    "name": "loaded_at",
+    "type": "TIMESTAMP",
+    "mode": "REQUIRED",
+    "description": "ロード実行日時"
+  },
+  {
+    "name": "records_count",
+    "type": "INT64",
+    "mode": "NULLABLE",
+    "description": "ロードされたレコード数"
+  },
+  {
+    "name": "table_name",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "ロード先テーブル名"
+  },
+  {
+    "name": "data_type",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "データタイプ (BAA, KYF, SEC等)"
+  },
+  {
+    "name": "status",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "ステータス (success/failed)"
+  },
+  {
+    "name": "error_message",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "エラーメッセージ (失敗時)"
+  },
+  {
+    "name": "duration_seconds",
+    "type": "FLOAT64",
+    "mode": "NULLABLE",
+    "description": "処理時間(秒)"
+  },
+  {
+    "name": "file_size_bytes",
+    "type": "INT64",
+    "mode": "NULLABLE",
+    "description": "ファイルサイズ(バイト)"
+  }
+]

--- a/src/data/load_to_bq.py
+++ b/src/data/load_to_bq.py
@@ -10,6 +10,7 @@ Cloud Run環境での実行を想定しています。
 - BigQueryへのUPSERT (MERGE文)
 - バッチ処理対応
 - エラーハンドリングと失敗ファイルの記録
+- ロード履歴の記録と重複スキップ機能
 """
 
 import logging
@@ -20,7 +21,7 @@ import time
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Set
 
 from google.cloud import bigquery, storage
 from google.cloud.exceptions import GoogleCloudError
@@ -65,6 +66,9 @@ TABLE_UNIQUE_KEYS = {
     "horse_extended": ["race_id", "horse_number"],
     "venue_info": ["venue_id"],
 }
+
+# ロード履歴テーブル名
+LOAD_HISTORY_TABLE = "load_history"
 
 
 @dataclass
@@ -162,6 +166,103 @@ class BigQueryLoader:
             self._storage_client = storage.Client(project=self.project_id)
             logger.info("Cloud Storageクライアントを初期化しました")
         return self._storage_client
+
+    def _get_loaded_files(self) -> Set[str]:
+        """
+        ロード履歴テーブルから成功したファイル名のセットを取得
+
+        Returns:
+            ロード済みファイル名のセット
+        """
+        table_ref = f"{self.project_id}.{self.dataset_id}.{LOAD_HISTORY_TABLE}"
+
+        query = f"""
+        SELECT DISTINCT file_name
+        FROM `{table_ref}`
+        WHERE status = 'success'
+        """
+
+        try:
+            query_job = self.bq_client.query(query)
+            results = query_job.result()
+            loaded_files = {row.file_name for row in results}
+            logger.info(f"ロード履歴から {len(loaded_files)} 件の成功ファイルを取得しました")
+            return loaded_files
+        except Exception as e:
+            # テーブルが存在しない場合は空のセットを返す
+            if "Not found" in str(e):
+                logger.warning(
+                    f"ロード履歴テーブルが見つかりません: {table_ref}. "
+                    "スキップ機能は無効になります。"
+                )
+                return set()
+            logger.error(f"ロード履歴の取得に失敗しました: {e}")
+            raise
+
+    def _record_load_history(
+        self,
+        file_name: str,
+        status: str,
+        records_count: int = 0,
+        table_name: Optional[str] = None,
+        data_type: Optional[str] = None,
+        error_message: Optional[str] = None,
+        duration_seconds: float = 0.0,
+        file_size_bytes: Optional[int] = None,
+    ) -> None:
+        """
+        ロード履歴をBigQueryに記録
+
+        Args:
+            file_name: ファイル名
+            status: ステータス (success/failed)
+            records_count: ロードしたレコード数
+            table_name: ロード先テーブル名
+            data_type: データタイプ
+            error_message: エラーメッセージ
+            duration_seconds: 処理時間
+            file_size_bytes: ファイルサイズ
+        """
+        table_ref = f"{self.project_id}.{self.dataset_id}.{LOAD_HISTORY_TABLE}"
+
+        row = {
+            "file_name": file_name,
+            "loaded_at": datetime.utcnow().isoformat(),
+            "records_count": records_count,
+            "table_name": table_name,
+            "data_type": data_type,
+            "status": status,
+            "error_message": error_message,
+            "duration_seconds": duration_seconds,
+            "file_size_bytes": file_size_bytes,
+        }
+
+        try:
+            errors = self.bq_client.insert_rows_json(table_ref, [row])
+            if errors:
+                logger.warning(f"ロード履歴の記録に失敗しました: {errors}")
+            else:
+                logger.debug(f"ロード履歴を記録しました: {file_name} ({status})")
+        except Exception as e:
+            # ロード履歴の記録失敗はワーニングに留める
+            logger.warning(f"ロード履歴の記録に失敗しました: {e}")
+
+    def _is_file_already_loaded(
+        self, file_name: str, loaded_files: Optional[Set[str]] = None
+    ) -> bool:
+        """
+        ファイルが既にロード済みかどうかを確認
+
+        Args:
+            file_name: ファイル名
+            loaded_files: ロード済みファイルのセット (キャッシュ用)
+
+        Returns:
+            ロード済みの場合True
+        """
+        if loaded_files is None:
+            loaded_files = self._get_loaded_files()
+        return file_name in loaded_files
 
     def _download_file_from_gcs(self, blob_name: str) -> Optional[str]:
         """
@@ -300,18 +401,23 @@ class BigQueryLoader:
             logger.error(f"BigQuery ロードエラー: {e}")
             raise
 
-    def load_file(self, blob_name: str) -> LoadResult:
+    def load_file(
+        self, blob_name: str, record_history: bool = True
+    ) -> LoadResult:
         """
         単一ファイルをGCSからBigQueryにロード
 
         Args:
             blob_name: GCS上のファイルパス
+            record_history: ロード履歴を記録するか (デフォルト: True)
 
         Returns:
             LoadResult: ロード結果
         """
         start_time = time.time()
         result = LoadResult(file_name=blob_name, status="failed")
+        data_type = None
+        table_name = None
 
         try:
             # ファイル名からデータタイプを抽出
@@ -372,12 +478,26 @@ class BigQueryLoader:
         finally:
             result.duration_seconds = time.time() - start_time
 
+            # ロード履歴を記録
+            if record_history:
+                self._record_load_history(
+                    file_name=blob_name,
+                    status=result.status,
+                    records_count=result.records_processed,
+                    table_name=table_name,
+                    data_type=data_type,
+                    error_message=result.error,
+                    duration_seconds=result.duration_seconds,
+                )
+
         return result
 
     def load_files_batch(
         self,
         blob_names: List[str],
         continue_on_error: bool = True,
+        skip_loaded: bool = False,
+        record_history: bool = True,
     ) -> BatchLoadResult:
         """
         複数ファイルをバッチでロード
@@ -385,6 +505,8 @@ class BigQueryLoader:
         Args:
             blob_names: GCS上のファイルパスのリスト
             continue_on_error: エラー時に処理を継続するか
+            skip_loaded: 既にロード済みのファイルをスキップするか
+            record_history: ロード履歴を記録するか
 
         Returns:
             BatchLoadResult: バッチロード結果
@@ -394,10 +516,28 @@ class BigQueryLoader:
 
         logger.info(f"バッチロード開始: {len(blob_names)} ファイル")
 
+        # 重複スキップが有効な場合、ロード済みファイルを取得
+        loaded_files: Set[str] = set()
+        if skip_loaded:
+            loaded_files = self._get_loaded_files()
+            logger.info(f"重複スキップ機能: 有効 ({len(loaded_files)} 件のロード済みファイル)")
+
         for i, blob_name in enumerate(blob_names, 1):
+            # 重複スキップ判定
+            if skip_loaded and blob_name in loaded_files:
+                logger.info(f"スキップ ({i}/{len(blob_names)}): {blob_name} (ロード済み)")
+                result = LoadResult(
+                    file_name=blob_name,
+                    status="skipped",
+                    error="既にロード済み",
+                )
+                batch_result.results.append(result)
+                batch_result.skipped_count += 1
+                continue
+
             logger.info(f"処理中 ({i}/{len(blob_names)}): {blob_name}")
 
-            result = self.load_file(blob_name)
+            result = self.load_file(blob_name, record_history=record_history)
             batch_result.results.append(result)
 
             if result.status == "success":
@@ -536,6 +676,16 @@ def main():
         action="store_true",
         help="エラー時に処理を中断する",
     )
+    parser.add_argument(
+        "--skip-loaded",
+        action="store_true",
+        help="既にロード済みのファイルをスキップする (重複スキップ機能)",
+    )
+    parser.add_argument(
+        "--no-history",
+        action="store_true",
+        help="ロード履歴を記録しない",
+    )
 
     args = parser.parse_args()
 
@@ -572,6 +722,8 @@ def main():
     result = loader.load_files_batch(
         files_to_load,
         continue_on_error=not args.stop_on_error,
+        skip_loaded=args.skip_loaded,
+        record_history=not args.no_history,
     )
 
     # 結果出力

--- a/tests/test_load_to_bq.py
+++ b/tests/test_load_to_bq.py
@@ -14,6 +14,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "src" / "data"))
 from load_to_bq import (
     BatchLoadResult,
     BigQueryLoader,
+    LOAD_HISTORY_TABLE,
     LoadResult,
     create_loader_from_env,
     extract_data_type,
@@ -503,3 +504,260 @@ class TestBigQueryLoaderMerge:
 
         # 一時テーブルは削除される
         mock_client.delete_table.assert_called()
+
+
+class TestGetLoadedFiles:
+    """_get_loaded_filesメソッドのテスト"""
+
+    @patch("load_to_bq.bigquery.Client")
+    def test_get_loaded_files_success(self, mock_bq_client):
+        """ロード済みファイル一覧を取得する"""
+        loader = BigQueryLoader(project_id="test-project")
+
+        mock_client = MagicMock()
+        mock_bq_client.return_value = mock_client
+
+        # クエリ結果をモック
+        mock_row1 = MagicMock()
+        mock_row1.file_name = "BAA260104.csv"
+        mock_row2 = MagicMock()
+        mock_row2.file_name = "KYF260104.csv"
+
+        mock_query_job = MagicMock()
+        mock_query_job.result.return_value = [mock_row1, mock_row2]
+        mock_client.query.return_value = mock_query_job
+
+        result = loader._get_loaded_files()
+
+        assert result == {"BAA260104.csv", "KYF260104.csv"}
+        mock_client.query.assert_called_once()
+        # クエリが正しいテーブルを参照していることを確認
+        query_call = mock_client.query.call_args[0][0]
+        assert LOAD_HISTORY_TABLE in query_call
+        assert "status = 'success'" in query_call
+
+    @patch("load_to_bq.bigquery.Client")
+    def test_get_loaded_files_table_not_found(self, mock_bq_client):
+        """テーブルが存在しない場合は空のセットを返す"""
+        loader = BigQueryLoader(project_id="test-project")
+
+        mock_client = MagicMock()
+        mock_bq_client.return_value = mock_client
+
+        # テーブルが見つからないエラー
+        mock_client.query.side_effect = Exception("Not found: Table test-project.raw.load_history")
+
+        result = loader._get_loaded_files()
+
+        assert result == set()
+
+    @patch("load_to_bq.bigquery.Client")
+    def test_get_loaded_files_other_error(self, mock_bq_client):
+        """その他のエラーは例外を発生させる"""
+        loader = BigQueryLoader(project_id="test-project")
+
+        mock_client = MagicMock()
+        mock_bq_client.return_value = mock_client
+
+        # その他のエラー
+        mock_client.query.side_effect = Exception("Network error")
+
+        with pytest.raises(Exception):
+            loader._get_loaded_files()
+
+
+class TestRecordLoadHistory:
+    """_record_load_historyメソッドのテスト"""
+
+    @patch("load_to_bq.bigquery.Client")
+    def test_record_load_history_success(self, mock_bq_client):
+        """ロード履歴を正常に記録する"""
+        loader = BigQueryLoader(project_id="test-project")
+
+        mock_client = MagicMock()
+        mock_bq_client.return_value = mock_client
+        mock_client.insert_rows_json.return_value = []
+
+        loader._record_load_history(
+            file_name="BAA260104.csv",
+            status="success",
+            records_count=100,
+            table_name="race_info",
+            data_type="BAA",
+            duration_seconds=1.5,
+        )
+
+        mock_client.insert_rows_json.assert_called_once()
+        call_args = mock_client.insert_rows_json.call_args
+        table_ref = call_args[0][0]
+        rows = call_args[0][1]
+
+        assert LOAD_HISTORY_TABLE in table_ref
+        assert len(rows) == 1
+        assert rows[0]["file_name"] == "BAA260104.csv"
+        assert rows[0]["status"] == "success"
+        assert rows[0]["records_count"] == 100
+        assert rows[0]["table_name"] == "race_info"
+        assert rows[0]["data_type"] == "BAA"
+
+    @patch("load_to_bq.bigquery.Client")
+    def test_record_load_history_failure(self, mock_bq_client):
+        """ロード履歴の記録失敗時はワーニングのみ（例外は発生しない）"""
+        loader = BigQueryLoader(project_id="test-project")
+
+        mock_client = MagicMock()
+        mock_bq_client.return_value = mock_client
+        mock_client.insert_rows_json.return_value = [{"error": "insert error"}]
+
+        # 例外は発生しない（ワーニングのみ）
+        loader._record_load_history(
+            file_name="BAA260104.csv",
+            status="failed",
+            error_message="Test error",
+        )
+
+        mock_client.insert_rows_json.assert_called_once()
+
+
+class TestIsFileAlreadyLoaded:
+    """_is_file_already_loadedメソッドのテスト"""
+
+    def test_file_is_loaded(self):
+        """ファイルがロード済みの場合Trueを返す"""
+        loader = BigQueryLoader(project_id="test-project")
+        loaded_files = {"BAA260104.csv", "KYF260104.csv"}
+
+        result = loader._is_file_already_loaded("BAA260104.csv", loaded_files)
+
+        assert result is True
+
+    def test_file_is_not_loaded(self):
+        """ファイルが未ロードの場合Falseを返す"""
+        loader = BigQueryLoader(project_id="test-project")
+        loaded_files = {"BAA260104.csv", "KYF260104.csv"}
+
+        result = loader._is_file_already_loaded("SEC260104.csv", loaded_files)
+
+        assert result is False
+
+
+class TestLoadFilesWithSkip:
+    """重複スキップ機能を含むload_files_batchメソッドのテスト"""
+
+    def test_batch_load_with_skip_loaded(self):
+        """skip_loaded=Trueでロード済みファイルをスキップする"""
+        loader = BigQueryLoader(project_id="test-project")
+
+        # ロード済みファイルを返すモック
+        with patch.object(
+            loader, "_get_loaded_files", return_value={"file1.csv", "file2.csv"}
+        ):
+            with patch.object(loader, "load_file") as mock_load:
+                mock_load.return_value = LoadResult(
+                    file_name="file3.csv",
+                    status="success",
+                    records_processed=10,
+                )
+
+                result = loader.load_files_batch(
+                    ["file1.csv", "file2.csv", "file3.csv"],
+                    skip_loaded=True,
+                )
+
+        # file1.csvとfile2.csvはスキップされ、file3.csvのみロードされる
+        assert result.total_files == 3
+        assert result.success_count == 1
+        assert result.skipped_count == 2
+        assert result.failed_count == 0
+
+        # load_fileはfile3.csvのみ呼ばれる
+        mock_load.assert_called_once_with("file3.csv", record_history=True)
+
+    def test_batch_load_without_skip_loaded(self):
+        """skip_loaded=Falseで全ファイルをロードする"""
+        loader = BigQueryLoader(project_id="test-project")
+
+        with patch.object(loader, "load_file") as mock_load:
+            mock_load.return_value = LoadResult(
+                file_name="test.csv",
+                status="success",
+                records_processed=10,
+            )
+
+            result = loader.load_files_batch(
+                ["file1.csv", "file2.csv"],
+                skip_loaded=False,
+            )
+
+        # 全ファイルがロードされる
+        assert result.total_files == 2
+        assert result.success_count == 2
+        assert mock_load.call_count == 2
+
+    def test_batch_load_skip_reason_in_result(self):
+        """スキップされたファイルの理由が結果に含まれる"""
+        loader = BigQueryLoader(project_id="test-project")
+
+        with patch.object(
+            loader, "_get_loaded_files", return_value={"file1.csv"}
+        ):
+            with patch.object(loader, "load_file"):
+                result = loader.load_files_batch(
+                    ["file1.csv"],
+                    skip_loaded=True,
+                )
+
+        assert len(result.results) == 1
+        assert result.results[0].status == "skipped"
+        assert result.results[0].error == "既にロード済み"
+
+
+class TestLoadFileWithHistory:
+    """履歴記録を含むload_fileメソッドのテスト"""
+
+    def test_load_file_records_history_on_success(self):
+        """成功時にロード履歴を記録する"""
+        loader = BigQueryLoader(project_id="test-project")
+
+        with patch.object(loader, "_download_file_from_gcs", return_value="data"):
+            with patch.object(loader, "_load_to_bigquery", return_value=100):
+                with patch.object(loader, "_record_load_history") as mock_history:
+                    with patch("load_to_bq.JRDBParser") as mock_parser:
+                        mock_parser.parse_file.return_value = [{"data": "test"}]
+
+                        result = loader.load_file("BAA260104.csv")
+
+        assert result.status == "success"
+        mock_history.assert_called_once()
+        call_kwargs = mock_history.call_args[1]
+        assert call_kwargs["file_name"] == "BAA260104.csv"
+        assert call_kwargs["status"] == "success"
+        assert call_kwargs["records_count"] == 100
+
+    def test_load_file_records_history_on_failure(self):
+        """失敗時にロード履歴を記録する"""
+        loader = BigQueryLoader(project_id="test-project")
+
+        with patch.object(loader, "_download_file_from_gcs", return_value=None):
+            with patch.object(loader, "_record_load_history") as mock_history:
+                result = loader.load_file("BAA260104.csv")
+
+        assert result.status == "failed"
+        mock_history.assert_called_once()
+        call_kwargs = mock_history.call_args[1]
+        assert call_kwargs["status"] == "failed"
+        assert call_kwargs["error_message"] is not None
+
+    def test_load_file_no_history_when_disabled(self):
+        """record_history=Falseで履歴を記録しない"""
+        loader = BigQueryLoader(project_id="test-project")
+
+        with patch.object(loader, "_download_file_from_gcs", return_value="data"):
+            with patch.object(loader, "_load_to_bigquery", return_value=100):
+                with patch.object(loader, "_record_load_history") as mock_history:
+                    with patch("load_to_bq.JRDBParser") as mock_parser:
+                        mock_parser.parse_file.return_value = [{"data": "test"}]
+
+                        loader.load_file("BAA260104.csv", record_history=False)
+
+        mock_history.assert_not_called()


### PR DESCRIPTION
## Summary
- ロード履歴テーブル(`raw.load_history`)のスキーマを追加
- BigQueryLoaderにロード履歴の記録・参照機能を実装
- 既にロード済みのファイルをスキップする重複防止機能を実装
- 関連するユニットテストを追加（13テストケース）

## 変更内容

### 新規ファイル
- `config/bq_schema_load_history.json`: ロード履歴テーブルのスキーマ定義

### 変更ファイル
- `src/data/load_to_bq.py`: 
  - `_get_loaded_files()`: ロード済みファイル一覧を取得
  - `_record_load_history()`: ロード履歴をBigQueryに記録
  - `_is_file_already_loaded()`: ファイルがロード済みか確認
  - `load_file()`: 履歴記録オプションを追加
  - `load_files_batch()`: `skip_loaded`, `record_history` オプションを追加
  - CLI: `--skip-loaded`, `--no-history` オプションを追加

- `tests/test_load_to_bq.py`:
  - `TestGetLoadedFiles`: ロード済みファイル取得のテスト
  - `TestRecordLoadHistory`: ロード履歴記録のテスト
  - `TestIsFileAlreadyLoaded`: ファイル存在確認のテスト
  - `TestLoadFilesWithSkip`: 重複スキップ機能のテスト
  - `TestLoadFileWithHistory`: 履歴記録付きロードのテスト

## 使用方法

```bash
# 既にロード済みのファイルをスキップしてロード
python -m src.data.load_to_bq --project-id PROJECT_ID --skip-loaded

# 履歴を記録せずにロード
python -m src.data.load_to_bq --project-id PROJECT_ID --no-history
```

## Test plan
- [x] 既存のテストが全てパスすることを確認
- [x] 新規追加したテストが全てパスすることを確認
- [ ] BigQueryに`load_history`テーブルを作成後、実際にロード処理を実行してテスト

## Closes
- Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)