### PR TITLE
feat: HJB/HJC払戻データのBigQuery格納実装 (Issue #93)

### DIFF
--- a/config/bq_schema_payouts.json
+++ b/config/bq_schema_payouts.json
@@ -1,0 +1,56 @@
+[
+  {
+    "name": "race_id",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "レースID (場コード2+年2+回1+日1+R2)"
+  },
+  {
+    "name": "bet_type",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "馬券種別 (win/place/wakuren/umaren/wide/umatan/sanrenpuku/sanrentan)"
+  },
+  {
+    "name": "horse_number_1",
+    "type": "INT64",
+    "mode": "NULLABLE",
+    "description": "馬番1 (単勝・複勝は着順1位、連系は1頭目)"
+  },
+  {
+    "name": "horse_number_2",
+    "type": "INT64",
+    "mode": "NULLABLE",
+    "description": "馬番2 (2連・3連系の2頭目)"
+  },
+  {
+    "name": "horse_number_3",
+    "type": "INT64",
+    "mode": "NULLABLE",
+    "description": "馬番3 (3連系の3頭目)"
+  },
+  {
+    "name": "payout_amount",
+    "type": "INT64",
+    "mode": "NULLABLE",
+    "description": "払戻金額 (100円あたりの払戻金額、単位: 円)"
+  },
+  {
+    "name": "rank",
+    "type": "INT64",
+    "mode": "NULLABLE",
+    "description": "払戻順位 (1始まり)"
+  },
+  {
+    "name": "created_at",
+    "type": "TIMESTAMP",
+    "mode": "NULLABLE",
+    "description": "レコード作成日時"
+  },
+  {
+    "name": "updated_at",
+    "type": "TIMESTAMP",
+    "mode": "NULLABLE",
+    "description": "レコード更新日時"
+  }
+]

--- a/src/automation/data/jrdb_parser.py
+++ b/src/automation/data/jrdb_parser.py
@@ -9,6 +9,7 @@ BigQueryにロード可能な形式に変換します。
 - KYF/KYG/KYH: 競走馬データ
 - SEC: 成績データ
 - KAA/KAB: 開催データ
+- HJB/HJC: 払戻情報データ
 - OZ: オッズデータ
 """
 
@@ -709,8 +710,9 @@ class JRDBParser:
                 # レース脚質 (位置269)
                 race_running_style = line[269:270].strip() if len(line) > 269 and line[269:270].strip() else None
 
-            # === 中間フィールド (位置が複雑なため概算) ===
-            # 複勝オッズ・10時オッズ・コーナー順位など
+            # === 第2版追加フィールド (位置211以降) ===
+            # SEC仕様書 第2版: 確定複勝オッズ下(相対291)・10時単勝(297)・10時複勝(303)
+            # UTF-8文字列における0-based位置: 219, 225, 231
             place_odds = None
             odds_10am_win = None
             odds_10am_place = None
@@ -723,11 +725,13 @@ class JRDBParser:
             jockey_code = None
             trainer_code = None
 
-            # 中間フィールドの抽出を試みる (位置211以降)
-            if len(line) >= 260:
-                # 10時オッズ付近を探す
-                odds_10am_win = JRDBParser.safe_float(line[219:225]) if len(line) > 225 else None
-                odds_10am_place = JRDBParser.safe_float(line[225:231]) if len(line) > 231 else None
+            if len(line) >= 237:
+                # 確定複勝オッズ下 (仕様書 相対291, UTF-8文字位置 219-225)
+                place_odds = JRDBParser.safe_float(line[219:225])
+                # 10時単勝オッズ (仕様書 相対297, UTF-8文字位置 225-231)
+                odds_10am_win = JRDBParser.safe_float(line[225:231])
+                # 10時複勝オッズ (仕様書 相対303, UTF-8文字位置 231-237)
+                odds_10am_place = JRDBParser.safe_float(line[231:237]) if len(line) > 237 else None
 
             return {
                 'race_id': race_key,
@@ -1249,6 +1253,216 @@ class JRDBParser:
             return None
 
     @staticmethod
+    def parse_hjb_line(line: str) -> Optional[Dict]:
+        """
+        HJB/HJC (払戻情報データ) を解析
+
+        1レース分の払戻金情報を馬券種ごとに返す。
+        仕様書: HJC第4a版 (2024.09.29), レコード長 444バイト (HJB は三連単なし 341文字)
+
+        フォーマット (0-based文字位置):
+          0-7  : レースキー
+          8-34 : 単勝払戻 3件×9文字 (馬番2 + 払戻金7)
+          35-79: 複勝払戻 5件×9文字
+          80-106: 枠連払戻 3件×9文字 (枠番2 + 払戻金7)
+          107-142: 馬連払戻 3件×12文字 (馬番4 + 払戻金8)
+          143-226: ワイド払戻 7件×12文字 (馬番4 + 払戻金8)
+          227-298: 馬単払戻 6件×12文字 (馬番4 + 払戻金8)
+          299-340: 三連複払戻 3件×14文字 (馬番6 + 払戻金8) [HJBのみ]
+          341-430: 三連単払戻 6件×15文字 (馬番6 + 払戻金9) [HJCのみ]
+
+        Args:
+            line: 固定長レコード文字列 (UTF-8変換済み)
+
+        Returns:
+            払戻情報の辞書 (単勝・複勝・枠連・馬連・ワイド・馬単・三連複を含む) or None
+        """
+        try:
+            if len(line) < 35:
+                logger.warning(f"HJB line too short: {len(line)} chars")
+                return None
+
+            race_key = line[0:8].strip()
+            race_info = JRDBParser.parse_race_id(race_key)
+
+            def parse_payout_entry(seg: str, horse_bytes: int, payout_bytes: int):
+                """払戻エントリを解析: (馬番, 払戻金額) のタプルを返す。データなしは None"""
+                umaban_str = seg[0:horse_bytes].strip()
+                payout_str = seg[horse_bytes:horse_bytes + payout_bytes].strip()
+                umaban = JRDBParser.safe_int(umaban_str)
+                payout = JRDBParser.safe_int(payout_str)
+                if not umaban or not payout:
+                    return None
+                return (umaban, payout)
+
+            # --- 単勝払戻 (3件×9文字) ---
+            win_payouts = []
+            for i in range(3):
+                seg = line[8 + i * 9: 8 + (i + 1) * 9]
+                entry = parse_payout_entry(seg, 2, 7)
+                if entry:
+                    win_payouts.append(entry)
+
+            # --- 複勝払戻 (5件×9文字) ---
+            place_payouts = []
+            if len(line) >= 80:
+                for i in range(5):
+                    seg = line[35 + i * 9: 35 + (i + 1) * 9]
+                    entry = parse_payout_entry(seg, 2, 7)
+                    if entry:
+                        place_payouts.append(entry)
+
+            # --- 枠連払戻 (3件×9文字) ---
+            wakuren_payouts = []
+            if len(line) >= 107:
+                for i in range(3):
+                    seg = line[80 + i * 9: 80 + (i + 1) * 9]
+                    entry = parse_payout_entry(seg, 2, 7)
+                    if entry:
+                        wakuren_payouts.append(entry)
+
+            # --- 馬連払戻 (3件×12文字) ---
+            umaren_payouts = []
+            if len(line) >= 143:
+                for i in range(3):
+                    seg = line[107 + i * 12: 107 + (i + 1) * 12]
+                    entry = parse_payout_entry(seg, 4, 8)
+                    if entry:
+                        umaren_payouts.append(entry)
+
+            # --- ワイド払戻 (7件×12文字) ---
+            wide_payouts = []
+            if len(line) >= 227:
+                for i in range(7):
+                    seg = line[143 + i * 12: 143 + (i + 1) * 12]
+                    entry = parse_payout_entry(seg, 4, 8)
+                    if entry:
+                        wide_payouts.append(entry)
+
+            # --- 馬単払戻 (6件×12文字) ---
+            umatan_payouts = []
+            if len(line) >= 299:
+                for i in range(6):
+                    seg = line[227 + i * 12: 227 + (i + 1) * 12]
+                    entry = parse_payout_entry(seg, 4, 8)
+                    if entry:
+                        umatan_payouts.append(entry)
+
+            # --- 三連複払戻 (3件×14文字) ---
+            sanrenpuku_payouts = []
+            if len(line) >= 341:
+                for i in range(3):
+                    seg = line[299 + i * 14: 299 + (i + 1) * 14]
+                    entry = parse_payout_entry(seg, 6, 8)
+                    if entry:
+                        sanrenpuku_payouts.append(entry)
+
+            # --- 三連単払戻 (6件×15文字, HJCのみ) ---
+            sanrentan_payouts = []
+            if len(line) >= 431:
+                for i in range(6):
+                    seg = line[341 + i * 15: 341 + (i + 1) * 15]
+                    entry = parse_payout_entry(seg, 6, 9)
+                    if entry:
+                        sanrentan_payouts.append(entry)
+
+            return {
+                'race_id': race_key,
+                'venue_code': race_info['venue_code'],
+                'year': race_info['year'],
+                'race_number': race_info['race_number'],
+                # 単勝: [(馬番, 払戻金額), ...]
+                'win_payouts': win_payouts,
+                # 複勝: [(馬番, 払戻金額), ...]
+                'place_payouts': place_payouts,
+                # 枠連: [(枠番組合せ, 払戻金額), ...]
+                'wakuren_payouts': wakuren_payouts,
+                # 馬連: [(馬番組合せ, 払戻金額), ...]
+                'umaren_payouts': umaren_payouts,
+                # ワイド: [(馬番組合せ, 払戻金額), ...]
+                'wide_payouts': wide_payouts,
+                # 馬単: [(馬番組合せ, 払戻金額), ...]
+                'umatan_payouts': umatan_payouts,
+                # 三連複: [(馬番組合せ, 払戻金額), ...]
+                'sanrenpuku_payouts': sanrenpuku_payouts,
+                # 三連単: [(馬番組合せ, 払戻金額), ...]
+                'sanrentan_payouts': sanrentan_payouts,
+                'created_at': datetime.utcnow().isoformat(),
+                'updated_at': datetime.utcnow().isoformat(),
+            }
+
+        except Exception as e:
+            logger.error(f"Error parsing HJB line: {e}", exc_info=True)
+            return None
+
+    @staticmethod
+    def expand_hjb_to_payout_rows(hjb_record: Dict) -> List[Dict]:
+        """
+        HJBの1レース払戻レコードを、1行1払戻の形式に展開する
+
+        BigQueryのraw.payoutsテーブルに挿入するための形式に変換する。
+
+        Args:
+            hjb_record: parse_hjb_line() の返り値
+
+        Returns:
+            払戻行のリスト (各行がraw.payoutsの1レコードに対応)
+        """
+        rows = []
+        race_id = hjb_record['race_id']
+        created_at = hjb_record['created_at']
+        updated_at = hjb_record['updated_at']
+
+        bet_type_map = {
+            'win': 'win_payouts',
+            'place': 'place_payouts',
+            'wakuren': 'wakuren_payouts',
+            'umaren': 'umaren_payouts',
+            'wide': 'wide_payouts',
+            'umatan': 'umatan_payouts',
+            'sanrenpuku': 'sanrenpuku_payouts',
+            'sanrentan': 'sanrentan_payouts',
+        }
+
+        for bet_type, field_name in bet_type_map.items():
+            payouts = hjb_record.get(field_name, [])
+            for rank, (combo, payout) in enumerate(payouts, start=1):
+                # 馬券種別に応じて組合せ番号を個別の馬番に分割する。
+                # safe_int() で int 変換すると先頭ゼロが失われるため、
+                # 馬券種別ごとに固定桁数でゼロパディングしてから2桁ずつ分割する。
+                if bet_type in ('win', 'place'):
+                    # 単勝・複勝: 1頭 (2桁以下の馬番)
+                    horse_numbers = [combo]
+                elif bet_type == 'wakuren':
+                    # 枠連: 2桁フィールド → 十の位が枠番1, 一の位が枠番2
+                    horse_numbers = [n for n in (combo // 10, combo % 10) if n > 0]
+                elif bet_type in ('umaren', 'wide', 'umatan'):
+                    # 馬連・ワイド・馬単: 4桁 (XX YY) → 馬番XX + 馬番YY
+                    s = f"{combo:04d}"
+                    horse_numbers = [n for n in (int(s[0:2]), int(s[2:4])) if n > 0]
+                elif bet_type in ('sanrenpuku', 'sanrentan'):
+                    # 三連複・三連単: 6桁 (XX YY ZZ) → 馬番XX + 馬番YY + 馬番ZZ
+                    s = f"{combo:06d}"
+                    horse_numbers = [
+                        n for n in (int(s[0:2]), int(s[2:4]), int(s[4:6])) if n > 0
+                    ]
+                else:
+                    horse_numbers = [combo]
+                rows.append({
+                    'race_id': race_id,
+                    'bet_type': bet_type,
+                    'horse_number_1': horse_numbers[0] if len(horse_numbers) > 0 else None,
+                    'horse_number_2': horse_numbers[1] if len(horse_numbers) > 1 else None,
+                    'horse_number_3': horse_numbers[2] if len(horse_numbers) > 2 else None,
+                    'payout_amount': payout,
+                    'rank': rank,
+                    'created_at': created_at,
+                    'updated_at': updated_at,
+                })
+
+        return rows
+
+    @staticmethod
     def parse_file(file_content: str, data_type: str) -> List[Dict]:
         """
         ファイル全体を解析
@@ -1274,6 +1488,8 @@ class JRDBParser:
             'UKC': JRDBParser.parse_ukc_line,
             'KKA': JRDBParser.parse_kka_line,
             'KAA': JRDBParser.parse_kaa_line,
+            'HJB': JRDBParser.parse_hjb_line,
+            'HJC': JRDBParser.parse_hjb_line,
         }
 
         parser_func = parser_map.get(data_type.upper())

