### PR TITLE
feat: Optunaによるハイパーパラメータ調整機能の追加

### DIFF
--- a/config/model_config.yaml
+++ b/config/model_config.yaml
@@ -58,6 +58,51 @@ gcs:
   bucket_suffix: "keiba-models"
   model_prefix: "lgbm_ranker"
 
+# チューニング設定（Optuna）
+tuning:
+  n_trials: 100
+  timeout: 3600  # 秒
+  study_name: "keiba_lgbm_lambdarank"
+  storage: null  # null=in-memory, or "sqlite:///optuna.db"
+
+  # 探索範囲
+  search_space:
+    num_leaves:
+      type: int
+      low: 15
+      high: 127
+    learning_rate:
+      type: float
+      low: 0.01
+      high: 0.3
+      log: true
+    feature_fraction:
+      type: float
+      low: 0.4
+      high: 1.0
+    bagging_fraction:
+      type: float
+      low: 0.4
+      high: 1.0
+    bagging_freq:
+      type: int
+      low: 1
+      high: 10
+    min_child_samples:
+      type: int
+      low: 5
+      high: 100
+    reg_alpha:
+      type: float
+      low: 1e-8
+      high: 10.0
+      log: true
+    reg_lambda:
+      type: float
+      low: 1e-8
+      high: 10.0
+      log: true
+
 # 評価設定
 evaluation:
   metrics:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ numpy==1.26.2
 # Machine Learning
 lightgbm==4.6.0
 scikit-learn==1.3.2
+optuna==4.2.1
 
 # Visualization (for notebooks)
 matplotlib==3.8.2

--- a/src/models/train.py
+++ b/src/models/train.py
@@ -26,6 +26,7 @@ from google.cloud import bigquery, storage
 from sklearn.metrics import roc_auc_score
 
 from src.models.lgbm_ranker import LGBMRanker, LGBMRankerConfig
+from src.models.tuning import run_tuning, save_best_params
 
 logger = logging.getLogger(__name__)
 
