### PR TITLE
fix: 着順表示のバグを修正（raw.race_resultsから直接取得）

### DIFF
--- a/src/models/predict.py
+++ b/src/models/predict.py
@@ -72,6 +72,36 @@ def fetch_prediction_data(
     return df
 
 
+def fetch_race_results(
+    project_id: str,
+    target_dates: list[datetime.date],
+) -> pd.DataFrame:
+    """
+    raw.race_results から対象日の着順データを取得する
+
+    レース終了後の実際の着順確認に使用する。
+    レースが未実施の場合（未来のレース）は空のDataFrameを返す。
+
+    Args:
+        project_id: GCPプロジェクトID
+        target_dates: 対象日のリスト
+
+    Returns:
+        着順データのDataFrame（race_id, horse_id, finish_position）
+    """
+    client = bigquery.Client(project=project_id)
+    dates_str = ", ".join(f"'{d.isoformat()}'" for d in target_dates)
+    query = f"""
+    SELECT race_id, horse_id, finish_position
+    FROM `{project_id}.raw.race_results`
+    WHERE race_date IN ({dates_str})
+    """
+    logger.info(f"Fetching race results for dates: {target_dates}")
+    df = client.query(query).to_dataframe()
+    logger.info(f"Fetched {len(df)} race result rows")
+    return df
+
+
 def load_model_from_gcs(
     project_id: str,
     bucket_suffix: str,
@@ -238,9 +268,18 @@ def predict_pipeline(
         ascending=False, method="min"
     ).astype(int)
 
-    # 着順情報がある場合は実際の順位も付与
-    if "finish_position" in df.columns:
-        result_df["finish_position"] = df["finish_position"]
+    # 着順情報: raw.race_resultsから直接取得する
+    # features.training_dataのfinish_positionは不正な値（0/1等）が格納されている
+    # 場合があるため、信頼性の高いデータソースを使用する
+    race_results_df = fetch_race_results(project_id=project_id, target_dates=target_dates)
+    if len(race_results_df) > 0:
+        result_df = result_df.merge(
+            race_results_df[["race_id", "horse_id", "finish_position"]],
+            on=["race_id", "horse_id"],
+            how="left",
+        )
+    else:
+        result_df["finish_position"] = np.nan
 
     # オッズ情報がある場合
     for odds_col in ["odds_yesterday", "odds_today"]:
@@ -277,7 +316,11 @@ def format_predictions(result_df: pd.DataFrame) -> str:
 
         for _, row in group.iterrows():
             finish_raw = row.get("finish_position", None)
-            finish = str(int(finish_raw)) if pd.notna(finish_raw) else "-"
+            if finish_raw is None or pd.isna(finish_raw):
+                finish = "-"
+            else:
+                pos = int(finish_raw)
+                finish = str(pos) if pos > 0 else "-"
             horse_name = str(row.get("horse_name", "") or "")
             lines.append(
                 f"{int(row['pred_rank']):>6} "

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -12,6 +12,7 @@ import pytest
 from src.models.lgbm_ranker import LGBMRanker, LGBMRankerConfig
 from src.models.predict import (
     format_predictions,
+    fetch_race_results,
     predict_pipeline,
 )
 
@@ -95,10 +96,12 @@ class TestPredictPipeline:
                     })
         return pd.DataFrame(rows)
 
+    @patch("src.models.predict.fetch_race_results")
     @patch("src.models.predict.fetch_prediction_data")
-    def test_predict_pipeline_basic(self, mock_fetch, trained_model_path, mock_predict_df):
+    def test_predict_pipeline_basic(self, mock_fetch, mock_race_results, trained_model_path, mock_predict_df):
         """推論パイプラインが正常に動作すること"""
         mock_fetch.return_value = mock_predict_df
+        mock_race_results.return_value = pd.DataFrame(columns=["race_id", "horse_id", "finish_position"])
 
         config = {
             "data": {
@@ -133,12 +136,14 @@ class TestPredictPipeline:
             ranks = sorted(group["pred_rank"].tolist())
             assert ranks[0] == 1
 
+    @patch("src.models.predict.fetch_race_results")
     @patch("src.models.predict.fetch_prediction_data")
     def test_predict_pipeline_with_target_dates(
-        self, mock_fetch, trained_model_path, mock_predict_df
+        self, mock_fetch, mock_race_results, trained_model_path, mock_predict_df
     ):
         """target_datesを指定した場合、その日付でfetch_prediction_dataが呼ばれること"""
         mock_fetch.return_value = mock_predict_df
+        mock_race_results.return_value = pd.DataFrame(columns=["race_id", "horse_id", "finish_position"])
 
         config = {
             "data": {
@@ -171,12 +176,14 @@ class TestPredictPipeline:
 
         assert len(result_df) > 0
 
+    @patch("src.models.predict.fetch_race_results")
     @patch("src.models.predict.fetch_prediction_data")
     def test_predict_pipeline_default_uses_week_boundaries(
-        self, mock_fetch, trained_model_path, mock_predict_df
+        self, mock_fetch, mock_race_results, trained_model_path, mock_predict_df
     ):
         """target_dates未指定時、execution_dateの週の土日が使われること"""
         mock_fetch.return_value = mock_predict_df
+        mock_race_results.return_value = pd.DataFrame(columns=["race_id", "horse_id", "finish_position"])
 
         config = {
             "data": {
@@ -207,10 +214,12 @@ class TestPredictPipeline:
         assert datetime.date(2026, 2, 14) in passed_dates
         assert datetime.date(2026, 2, 15) in passed_dates
 
+    @patch("src.models.predict.fetch_race_results")
     @patch("src.models.predict.fetch_prediction_data")
-    def test_predict_pipeline_empty_data(self, mock_fetch, trained_model_path):
+    def test_predict_pipeline_empty_data(self, mock_fetch, mock_race_results, trained_model_path):
         """推論対象データがない場合、空のDataFrameを返すこと"""
         mock_fetch.return_value = pd.DataFrame()
+        mock_race_results.return_value = pd.DataFrame(columns=["race_id", "horse_id", "finish_position"])
 
         config = {
             "data": {
@@ -263,3 +272,50 @@ class TestFormatPredictions:
         assert "札幌" in result  # venue_code "01" → "札幌" に変換される
         assert "1R" in result
         assert "0.8000" in result
+
+    def test_format_position_zero_shows_dash(self):
+        """finish_position=0の場合、'-'が表示されること（取消/除外/中止の馬）"""
+        df = pd.DataFrame({
+            "race_id": ["r1", "r1"],
+            "race_date": [datetime.date(2026, 2, 14)] * 2,
+            "horse_id": ["h1", "h2"],
+            "horse_name": ["テスト馬1", "テスト馬2"],
+            "horse_number": [1, 2],
+            "venue_code": ["05", "05"],
+            "race_number": [1, 1],
+            "pred_score": [0.8, 0.5],
+            "win_place_prob": [0.7, 0.5],
+            "pred_rank": [1, 2],
+            "finish_position": [1, 0],  # 2頭目は取消（finish_position=0）
+        })
+
+        result = format_predictions(df)
+        lines = result.split("\n")
+        # 着順カラムの値を取得（各行末尾が着順）
+        horse_lines = [l for l in lines if "テスト馬" in l]
+        assert len(horse_lines) == 2
+        # 1着は "1" が表示される
+        assert horse_lines[0].strip().endswith("1")
+        # 取消馬は "-" が表示される
+        assert horse_lines[1].strip().endswith("-")
+
+    def test_format_position_none_shows_dash(self):
+        """finish_positionがNaNの場合（未来レース）、'-'が表示されること"""
+        df = pd.DataFrame({
+            "race_id": ["r1"],
+            "race_date": [datetime.date(2026, 2, 14)],
+            "horse_id": ["h1"],
+            "horse_name": ["テスト馬1"],
+            "horse_number": [1],
+            "venue_code": ["05"],
+            "race_number": [1],
+            "pred_score": [0.8],
+            "win_place_prob": [0.7],
+            "pred_rank": [1],
+            "finish_position": [float("nan")],  # 未来レースはNaN
+        })
+
+        result = format_predictions(df)
+        horse_lines = [l for l in result.split("\n") if "テスト馬" in l]
+        assert len(horse_lines) == 1
+        assert horse_lines[0].strip().endswith("-")


### PR DESCRIPTION
## 問題
`predict.py`が`features.training_data`の`finish_position`を着順として表示していたが、
以下のケースで不正な値が表示されていた:
- 一部のレースで着順が0/1のバイナリ値になる
- 取消/除外/中止の馬の着順が"0"と表示される（"-"が正しい）

## 根本原因
1. `feature_query_raw.sql`は現在レースの`finish_position`を出力しない（過去レースの`finish_position_1~5`のみ）
2. `features.training_data.finish_position`は過去の別パイプラインで設定された値で、一部レースにバイナリ値(0/1)が格納されていた
3. `raw.race_results`が着順の正しいデータソースだが使用されていなかった

## 修正内容
- `fetch_race_results()`を追加: `raw.race_results`から着順を直接取得
- `predict_pipeline()`: 信頼性の低い`features.training_data.finish_position`の代わりに`raw.race_results`を使用
- `format_predictions()`: `finish_position=0`（取消/除外/中止）を"-"として表示

## 動作
- **過去レース**: `raw.race_results`から正確な着順を取得して表示
- **未来レース（予測時）**: データなし → "-"を表示（正しい動作）
- **取消/除外/中止**: `finish_position=0` → "-"を表示

## テスト
- 既存6件のテストをすべて通過
- 新規テスト2件を追加:
  - `test_format_position_zero_shows_dash`: `finish_position=0`→"-"の確認
  - `test_format_position_none_shows_dash`: NaN→"-"の確認（未来レース）

🤖 Generated with [Claude Code](https://claude.com/claude-code)