--- a/src/automation/data/load_to_bq.py
+++ b/src/automation/data/load_to_bq.py
@@ -47,6 +47,8 @@ TABLE_MAPPING = {
     "UKC": "horse_master",
     "KKA": "horse_extended",
     "KAA": "venue_info",
+    "HJB": "payouts",
+    "HJC": "payouts",
 }
 
 # テーブルごとの一意キー (MERGE文で使用)
@@ -57,7 +59,11 @@ TABLE_UNIQUE_KEYS = {
     "horse_master": ["horse_id"],
     "horse_extended": ["race_id", "horse_number"],
     "venue_info": ["venue_id"],
+    "payouts": ["race_id", "bet_type", "rank"],
 }
+
+# パース後に行展開が必要なデータタイプ
+EXPAND_DATA_TYPES = {"HJB", "HJC"}
 
 # ロード履歴テーブル名
 LOAD_HISTORY_TABLE = "load_history"
@@ -451,6 +457,18 @@ class BigQueryLoader:
                 result.error = "パース結果が空"
                 logger.warning(f"ファイルからデータをパースできませんでした: {blob_name}")
                 return result
+
+            # HJB/HJCは1レース分のレコードを複数ペイアウト行に展開する
+            if data_type.upper() in EXPAND_DATA_TYPES:
+                expanded: List[Dict] = []
+                for record in parsed_data:
+                    expanded.extend(JRDBParser.expand_hjb_to_payout_rows(record))
+                parsed_data = expanded
+                if not parsed_data:
+                    result.status = "skipped"
+                    result.error = "HJB展開結果が空"
+                    logger.warning(f"HJBデータの展開結果が空でした: {blob_name}")
+                    return result
 
             # BigQueryにロード
             records_loaded = self._load_to_bigquery(table_name, parsed_data, data_type)