@@ -342,6 +343,9 @@ def train_pipeline(
     config: dict,
     output_dir: Optional[str] = None,
     skip_gcs_upload: bool = False,
+    tune: bool = False,
+    n_trials: Optional[int] = None,
+    tune_timeout: Optional[int] = None,
 ) -> dict:
     """
     学習パイプラインを実行する
@@ -352,6 +356,9 @@ def train_pipeline(
         config: 設定辞書
         output_dir: モデル出力ディレクトリ（Noneの場合は一時ディレクトリ）
         skip_gcs_upload: GCSアップロードをスキップするか
+        tune: ハイパーパラメータ調整を実行するか
+        n_trials: Optuna の trial 数（Noneの場合は config から取得）
+        tune_timeout: チューニングのタイムアウト秒数（Noneの場合は config から取得）
 
     Returns:
         学習結果の辞書
@@ -392,19 +399,49 @@ def train_pipeline(
         categorical_columns=data_config.get("categorical_columns", []),
     )
 
-    # 4. モデル学習
+    categorical_in_features = [
+        c for c in data_config.get("categorical_columns", [])
+        if c in X_train.columns
+    ]
+
+    # 4. ハイパーパラメータ調整（--tune 指定時）
+    tuning_result = None
+    model_params = model_config["params"]
+
+    if tune:
+        # CLI引数でオーバーライド
+        tuning_config = dict(config.get("tuning", {}))
+        if n_trials is not None:
+            tuning_config["n_trials"] = n_trials
+        if tune_timeout is not None:
+            tuning_config["timeout"] = tune_timeout
+
+        config_for_tuning = {
+            "model": model_config,
+            "tuning": tuning_config,
+        }
+
+        tuning_result = run_tuning(
+            X_train=X_train,
+            y_train=y_train,
+            groups_train=groups_train,
+            X_valid=X_valid,
+            y_valid=y_valid,
+            groups_valid=groups_valid,
+            config=config_for_tuning,
+            categorical_feature=categorical_in_features or None,
+        )
+        model_params = tuning_result["best_params"]
+        logger.info(f"Using tuned params: {model_params}")
+
+    # 5. モデル学習（チューニング済みまたはデフォルトパラメータ）
     ranker_config = LGBMRankerConfig(
-        params=model_config["params"],
+        params=model_params,
         num_boost_round=model_config["training"]["num_boost_round"],
         early_stopping_rounds=model_config["training"]["early_stopping_rounds"],
         log_evaluation=model_config["training"]["log_evaluation"],
     )
     ranker = LGBMRanker(config=ranker_config)
-
-    categorical_in_features = [
-        c for c in data_config.get("categorical_columns", [])
-        if c in X_train.columns
-    ]
 
     ranker.train(
         X_train=X_train,
@@ -416,7 +453,7 @@ def train_pipeline(
         categorical_feature=categorical_in_features or None,
     )
 
-    # 5. 検証データで評価
+    # 6. 検証データで評価
     valid_pred = ranker.predict(X_valid)
     metrics = evaluate_predictions(
         y_true_positions=valid_df["finish_position"].values,
@@ -425,7 +462,7 @@ def train_pipeline(
     )
     logger.info(f"Validation metrics: {metrics}")
 
-    # 6. モデル保存
+    # 7. モデル保存
     if output_dir is None:
         output_dir = tempfile.mkdtemp(prefix="keiba_model_")
 
@@ -433,7 +470,14 @@ def train_pipeline(
     model_path = str(Path(output_dir) / f"lgbm_ranker_{date_str}.txt")
     ranker.save(model_path)
 
-    # 7. GCSアップロード
+    # チューニング結果のパラメータも保存
+    if tuning_result is not None:
+        params_path = str(
+            Path(output_dir) / f"best_params_{date_str}.json"
+        )
+        save_best_params(tuning_result["best_params"], params_path)
+
+    # 8. GCSアップロード
     gcs_uri = ""
     if not skip_gcs_upload:
         gcs_uri = upload_model_to_gcs(
@@ -444,7 +488,7 @@ def train_pipeline(
             execution_date=execution_date,
         )
 
-    # 8. 特徴量重要度
+    # 9. 特徴量重要度
     importance = ranker.feature_importance()
     logger.info(f"Top 10 features:\n{importance.head(10).to_string()}")
 
@@ -460,6 +504,14 @@ def train_pipeline(
         "num_features": X_train.shape[1],
         "top_features": importance.head(10).to_dict(orient="records"),
     }
+
+    if tuning_result is not None:
+        result["tuning"] = {
+            "best_value": tuning_result["best_value"],
+            "best_trial_number": tuning_result["best_trial_number"],
+            "n_trials": tuning_result["n_trials"],
+            "best_params": tuning_result["best_params"],
+        }
 
     return result
 
@@ -495,6 +547,23 @@ def main():
         action="store_true",
         help="GCSアップロードをスキップ",
     )
+    parser.add_argument(
+        "--tune",
+        action="store_true",
+        help="Optunaによるハイパーパラメータ調整を実行",
+    )
+    parser.add_argument(
+        "--n-trials",
+        type=int,
+        default=None,
+        help="Optuna の trial 数（デフォルト: config から取得）",
+    )
+    parser.add_argument(
+        "--tune-timeout",
+        type=int,
+        default=None,
+        help="チューニングのタイムアウト秒数（デフォルト: config から取得）",
+    )
     parser.add_argument("--verbose", "-v", action="store_true", help="詳細ログ")
 
     args = parser.parse_args()
@@ -518,6 +587,9 @@ def main():
         config=config,
         output_dir=args.output_dir,
         skip_gcs_upload=args.skip_gcs_upload,
+        tune=args.tune,
+        n_trials=args.n_trials,
+        tune_timeout=args.tune_timeout,
     )
 
     print("\n" + "=" * 60)
@@ -537,6 +609,11 @@ def main():
     print(f"  Recall@3: {result['metrics']['recall@3']:.4f}")
     print(f"  AUC:      {result['metrics']['auc']:.4f}")
     print(f"  レース数: {result['metrics']['num_races']}")
+    if "tuning" in result:
+        print(f"\nチューニング結果:")
+        print(f"  Best AUC (tuning): {result['tuning']['best_value']:.4f}")
+        print(f"  Trial数: {result['tuning']['n_trials']}")
+        print(f"  Best trial: #{result['tuning']['best_trial_number']}")
     print("=" * 60)
 
     return 0

--- a/src/models/tuning.py
+++ b/src/models/tuning.py
@@ -1,0 +1,239 @@
+"""
+Optuna によるハイパーパラメータ調整モジュール
+
+LightGBM LambdaRank モデルのハイパーパラメータを
+Optuna のベイズ最適化で探索する。
+
+Usage:
+    from src.models.tuning import run_tuning
+    best_params = run_tuning(X_train, y_train, groups_train,
+                             X_valid, y_valid, groups_valid, config)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Optional
+
+import lightgbm as lgb
+import numpy as np
+import optuna
+import pandas as pd
+from sklearn.metrics import roc_auc_score
+
+logger = logging.getLogger(__name__)
+
+# Optuna のログレベルを WARNING に設定（trial ごとの詳細出力を抑制）
+optuna.logging.set_verbosity(optuna.logging.WARNING)
+
+# デフォルトの探索範囲
+DEFAULT_SEARCH_SPACE = {
+    "num_leaves": {"type": "int", "low": 15, "high": 127},
+    "learning_rate": {"type": "float", "low": 0.01, "high": 0.3, "log": True},
+    "feature_fraction": {"type": "float", "low": 0.4, "high": 1.0},
+    "bagging_fraction": {"type": "float", "low": 0.4, "high": 1.0},
+    "bagging_freq": {"type": "int", "low": 1, "high": 10},
+    "min_child_samples": {"type": "int", "low": 5, "high": 100},
+    "reg_alpha": {"type": "float", "low": 1e-8, "high": 10.0, "log": True},
+    "reg_lambda": {"type": "float", "low": 1e-8, "high": 10.0, "log": True},
+}
+
+
+def _suggest_param(trial: optuna.Trial, name: str, spec: dict):
+    """探索範囲の仕様に基づいてパラメータをサンプリングする"""
+    if spec["type"] == "int":
+        return trial.suggest_int(name, spec["low"], spec["high"])
+    elif spec["type"] == "float":
+        return trial.suggest_float(
+            name, spec["low"], spec["high"], log=spec.get("log", False)
+        )
+    else:
+        raise ValueError(f"Unknown param type: {spec['type']}")
+
+
+def create_objective(
+    X_train: pd.DataFrame,
+    y_train: np.ndarray,
+    groups_train: list[int],
+    X_valid: pd.DataFrame,
+    y_valid: np.ndarray,
+    groups_valid: list[int],
+    base_params: dict,
+    training_config: dict,
+    search_space: dict,
+    categorical_feature: Optional[list[str]] = None,
+):
+    """
+    Optuna の目的関数を生成する（クロージャ）
+
+    Args:
+        X_train: 学習用特徴量
+        y_train: 学習用ラベル
+        groups_train: 学習用グループサイズ
+        X_valid: 検証用特徴量
+        y_valid: 検証用ラベル
+        groups_valid: 検証用グループサイズ
+        base_params: LightGBM の固定パラメータ（objective, metric 等）
+        training_config: 学習設定（num_boost_round, early_stopping_rounds 等）
+        search_space: 探索範囲の辞書
+        categorical_feature: カテゴリカル特徴量リスト
+
+    Returns:
+        objective 関数
+    """
+    train_data = lgb.Dataset(
+        X_train,
+        label=y_train,
+        group=groups_train,
+        categorical_feature=categorical_feature or "auto",
+        free_raw_data=False,
+    )
+    valid_data = lgb.Dataset(
+        X_valid,
+        label=y_valid,
+        group=groups_valid,
+        categorical_feature=categorical_feature or "auto",
+        reference=train_data,
+        free_raw_data=False,
+    )
+
+    def objective(trial: optuna.Trial) -> float:
+        # 固定パラメータ + 探索パラメータ
+        params = dict(base_params)
+        for param_name, spec in search_space.items():
+            params[param_name] = _suggest_param(trial, param_name, spec)
+
+        model = lgb.train(
+            params,
+            train_data,
+            num_boost_round=training_config.get("num_boost_round", 1000),
+            valid_sets=[valid_data],
+            valid_names=["valid"],
+            callbacks=[
+                lgb.early_stopping(
+                    training_config.get("early_stopping_rounds", 50),
+                    verbose=False,
+                ),
+                lgb.log_evaluation(period=0),
+            ],
+        )
+
+        # 検証データでAUCを計算
+        y_pred = model.predict(X_valid)
+        y_true_positions = y_valid
+        binary_labels = np.where(
+            (y_true_positions >= 1) & (y_true_positions <= 3), 1, 0
+        )
+        # ラベルが既に二値（0/1）の場合はそのまま使用
+        if set(np.unique(y_true_positions)).issubset({0, 1}):
+            binary_labels = y_true_positions.astype(int)
+
+        if len(np.unique(binary_labels)) < 2:
+            return 0.0
+
+        auc = roc_auc_score(binary_labels, y_pred)
+        return auc
+
+    return objective
+
+
+def run_tuning(
+    X_train: pd.DataFrame,
+    y_train: np.ndarray,
+    groups_train: list[int],
+    X_valid: pd.DataFrame,
+    y_valid: np.ndarray,
+    groups_valid: list[int],
+    config: dict,
+    categorical_feature: Optional[list[str]] = None,
+) -> dict:
+    """
+    Optuna でハイパーパラメータ調整を実行する
+
+    Args:
+        X_train: 学習用特徴量
+        y_train: 学習用ラベル
+        groups_train: 学習用グループサイズ
+        X_valid: 検証用特徴量
+        y_valid: 検証用ラベル
+        groups_valid: 検証用グループサイズ
+        config: 設定辞書（model, tuning セクションを含む）
+        categorical_feature: カテゴリカル特徴量リスト
+
+    Returns:
+        最適パラメータの辞書（base_params にマージ済み）
+    """
+    model_config = config["model"]
+    tuning_config = config.get("tuning", {})
+
+    n_trials = tuning_config.get("n_trials", 100)
+    timeout = tuning_config.get("timeout", 3600)
+    study_name = tuning_config.get("study_name", "keiba_lgbm_lambdarank")
+    storage = tuning_config.get("storage", None)
+    search_space = tuning_config.get("search_space", DEFAULT_SEARCH_SPACE)
+
+    # 固定パラメータ（探索対象外）
+    base_params = {
+        k: v for k, v in model_config["params"].items()
+        if k not in search_space
+    }
+
+    objective = create_objective(
+        X_train=X_train,
+        y_train=y_train,
+        groups_train=groups_train,
+        X_valid=X_valid,
+        y_valid=y_valid,
+        groups_valid=groups_valid,
+        base_params=base_params,
+        training_config=model_config["training"],
+        search_space=search_space,
+        categorical_feature=categorical_feature,
+    )
+
+    study = optuna.create_study(
+        study_name=study_name,
+        storage=storage,
+        direction="maximize",
+        load_if_exists=True,
+    )
+
+    logger.info(
+        f"Tuning started: n_trials={n_trials}, timeout={timeout}s, "
+        f"search_space={list(search_space.keys())}"
+    )
+
+    study.optimize(objective, n_trials=n_trials, timeout=timeout)
+
+    logger.info(
+        f"Tuning completed: best_trial={study.best_trial.number}, "
+        f"best_value={study.best_value:.4f}"
+    )
+    logger.info(f"Best params: {study.best_params}")
+
+    # base_params に最適パラメータをマージ
+    best_params = dict(base_params)
+    best_params.update(study.best_params)
+
+    return {
+        "best_params": best_params,
+        "best_value": study.best_value,
+        "best_trial_number": study.best_trial.number,
+        "n_trials": len(study.trials),
+    }
+
+
+def save_best_params(params: dict, path: str) -> None:
+    """
+    最適パラメータをJSONファイルに保存する
+
+    Args:
+        params: パラメータ辞書
+        path: 保存先パス
+    """
+    file_path = Path(path)
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text(json.dumps(params, ensure_ascii=False, indent=2))
+    logger.info(f"Best params saved to {file_path}")

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -404,3 +404,43 @@ class TestTrainPipeline:
             assert result["predict_rows"] > 0
             assert result["num_features"] > 0
             assert Path(result["model_path"]).exists()
