### PR TITLE
feat: LambdaRankのラベルを二値化（3着以内=1, 他=0）

### DIFF
--- a/config/model_config.yaml
+++ b/config/model_config.yaml
@@ -1,4 +1,5 @@
 # LightGBM LambdaRank モデル設定
+# ラベル: 二値（3着以内=1, それ以外=0）でランク学習
 model:
   # LightGBMパラメータ
   params:
@@ -62,3 +63,4 @@ evaluation:
   metrics:
     - "ndcg@3"
     - "recall@3"
+    - "auc"

--- a/src/models/train.py
+++ b/src/models/train.py
@@ -23,6 +23,7 @@ import numpy as np
 import pandas as pd
 import yaml
 from google.cloud import bigquery, storage
+from sklearn.metrics import roc_auc_score
 
 from src.models.lgbm_ranker import LGBMRanker, LGBMRankerConfig
 
@@ -207,16 +208,14 @@ def prepare_features(
 
     Returns:
         (X, y, groups) のタプル
-        y: 着順ベースの整数relevanceスコア（1着=3, 2着=2, 3着=1, 4着以下=0）
+        y: 二値ラベル（3着以内=1, それ以外=0）
     """
     X = build_feature_matrix(df, exclude_columns, categorical_columns)
 
-    # ラベル: 着順を整数のrelevanceスコアに変換
-    # LightGBM lambdarankは整数ラベルが必要
+    # ラベル: 3着以内=1, それ以外=0 の二値ラベル
+    # finish_position=0（出走取消等）は0として扱う
     positions = df["finish_position"].values.astype(int)
-    y = np.where(positions == 1, 3,
-         np.where(positions == 2, 2,
-          np.where(positions == 3, 1, 0)))
+    y = np.where((positions >= 1) & (positions <= 3), 1, 0)
 
     # グループサイズ（各レースの馬数）
     groups = df.groupby("race_id", sort=False).size().tolist()
@@ -279,9 +278,19 @@ def evaluate_predictions(
 
         start = end
 
+    # レース横断でのAUC（二値ラベル: 3着以内=1, それ以外=0）
+    binary_labels = np.where(
+        (y_true_positions >= 1) & (y_true_positions <= 3), 1, 0
+    )
+    if len(np.unique(binary_labels)) >= 2:
+        auc = float(roc_auc_score(binary_labels, y_pred))
+    else:
+        auc = 0.0
+
     return {
         "ndcg@3": float(np.mean(ndcg_scores)) if ndcg_scores else 0.0,
         "recall@3": float(np.mean(recall_scores)) if recall_scores else 0.0,
+        "auc": auc,
         "num_races": len(groups),
     }
 
@@ -526,6 +535,7 @@ def main():
     print(f"\n評価指標:")
     print(f"  NDCG@3:   {result['metrics']['ndcg@3']:.4f}")
     print(f"  Recall@3: {result['metrics']['recall@3']:.4f}")
+    print(f"  AUC:      {result['metrics']['auc']:.4f}")
     print(f"  レース数: {result['metrics']['num_races']}")
     print("=" * 60)
 

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -43,9 +43,7 @@ class TestPredictPipeline:
             X_train[col] = X_train[col].astype("category")
 
         positions = np.tile(np.arange(1, n_horses + 1), n_races)
-        y_train = np.where(positions == 1, 3,
-                   np.where(positions == 2, 2,
-                    np.where(positions == 3, 1, 0)))
+        y_train = np.where((positions >= 1) & (positions <= 3), 1, 0)
         groups_train = [n_horses] * n_races
 
         # 検証用

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -147,9 +147,9 @@ class TestPrepareFeatures:
     def test_basic_preparation(self):
         """特徴量準備が正しく動作すること"""
         df = pd.DataFrame({
-            "race_id": ["r1", "r1", "r1", "r2", "r2"],
+            "race_id": ["r1", "r1", "r1", "r1", "r1"],
             "horse_id": ["h1", "h2", "h3", "h4", "h5"],
-            "finish_position": [1, 2, 3, 1, 2],
+            "finish_position": [1, 2, 3, 4, 5],
             "feature_a": [1.0, 2.0, 3.0, 4.0, 5.0],
             "feature_b": [0.1, 0.2, 0.3, 0.4, 0.5],
             "course_type": ["turf", "dirt", "turf", "dirt", "turf"],
@@ -168,13 +168,15 @@ class TestPrepareFeatures:
         assert "feature_b" in X.columns
         assert X["course_type"].dtype.name == "category"
 
-        # relevanceスコアの確認（整数: 1着=3, 2着=2, 3着=1）
-        assert y[0] == 3  # 1着 → 3
-        assert y[1] == 2  # 2着 → 2
+        # 二値ラベルの確認（3着以内=1, それ以外=0）
+        assert y[0] == 1  # 1着 → 1
+        assert y[1] == 1  # 2着 → 1
         assert y[2] == 1  # 3着 → 1
+        assert y[3] == 0  # 4着 → 0
+        assert y[4] == 0  # 5着 → 0
 
         # グループサイズ
-        assert groups == [3, 2]
+        assert groups == [5]
 
     def test_zero_finish_position(self):
         """着順が0の場合でもエラーにならないこと"""
@@ -186,10 +188,10 @@ class TestPrepareFeatures:
         X, y, groups = prepare_features(
             df, exclude_columns=["race_id", "finish_position"], categorical_columns=[]
         )
-        # 0着 → relevance 0
+        # 0着 → 0（3着以内でない）
         assert y[0] == 0
-        # 1着 → relevance 3
-        assert y[1] == 3
+        # 1着 → 1（3着以内）
+        assert y[1] == 1
 
 
 class TestEvaluatePredictions:
@@ -206,6 +208,7 @@ class TestEvaluatePredictions:
         metrics = evaluate_predictions(y_true_positions, y_pred, groups)
         assert metrics["ndcg@3"] == pytest.approx(1.0)
         assert metrics["recall@3"] == pytest.approx(1.0)
+        assert metrics["auc"] == pytest.approx(1.0)
         assert metrics["num_races"] == 1
 
     def test_worst_prediction(self):
@@ -230,6 +233,8 @@ class TestEvaluatePredictions:
         assert metrics["num_races"] == 2
         # 1レース目: 完璧(NDCG=1.0), 2レース目: 逆(NDCG<1.0)
         assert 0.0 < metrics["ndcg@3"] < 1.0
+        # AUCは0〜1の範囲
+        assert 0.0 <= metrics["auc"] <= 1.0
 
 
 class TestTrainPipeline:
@@ -389,9 +394,11 @@ class TestTrainPipeline:
             assert "metrics" in result
             assert "ndcg@3" in result["metrics"]
             assert "recall@3" in result["metrics"]
+            assert "auc" in result["metrics"]
             assert result["metrics"]["num_races"] > 0
             assert 0.0 <= result["metrics"]["ndcg@3"] <= 1.0
             assert 0.0 <= result["metrics"]["recall@3"] <= 1.0
+            assert 0.0 <= result["metrics"]["auc"] <= 1.0
             assert result["train_rows"] > 0
             assert result["valid_rows"] > 0
             assert result["predict_rows"] > 0


### PR DESCRIPTION
## Summary
- LambdaRankのランク学習の枠組みは維持したまま、ラベルを4段階relevanceスコア（1着=3,2着=2,3着=1,4着以下=0）から二値ラベル（3着以内=1, それ以外=0）に変更
- 評価指標にAUC（二値ラベルの予測精度）を追加
- テストを二値ラベルに合わせて更新

## 変更ファイル
- `src/models/train.py`: `prepare_features()` のラベル生成を二値化、`evaluate_predictions()` にAUC追加
- `config/model_config.yaml`: コメント追加、evaluation.metrics にAUC追加
- `tests/test_train.py`: 二値ラベルのアサーション、AUC指標の検証
- `tests/test_predict.py`: fixture内のラベル生成を二値に統一

## 変更しないもの
- `src/models/lgbm_ranker.py`（LambdaRankモデルクラスはそのまま）
- `src/models/predict.py`（スコアの大小関係は不変のため変更不要）

## Test plan
- [x] `python3 -m pytest tests/test_train.py tests/test_predict.py tests/test_lgbm_ranker.py -v` 全28テスト通過

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)