--- a/src/manual/create_tables.py
+++ b/src/manual/create_tables.py
@@ -246,6 +246,14 @@ class BigQueryTableCreator:
             },
             {
                 "dataset_id": "raw",
+                "table_id": "payouts",
+                "schema_file": "bq_schema_payouts.json",
+                "partition_field": None,
+                "clustering_fields": ["race_id", "bet_type"],
+                "description": "払戻情報データ (HJB/HJC: 払戻情報)",
+            },
+            {
+                "dataset_id": "raw",
                 "table_id": "load_history",
                 "schema_file": "bq_schema_load_history.json",
                 "partition_field": None,

--- a/tests/test_jrdb_parser_hjb.py
+++ b/tests/test_jrdb_parser_hjb.py
@@ -1,0 +1,329 @@
+"""
+JRDBParser の HJB/HJC 払戻情報パーサーのユニットテスト
+
+parse_hjb_line() および expand_hjb_to_payout_rows() の動作を検証する。
+"""
+
+import pytest
+
+from src.automation.data.jrdb_parser import JRDBParser
+
+
+def _build_hjb_line(
+    race_key: str = "08251301",
+    win: list = None,
+    place: list = None,
+    wakuren: list = None,
+    umaren: list = None,
+    wide: list = None,
+    umatan: list = None,
+    sanrenpuku: list = None,
+    sanrentan: list = None,
+) -> str:
+    """
+    テスト用 HJB/HJC 行文字列を構築するヘルパー。
+
+    各引数はエントリのリスト:
+        win/place/wakuren: [(horse_str2, payout_str7), ...]  (最大3/5/3件)
+        umaren/wide/umatan: [(horse_str4, payout_str8), ...]  (最大3/7/6件)
+        sanrenpuku: [(horse_str6, payout_str8), ...]  (最大3件)
+        sanrentan:  [(horse_str6, payout_str9), ...]  (最大6件, HJC のみ)
+
+    指定がない部分はスペースで埋める。
+    """
+    def _pad_entries(entries, horse_w, payout_w, max_n):
+        result = ""
+        for i in range(max_n):
+            if entries and i < len(entries):
+                h, p = entries[i]
+                result += h.ljust(horse_w)[:horse_w] + p.rjust(payout_w)[:payout_w]
+            else:
+                result += " " * (horse_w + payout_w)
+        return result
+
+    # 単勝(3件×9) + 複勝(5件×9) + 枠連(3件×9) + 馬連(3件×12) +
+    # ワイド(7件×12) + 馬単(6件×12) + 三連複(3件×14)
+    body = (
+        race_key
+        + _pad_entries(win, 2, 7, 3)
+        + _pad_entries(place, 2, 7, 5)
+        + _pad_entries(wakuren, 2, 7, 3)
+        + _pad_entries(umaren, 4, 8, 3)
+        + _pad_entries(wide, 4, 8, 7)
+        + _pad_entries(umatan, 4, 8, 6)
+        + _pad_entries(sanrenpuku, 6, 8, 3)
+    )
+    # 三連単(6件×15, HJCのみ)
+    if sanrentan is not None:
+        body += _pad_entries(sanrentan, 6, 9, 6)
+    return body
+
+
+class TestParseHjbLine:
+    """parse_hjb_line() のテスト"""
+
+    def test_parses_win_payout(self):
+        """単勝払戻が正しくパースされる"""
+        line = _build_hjb_line(
+            race_key="08251301",
+            win=[("03", "0000170")],
+        )
+        result = JRDBParser.parse_hjb_line(line)
+        assert result is not None
+        assert result["race_id"] == "08251301"
+        assert len(result["win_payouts"]) == 1
+        horse, payout = result["win_payouts"][0]
+        assert horse == 3
+        assert payout == 170
+
+    def test_parses_place_payouts(self):
+        """複勝払戻(複数馬)が正しくパースされる"""
+        line = _build_hjb_line(
+            place=[
+                ("03", "0000110"),
+                ("09", "0000110"),
+                ("08", "0000120"),
+            ],
+        )
+        result = JRDBParser.parse_hjb_line(line)
+        assert result is not None
+        assert len(result["place_payouts"]) == 3
+        horses = [p[0] for p in result["place_payouts"]]
+        assert horses == [3, 9, 8]
+
+    def test_parses_umaren_payout(self):
+        """馬連払戻(4桁組合せ)が正しくパースされる"""
+        line = _build_hjb_line(
+            umaren=[("0309", "00001540")],
+        )
+        result = JRDBParser.parse_hjb_line(line)
+        assert result is not None
+        assert len(result["umaren_payouts"]) == 1
+        combo, payout = result["umaren_payouts"][0]
+        # combo は safe_int("0309") = 309
+        assert combo == 309
+        assert payout == 1540
+
+    def test_parses_wide_payouts(self):
+        """ワイド払戻(複数)が正しくパースされる"""
+        line = _build_hjb_line(
+            wide=[
+                ("0309", "00000370"),
+                ("0308", "00000380"),
+                ("0908", "00000410"),
+            ],
+        )
+        result = JRDBParser.parse_hjb_line(line)
+        assert result is not None
+        assert len(result["wide_payouts"]) == 3
+
+    def test_parses_sanrenpuku_payout(self):
+        """三連複払戻(6桁組合せ)が正しくパースされる"""
+        line = _build_hjb_line(
+            sanrenpuku=[("030809", "00001050")],
+        )
+        result = JRDBParser.parse_hjb_line(line)
+        assert result is not None
+        assert len(result["sanrenpuku_payouts"]) == 1
+        combo, payout = result["sanrenpuku_payouts"][0]
+        assert combo == 30809
+        assert payout == 1050
+
+    def test_parses_sanrentan_payout_hjc(self):
+        """三連単払戻(HJCのみ, 9桁払戻金)が正しくパースされる"""
+        line = _build_hjb_line(
+            sanrentan=[("030908", "000005670")],
+        )
+        result = JRDBParser.parse_hjb_line(line)
+        assert result is not None
+        assert len(result["sanrentan_payouts"]) == 1
+        combo, payout = result["sanrentan_payouts"][0]
+        assert combo == 30908
+        assert payout == 5670
+
+    def test_empty_entries_are_ignored(self):
+        """空エントリ(スペース埋め)は含まれない"""
+        line = _build_hjb_line()  # 全エントリ空
+        result = JRDBParser.parse_hjb_line(line)
+        assert result is not None
+        assert result["win_payouts"] == []
+        assert result["place_payouts"] == []
+        assert result["umaren_payouts"] == []
+
+    def test_returns_none_for_short_line(self):
+        """行が短すぎる場合 None を返す"""
+        result = JRDBParser.parse_hjb_line("08251301   ")
+        assert result is None
+
+    def test_race_id_preserved(self):
+        """race_id がレースキーそのままで返る"""
+        line = _build_hjb_line(race_key="05261204")
+        result = JRDBParser.parse_hjb_line(line)
+        assert result is not None
+        assert result["race_id"] == "05261204"
+
+    def test_sanrentan_absent_in_hjb(self):
+        """HJB形式(三連単なし)では sanrentan_payouts が空"""
+        # sanrentan 引数を渡さない → 三連単セクションなし
+        line = _build_hjb_line(
+            win=[("03", "0000170")],
+        )
+        assert len(line) < 431
+        result = JRDBParser.parse_hjb_line(line)
+        assert result is not None
+        assert result["sanrentan_payouts"] == []
+
+
+class TestExpandHjbToPayoutRows:
+    """expand_hjb_to_payout_rows() のテスト"""
+
+    def _make_record(self, **payouts):
+        """テスト用の最小レコードを返す"""
+        base = {
+            "race_id": "08251301",
+            "venue_code": "08",
+            "year": 25,
+            "race_number": 1,
+            "win_payouts": [],
+            "place_payouts": [],
+            "wakuren_payouts": [],
+            "umaren_payouts": [],
+            "wide_payouts": [],
+            "umatan_payouts": [],
+            "sanrenpuku_payouts": [],
+            "sanrentan_payouts": [],
+            "created_at": "2025-01-01T00:00:00",
+            "updated_at": "2025-01-01T00:00:00",
+        }
+        base.update(payouts)
+        return base
+
+    def test_win_row_has_correct_fields(self):
+        """単勝: horse_number_1のみ設定され、2/3はNone"""
+        record = self._make_record(win_payouts=[(3, 170)])
+        rows = JRDBParser.expand_hjb_to_payout_rows(record)
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["bet_type"] == "win"
+        assert row["horse_number_1"] == 3
+        assert row["horse_number_2"] is None
+        assert row["horse_number_3"] is None
+        assert row["payout_amount"] == 170
+        assert row["rank"] == 1
+
+    def test_place_multiple_entries_rank(self):
+        """複勝: 複数エントリのrank連番"""
+        record = self._make_record(
+            place_payouts=[(3, 110), (9, 110), (8, 120)]
+        )
+        rows = JRDBParser.expand_hjb_to_payout_rows(record)
+        place_rows = [r for r in rows if r["bet_type"] == "place"]
+        assert len(place_rows) == 3
+        assert [r["rank"] for r in place_rows] == [1, 2, 3]
+        assert [r["horse_number_1"] for r in place_rows] == [3, 9, 8]
+
+    def test_umaren_splits_4digit_combo_correctly(self):
+        """馬連: 4桁組合せ(0309)→horse_number_1=3, horse_number_2=9"""
+        record = self._make_record(umaren_payouts=[(309, 1540)])
+        rows = JRDBParser.expand_hjb_to_payout_rows(record)
+        umaren_rows = [r for r in rows if r["bet_type"] == "umaren"]
+        assert len(umaren_rows) == 1
+        assert umaren_rows[0]["horse_number_1"] == 3
+        assert umaren_rows[0]["horse_number_2"] == 9
+        assert umaren_rows[0]["horse_number_3"] is None
+        assert umaren_rows[0]["payout_amount"] == 1540
+
+    def test_wide_splits_4digit_combo_with_leading_zero_horse(self):
+        """ワイド: 0103 → horse1=1, horse2=3 (先頭ゼロが消えた整数103を正しく分割)"""
+        record = self._make_record(wide_payouts=[(103, 500)])
+        rows = JRDBParser.expand_hjb_to_payout_rows(record)
+        wide_rows = [r for r in rows if r["bet_type"] == "wide"]
+        assert len(wide_rows) == 1
+        assert wide_rows[0]["horse_number_1"] == 1
+        assert wide_rows[0]["horse_number_2"] == 3
+
+    def test_umatan_splits_4digit_combo(self):
+        """馬単: 4桁組合せが正しく分割される"""
+        record = self._make_record(umatan_payouts=[(309, 2780)])
+        rows = JRDBParser.expand_hjb_to_payout_rows(record)
+        umatan_rows = [r for r in rows if r["bet_type"] == "umatan"]
+        assert len(umatan_rows) == 1
+        assert umatan_rows[0]["horse_number_1"] == 3
+        assert umatan_rows[0]["horse_number_2"] == 9
+
+    def test_sanrenpuku_splits_6digit_combo(self):
+        """三連複: 6桁組合せ(030809)→horse1=3, horse2=8, horse3=9"""
+        record = self._make_record(sanrenpuku_payouts=[(30809, 1050)])
+        rows = JRDBParser.expand_hjb_to_payout_rows(record)
+        sr_rows = [r for r in rows if r["bet_type"] == "sanrenpuku"]
+        assert len(sr_rows) == 1
+        assert sr_rows[0]["horse_number_1"] == 3
+        assert sr_rows[0]["horse_number_2"] == 8
+        assert sr_rows[0]["horse_number_3"] == 9
+        assert sr_rows[0]["payout_amount"] == 1050
+
+    def test_sanrentan_splits_6digit_combo(self):
+        """三連単: 6桁組合せが正しく分割される"""
+        record = self._make_record(sanrentan_payouts=[(30908, 5670)])
+        rows = JRDBParser.expand_hjb_to_payout_rows(record)
+        st_rows = [r for r in rows if r["bet_type"] == "sanrentan"]
+        assert len(st_rows) == 1
+        assert st_rows[0]["horse_number_1"] == 3
+        assert st_rows[0]["horse_number_2"] == 9
+        assert st_rows[0]["horse_number_3"] == 8
+
+    def test_wakuren_splits_frame_numbers(self):
+        """枠連: 2桁(38)→frame1=3, frame2=8"""
+        record = self._make_record(wakuren_payouts=[(38, 820)])
+        rows = JRDBParser.expand_hjb_to_payout_rows(record)
+        wk_rows = [r for r in rows if r["bet_type"] == "wakuren"]
+        assert len(wk_rows) == 1
+        assert wk_rows[0]["horse_number_1"] == 3
+        assert wk_rows[0]["horse_number_2"] == 8
+
+    def test_empty_record_returns_empty_list(self):
+        """空のレコード(全払戻なし)は空のリストを返す"""
+        record = self._make_record()
+        rows = JRDBParser.expand_hjb_to_payout_rows(record)
+        assert rows == []
+
+    def test_race_id_propagated(self):
+        """全行に race_id が伝播される"""
+        record = self._make_record(
+            win_payouts=[(3, 170)],
+            place_payouts=[(3, 110), (9, 110)],
+        )
+        rows = JRDBParser.expand_hjb_to_payout_rows(record)
+        for row in rows:
+            assert row["race_id"] == "08251301"
+
+    def test_full_hjb_line_round_trip(self):
+        """parse_hjb_line → expand_hjb_to_payout_rows のラウンドトリップ"""
+        line = _build_hjb_line(
+            race_key="08251301",
+            win=[("03", "0000170")],
+            place=[("03", "0000110"), ("09", "0000110"), ("08", "0000120")],
+            umaren=[("0309", "00001540")],
+            sanrenpuku=[("030809", "00001050")],
+        )
+        parsed = JRDBParser.parse_hjb_line(line)
+        assert parsed is not None
+        rows = JRDBParser.expand_hjb_to_payout_rows(parsed)
+        bet_types = {r["bet_type"] for r in rows}
+        assert "win" in bet_types
+        assert "place" in bet_types
+        assert "umaren" in bet_types
+        assert "sanrenpuku" in bet_types
+
+        win_rows = [r for r in rows if r["bet_type"] == "win"]
+        assert win_rows[0]["horse_number_1"] == 3
+        assert win_rows[0]["payout_amount"] == 170
+
+        umaren_rows = [r for r in rows if r["bet_type"] == "umaren"]
+        assert umaren_rows[0]["horse_number_1"] == 3
+        assert umaren_rows[0]["horse_number_2"] == 9
+
+        sr_rows = [r for r in rows if r["bet_type"] == "sanrenpuku"]
+        assert sr_rows[0]["horse_number_1"] == 3
+        assert sr_rows[0]["horse_number_2"] == 8
+        assert sr_rows[0]["horse_number_3"] == 9

--- a/tests/test_load_to_bq.py
+++ b/tests/test_load_to_bq.py
@@ -10,6 +10,7 @@ import pytest
 from src.automation.data.load_to_bq import (
     BatchLoadResult,
     BigQueryLoader,
+    EXPAND_DATA_TYPES,
     LOAD_HISTORY_TABLE,
     LoadResult,
     create_loader_from_env,
@@ -86,6 +87,12 @@ class TestGetTableName:
     def test_lowercase_input(self):
         """小文字の入力も正しく処理される"""
         assert get_table_name("baa") == "race_info"
+
+    def test_hjb_maps_to_payouts(self):
+        assert get_table_name("HJB") == "payouts"
+
+    def test_hjc_maps_to_payouts(self):
+        assert get_table_name("HJC") == "payouts"
 
     def test_unknown_data_type(self):
         """未知のデータタイプはNoneを返す"""
@@ -757,3 +764,80 @@ class TestLoadFileWithHistory:
                         loader.load_file("BAA260104.csv", record_history=False)
 
         mock_history.assert_not_called()
+
+
+class TestExpandDataTypes:
+    """EXPAND_DATA_TYPESの確認とHJBロード展開処理のテスト"""
+
+    def test_expand_data_types_contains_hjb_hjc(self):
+        """EXPAND_DATA_TYPESにHJBとHJCが含まれる"""
+        assert "HJB" in EXPAND_DATA_TYPES
+        assert "HJC" in EXPAND_DATA_TYPES
+
+    def test_expand_data_types_does_not_contain_sec(self):
+        """SECなど通常タイプはEXPAND_DATA_TYPESに含まれない"""
+        assert "SEC" not in EXPAND_DATA_TYPES
+        assert "BAA" not in EXPAND_DATA_TYPES
+
+    def test_hjb_load_file_expands_payout_rows(self):
+        """HJBファイルのload_fileがexpand_hjb_to_payout_rowsを呼び出し展開する"""
+        loader = BigQueryLoader(project_id="test-project")
+
+        # parse_hjb_line が返す1レース分のレコード
+        hjb_parsed_record = {
+            "race_id": "08251301",
+            "win_payouts": [(3, 170)],
+            "place_payouts": [(3, 110), (9, 110)],
+            "wakuren_payouts": [],
+            "umaren_payouts": [],
+            "wide_payouts": [],
+            "umatan_payouts": [],
+            "sanrenpuku_payouts": [],
+            "sanrentan_payouts": [],
+            "created_at": "2025-01-01T00:00:00",
+            "updated_at": "2025-01-01T00:00:00",
+        }
+        # expand後の期待されるペイアウト行 (win×1 + place×2 = 3行)
+        expanded_rows = [
+            {"race_id": "08251301", "bet_type": "win", "horse_number_1": 3,
+             "horse_number_2": None, "horse_number_3": None, "payout_amount": 170,
+             "rank": 1, "created_at": "2025-01-01T00:00:00", "updated_at": "2025-01-01T00:00:00"},
+            {"race_id": "08251301", "bet_type": "place", "horse_number_1": 3,
+             "horse_number_2": None, "horse_number_3": None, "payout_amount": 110,
+             "rank": 1, "created_at": "2025-01-01T00:00:00", "updated_at": "2025-01-01T00:00:00"},
+            {"race_id": "08251301", "bet_type": "place", "horse_number_1": 9,
+             "horse_number_2": None, "horse_number_3": None, "payout_amount": 110,
+             "rank": 2, "created_at": "2025-01-01T00:00:00", "updated_at": "2025-01-01T00:00:00"},
+        ]
+
+        with patch.object(loader, "_download_file_from_gcs", return_value="data"):
+            with patch.object(loader, "_load_to_bigquery", return_value=3) as mock_load_bq:
+                with patch.object(loader, "_record_load_history"):
+                    with patch("src.automation.data.load_to_bq.JRDBParser") as mock_parser:
+                        mock_parser.parse_file.return_value = [hjb_parsed_record]
+                        mock_parser.expand_hjb_to_payout_rows.return_value = expanded_rows
+
+                        result = loader.load_file("HJB260104.csv")
+
+        assert result.status == "success"
+        assert result.records_processed == 3
+        assert result.table == "raw.payouts"
+        # expand_hjb_to_payout_rows が呼ばれたことを確認
+        mock_parser.expand_hjb_to_payout_rows.assert_called_once_with(hjb_parsed_record)
+        # _load_to_bigquery には展開後のrows が渡された
+        mock_load_bq.assert_called_once_with("payouts", expanded_rows, "HJB")
+
+    def test_hjb_load_file_empty_after_expand_is_skipped(self):
+        """HJB展開結果が空の場合はskippedになる"""
+        loader = BigQueryLoader(project_id="test-project")
+
+        with patch.object(loader, "_download_file_from_gcs", return_value="data"):
+            with patch.object(loader, "_record_load_history"):
+                with patch("src.automation.data.load_to_bq.JRDBParser") as mock_parser:
+                    mock_parser.parse_file.return_value = [{"race_id": "08251301"}]
+                    mock_parser.expand_hjb_to_payout_rows.return_value = []
+
+                    result = loader.load_file("HJB260104.csv")
+
+        assert result.status == "skipped"
+        assert result.error == "HJB展開結果が空"


### PR DESCRIPTION
## Summary

- HJB/HJC (払戻情報データ) のBigQuery格納機能を実装
- SECパーサーの`place_odds`フィールドマッピングバグを修正
- `raw.payouts` テーブルの新規スキーマ・テーブル定義追加

## 変更内容

### jrdb_parser.py
- `parse_hjb_line()` を新規追加: HJB(三連単なし, 341字) / HJC(三連単あり, 444字) を解析し、各馬券種の払戻リストを返す
- `expand_hjb_to_payout_rows()` を新規追加: 1レース分のレコードを `raw.payouts` テーブル用の行(1行1払戻)に展開
  - **バグ修正**: `safe_int("0309") = 309` → `str(309) = "309"` で先頭ゼロが消え馬番が誤りになる問題を、馬券種別ごとの固定桁ゼロパディング分割で修正
- `parse_sec_line()` の `place_odds` / `odds_10am_win` / `odds_10am_place` の文字位置を修正

### load_to_bq.py
- `TABLE_MAPPING` に `HJB` / `HJC` → `payouts` を追加
- `TABLE_UNIQUE_KEYS` に `payouts: ["race_id", "bet_type", "rank"]` を追加
- `EXPAND_DATA_TYPES` 定数を追加 (HJB/HJC はパース後に行展開が必要なため識別)
- `load_file()` で HJB/HJC の場合 `expand_hjb_to_payout_rows()` を呼び出す処理を追加

### その他
- `config/bq_schema_payouts.json`: `raw.payouts` スキーマ新規作成
- `src/manual/create_tables.py`: `raw.payouts` テーブル定義を追加
- `tests/test_jrdb_parser_hjb.py`: HJBパーサーのユニットテスト21件追加
- `tests/test_load_to_bq.py`: HJB/HJCロード処理のテスト6件追加

## Test plan

- [x] `python3 -m pytest tests/test_jrdb_parser_hjb.py tests/test_load_to_bq.py -v` → 83件 passed
- [x] `python3 -m pytest` → 全298件 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)