+
+    @patch("src.models.train.fetch_training_data")
+    def test_train_pipeline_with_tuning(self, mock_fetch, mock_config, mock_training_df):
+        """チューニングモードで学習パイプラインが動作すること"""
+        mock_fetch.return_value = mock_training_df
+
+        # tuning設定を追加
+        mock_config["tuning"] = {
+            "n_trials": 2,
+            "timeout": 60,
+            "search_space": {
+                "feature_fraction": {
+                    "type": "float",
+                    "low": 0.5,
+                    "high": 1.0,
+                },
+            },
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = train_pipeline(
+                project_id="test-project",
+                execution_date=datetime.date(2026, 2, 13),
+                config=mock_config,
+                output_dir=tmpdir,
+                skip_gcs_upload=True,
+                tune=True,
+                n_trials=2,
+            )
+
+            assert "metrics" in result
+            assert "tuning" in result
+            assert result["tuning"]["n_trials"] == 2
+            assert 0.0 <= result["tuning"]["best_value"] <= 1.0
+            assert "best_params" in result["tuning"]
+            assert Path(result["model_path"]).exists()
+            # best_params JSONファイルも保存されていること
+            date_str = datetime.date(2026, 2, 13).strftime("%Y%m%d")
+            params_path = Path(tmpdir) / f"best_params_{date_str}.json"
+            assert params_path.exists()

--- a/tests/test_tuning.py
+++ b/tests/test_tuning.py
@@ -1,0 +1,252 @@
+"""
+Optuna ハイパーパラメータ調整モジュールのテスト
+"""
+
+import json
+import tempfile
+from pathlib import Path
+
+import lightgbm as lgb
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.models.tuning import (
+    DEFAULT_SEARCH_SPACE,
+    create_objective,
+    run_tuning,
+    save_best_params,
+)
+
+
+@pytest.fixture
+def sample_data():
+    """LambdaRank用のサンプルデータ（二値ラベル）"""
+    np.random.seed(42)
+    n_races = 10
+    n_horses = 8
+    n_total = n_races * n_horses
+
+    X_train = pd.DataFrame({
+        "distance": np.random.choice([1200, 1600, 2000], n_total),
+        "num_horses": [n_horses] * n_total,
+        "bracket_number": np.tile(np.arange(1, n_horses + 1), n_races),
+        "horse_number": np.tile(np.arange(1, n_horses + 1), n_races),
+        "weight": 55.0 + np.random.randn(n_total),
+        "feature_a": np.random.randn(n_total),
+        "feature_b": np.random.randn(n_total),
+        "feature_c": np.random.randn(n_total),
+    })
+
+    positions = np.tile(np.arange(1, n_horses + 1), n_races)
+    y_train = np.where((positions >= 1) & (positions <= 3), 1, 0)
+    groups_train = [n_horses] * n_races
+
+    X_valid = X_train.copy()
+    y_valid = y_train.copy()
+    groups_valid = groups_train.copy()
+
+    return {
+        "X_train": X_train,
+        "y_train": y_train,
+        "groups_train": groups_train,
+        "X_valid": X_valid,
+        "y_valid": y_valid,
+        "groups_valid": groups_valid,
+    }
+
+
+class TestCreateObjective:
+    """create_objectiveのテスト"""
+
+    def test_objective_returns_valid_auc(self, sample_data):
+        """objective関数が0~1のAUC値を返すこと"""
+        base_params = {
+            "objective": "lambdarank",
+            "metric": "ndcg",
+            "ndcg_eval_at": [3],
+            "boosting_type": "gbdt",
+            "verbose": -1,
+            "seed": 42,
+        }
+        training_config = {
+            "num_boost_round": 10,
+            "early_stopping_rounds": 5,
+        }
+
+        objective = create_objective(
+            X_train=sample_data["X_train"],
+            y_train=sample_data["y_train"],
+            groups_train=sample_data["groups_train"],
+            X_valid=sample_data["X_valid"],
+            y_valid=sample_data["y_valid"],
+            groups_valid=sample_data["groups_valid"],
+            base_params=base_params,
+            training_config=training_config,
+            search_space=DEFAULT_SEARCH_SPACE,
+        )
+
+        import optuna
+        study = optuna.create_study(direction="maximize")
+        study.optimize(objective, n_trials=1)
+
+        assert 0.0 <= study.best_value <= 1.0
+
+
+class TestRunTuning:
+    """run_tuningのテスト"""
+
+    def test_run_tuning_finds_params(self, sample_data):
+        """少数trialで最適パラメータが取得できること"""
+        config = {
+            "model": {
+                "params": {
+                    "objective": "lambdarank",
+                    "metric": "ndcg",
+                    "ndcg_eval_at": [3],
+                    "boosting_type": "gbdt",
+                    "verbose": -1,
+                    "seed": 42,
+                },
+                "training": {
+                    "num_boost_round": 10,
+                    "early_stopping_rounds": 5,
+                },
+            },
+            "tuning": {
+                "n_trials": 3,
+                "timeout": 60,
+            },
+        }
+
+        result = run_tuning(
+            X_train=sample_data["X_train"],
+            y_train=sample_data["y_train"],
+            groups_train=sample_data["groups_train"],
+            X_valid=sample_data["X_valid"],
+            y_valid=sample_data["y_valid"],
+            groups_valid=sample_data["groups_valid"],
+            config=config,
+        )
+
+        assert "best_params" in result
+        assert "best_value" in result
+        assert "best_trial_number" in result
+        assert "n_trials" in result
+        assert result["n_trials"] == 3
+        assert 0.0 <= result["best_value"] <= 1.0
+
+    def test_best_params_structure(self, sample_data):
+        """返却パラメータに固定パラメータと探索パラメータが含まれること"""
+        config = {
+            "model": {
+                "params": {
+                    "objective": "lambdarank",
+                    "metric": "ndcg",
+                    "ndcg_eval_at": [3],
+                    "boosting_type": "gbdt",
+                    "verbose": -1,
+                    "seed": 42,
+                },
+                "training": {
+                    "num_boost_round": 10,
+                    "early_stopping_rounds": 5,
+                },
+            },
+            "tuning": {
+                "n_trials": 2,
+                "timeout": 60,
+            },
+        }
+
+        result = run_tuning(
+            X_train=sample_data["X_train"],
+            y_train=sample_data["y_train"],
+            groups_train=sample_data["groups_train"],
+            X_valid=sample_data["X_valid"],
+            y_valid=sample_data["y_valid"],
+            groups_valid=sample_data["groups_valid"],
+            config=config,
+        )
+
+        best_params = result["best_params"]
+        # 固定パラメータが含まれること
+        assert best_params["objective"] == "lambdarank"
+        assert best_params["metric"] == "ndcg"
+        assert best_params["seed"] == 42
+        # 探索パラメータが含まれること
+        assert "num_leaves" in best_params
+        assert "learning_rate" in best_params
+        assert "feature_fraction" in best_params
+        assert "min_child_samples" in best_params
+        assert "reg_alpha" in best_params
+        assert "reg_lambda" in best_params
+
+    def test_custom_search_space(self, sample_data):
+        """カスタム探索範囲が適用されること"""
+        config = {
+            "model": {
+                "params": {
+                    "objective": "lambdarank",
+                    "metric": "ndcg",
+                    "ndcg_eval_at": [3],
+                    "boosting_type": "gbdt",
+                    "verbose": -1,
+                    "seed": 42,
+                    "num_leaves": 31,
+                    "learning_rate": 0.05,
+                },
+                "training": {
+                    "num_boost_round": 10,
+                    "early_stopping_rounds": 5,
+                },
+            },
+            "tuning": {
+                "n_trials": 2,
+                "timeout": 60,
+                "search_space": {
+                    "feature_fraction": {
+                        "type": "float",
+                        "low": 0.5,
+                        "high": 0.9,
+                    },
+                },
+            },
+        }
+
+        result = run_tuning(
+            X_train=sample_data["X_train"],
+            y_train=sample_data["y_train"],
+            groups_train=sample_data["groups_train"],
+            X_valid=sample_data["X_valid"],
+            y_valid=sample_data["y_valid"],
+            groups_valid=sample_data["groups_valid"],
+            config=config,
+        )
+
+        best_params = result["best_params"]
+        # 探索範囲外のパラメータは固定値のまま
+        assert best_params["num_leaves"] == 31
+        assert best_params["learning_rate"] == 0.05
+        # 探索対象のパラメータは範囲内
+        assert 0.5 <= best_params["feature_fraction"] <= 0.9
+
+
+class TestSaveBestParams:
+    """save_best_paramsのテスト"""
+
+    def test_save_and_load(self):
+        """パラメータの保存・読み込みが正しく動作すること"""
+        params = {
+            "objective": "lambdarank",
+            "num_leaves": 50,
+            "learning_rate": 0.1,
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = str(Path(tmpdir) / "best_params.json")
+            save_best_params(params, path)
+
+            assert Path(path).exists()
+            loaded = json.loads(Path(path).read_text())
+            assert loaded == params


### PR DESCRIPTION
## Summary
- `src/models/tuning.py` を新規作成し、Optuna ベイズ最適化によるハイパーパラメータ自動調整機能を追加
- `train.py` に `--tune` / `--n-trials` / `--tune-timeout` CLIオプションを追加し、チューニングモードを統合
- `config/model_config.yaml` に `tuning` セクションを追加（探索範囲、trial数、タイムアウト等を設定可能）

## 変更ファイル
| ファイル | 変更内容 |
|---------|---------|
| `src/models/tuning.py` (新規) | Optuna objective関数、run_tuning()、save_best_params() |
| `src/models/train.py` | train_pipeline() にtune/n_trials/tune_timeout引数追加、CLI追加 |
| `config/model_config.yaml` | tuningセクション追加 |
| `requirements.txt` | optuna==4.2.1 追加 |
| `tests/test_tuning.py` (新規) | objective関数、run_tuning、パラメータ構造、カスタム探索範囲、保存のテスト |
| `tests/test_train.py` | チューニングモードでのE2Eテスト追加 |

## 設計判断
- **目的関数はAUCを最大化**: LambdaRankで学習しつつ、二値ラベル（3着以内=1, 他=0）のAUCで評価
- **探索範囲はconfigで管理**: `search_space` でパラメータ別にtype/low/high/logを指定
- **CLI引数でオーバーライド可能**: `--n-trials` / `--tune-timeout` でconfig値を上書き
- **チューニング後に再学習**: 最適パラメータで本番学習を実行し、モデルを保存

## Test plan
- [x] `python3 -m pytest tests/test_tuning.py tests/test_train.py tests/test_predict.py tests/test_lgbm_ranker.py -v` 全34テスト通過

## 使用例
```bash
# チューニング実行（100 trials, タイムアウト1時間）
python src/models/train.py --project-id $GCP_PROJECT_ID --tune --skip-gcs-upload

# trial数を指定
python src/models/train.py --project-id $GCP_PROJECT_ID --tune --n-trials 50 --skip-gcs-upload
```

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)