### PR TITLE
fix: scheduler jobs updateの--headersフラグを修正

### DIFF
--- a/infrastructure/scripts/setup_scheduler.sh
+++ b/infrastructure/scripts/setup_scheduler.sh
@@ -144,7 +144,7 @@ if gcloud scheduler jobs describe "${JOB_NAME}" \
         --time-zone="${TIME_ZONE}" \
         --uri="${TARGET_URI}" \
         --http-method=POST \
-        --headers="Content-Type=application/json" \
+        --update-headers="Content-Type=application/json" \
         --message-body='{}' \
         --oidc-service-account-email="${PIPELINE_SA_EMAIL}" \
         --oidc-token-audience="${SERVICE_URL}" \


### PR DESCRIPTION
## Summary
- `gcloud scheduler jobs update http` で `--headers` が使えないエラーを修正
- `--headers` を `--update-headers` に変更（updateサブコマンドの正しいフラグ名）

## Test plan
- [ ] `./infrastructure/scripts/setup_scheduler.sh` を再実行してエラーなく完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)