### PR TITLE
fix: parse_race_idの回・日フィールドを16進数対応に修正 (Issue #95)

### DIFF
--- a/src/automation/data/jrdb_parser.py
+++ b/src/automation/data/jrdb_parser.py
@@ -67,8 +67,9 @@ class JRDBParser:
 
         venue_code = race_key[0:2]
         year = int(race_key[2:4])
-        kai = int(race_key[4:5])
-        day = int(race_key[5:6])
+        # 回・日は9を超える場合にJRDBが16進数表記 (a=10, b=11, ...) を使用する
+        kai = int(race_key[4:5], 16)
+        day = int(race_key[5:6], 16)
         race_num = int(race_key[6:8])
 
         # 2000年以降の年を補完

--- a/tests/test_jrdb_parser_hjb.py
+++ b/tests/test_jrdb_parser_hjb.py
@@ -59,6 +59,46 @@ def _build_hjb_line(
     return body
 
 
+class TestParseRaceIdHex:
+    """parse_race_id() の16進数フィールド対応テスト"""
+
+    def test_day_decimal(self):
+        """日フィールドが通常の数字(1-9)の場合は正常にパースされる"""
+        result = JRDBParser.parse_race_id("08251301")
+        assert result["day"] == 3
+
+    def test_day_hex_a(self):
+        """日フィールドが 'a' (=10) のレースキーを正しくパースする"""
+        result = JRDBParser.parse_race_id("08251a01")
+        assert result["day"] == 10
+
+    def test_day_hex_b(self):
+        """日フィールドが 'b' (=11) のレースキーを正しくパースする（実際のバグケース）"""
+        result = JRDBParser.parse_race_id("08221b01")
+        assert result["day"] == 11
+
+    def test_day_hex_c(self):
+        """日フィールドが 'c' (=12) のレースキーを正しくパースする"""
+        result = JRDBParser.parse_race_id("08221c01")
+        assert result["day"] == 12
+
+    def test_kai_hex_a(self):
+        """回フィールドが 'a' (=10) の場合も正しくパースされる"""
+        result = JRDBParser.parse_race_id("0822a101")
+        assert result["kai"] == 10
+
+    def test_hjb_line_with_hex_day_parses_successfully(self):
+        """16進数の日フィールドを含むHJB行全体が正常にパースされる（Issue #95）"""
+        line = _build_hjb_line(
+            race_key="08221b01",  # day='b'=11
+            win=[("03", "0000170")],
+        )
+        result = JRDBParser.parse_hjb_line(line)
+        assert result is not None
+        assert result["race_id"] == "08221b01"
+        assert len(result["win_payouts"]) == 1
+
+
 class TestParseHjbLine:
     """parse_hjb_line() のテスト"""
 


### PR DESCRIPTION
## Summary

- `parse_race_id()` の `kai`（回）・`day`（日）フィールドを `int(x, 16)` に変更し、JRDBの16進数表記に対応
- 0〜9 の通常値は16進数でも同値のため既存の挙動に変化なし

## 背景

JRDBはレースキーの回・日フィールドで、値が9を超える場合に16進数表記（`a`=10, `b`=11...）を使用する。  
これを `int(x)` で変換しようとすると `ValueError` が発生し、該当レコードが `raw.payouts` に欠落していた。

```
# 実際のエラー (HJB220319.csv)
ValueError: invalid literal for int() with base 10: 'b'
  day = int(race_key[5:6])
```

## 変更内容

`src/automation/data/jrdb_parser.py`
```python
# Before
kai = int(race_key[4:5])
day = int(race_key[5:6])

# After
kai = int(race_key[4:5], 16)  # 9超は16進数表記 (a=10, b=11, ...)
day = int(race_key[5:6], 16)
```

`tests/test_jrdb_parser_hjb.py`
- `TestParseRaceIdHex` クラスを追加（6件）
  - day=`'a'`(10), `'b'`(11), `'c'`(12), kai=`'a'`(10) の各ケース
  - 16進数日付を含むHJB行全体のパース成功ケース

## Test plan

- [x] `python3 -m pytest tests/test_jrdb_parser_hjb.py -v` → 27件 passed
- [x] `python3 -m pytest` → 全304件 passed

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)