### PR TITLE
fix: Cloud Schedulerの422エラーを修正

### DIFF
--- a/infrastructure/scripts/setup_scheduler.sh
+++ b/infrastructure/scripts/setup_scheduler.sh
@@ -145,6 +145,7 @@ if gcloud scheduler jobs describe "${JOB_NAME}" \
         --uri="${TARGET_URI}" \
         --http-method=POST \
         --headers="Content-Type=application/json" \
+        --message-body='{}' \
         --oidc-service-account-email="${PIPELINE_SA_EMAIL}" \
         --oidc-token-audience="${SERVICE_URL}" \
         --attempt-deadline=900s \
@@ -164,6 +165,7 @@ else
         --uri="${TARGET_URI}" \
         --http-method=POST \
         --headers="Content-Type=application/json" \
+        --message-body='{}' \
         --oidc-service-account-email="${PIPELINE_SA_EMAIL}" \
         --oidc-token-audience="${SERVICE_URL}" \
         --attempt-deadline=900s \


### PR DESCRIPTION
## Summary
- Cloud Schedulerから `POST /api/v1/load/daily/async` を呼び出した際に422 Unprocessable Entityが返される問題を修正
- `setup_scheduler.sh` のjob create/updateコマンドに `--message-body='{}'` を追加し、FastAPIが期待するJSONボディを送信するように変更

## Test plan
- [ ] `setup_scheduler.sh` を再実行してジョブを更新
- [ ] `gcloud scheduler jobs run daily-data-pipeline --location=asia-northeast1` で手動実行し、422でなく200/202が返ることを確認
- [ ] Cloud Runログで正常にパイプラインが開始されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)