### PR TITLE
fix: バックテストのオッズカラム未取得バグを修正

### DIFF
--- a/scripts/run_backtest.py
+++ b/scripts/run_backtest.py
@@ -121,6 +121,51 @@ def fetch_historical_results(
     return df
 
 
+def fetch_place_odds(
+    project_id: str,
+    race_ids: list[str],
+) -> pd.DataFrame:
+    """
+    複勝オッズを raw.odds から取得する
+
+    各 (race_id, horse_id) ごとに最新タイムスタンプのオッズを1行に集約する。
+    raw.odds にデータがない場合は空 DataFrame を返す。
+
+    Args:
+        project_id: GCP プロジェクト ID
+        race_ids: オッズを取得するレース ID のリスト
+
+    Returns:
+        複勝オッズ DataFrame (race_id, horse_id, horse_number, place_odds)
+    """
+    if not race_ids:
+        return pd.DataFrame()
+
+    client = bigquery.Client(project=project_id)
+    ids_str = ", ".join(f"'{r}'" for r in race_ids)
+    query = f"""
+    SELECT race_id, horse_id, horse_number, odds_value AS place_odds
+    FROM (
+        SELECT race_id, horse_id, horse_number, odds_value,
+               ROW_NUMBER() OVER (
+                   PARTITION BY race_id, horse_id
+                   ORDER BY odds_timestamp DESC
+               ) AS rn
+        FROM `{project_id}.raw.odds`
+        WHERE odds_type = 'place'
+          AND race_id IN ({ids_str})
+    )
+    WHERE rn = 1
+    """
+    try:
+        df = client.query(query).to_dataframe()
+        logger.info(f"Fetched {len(df)} place odds rows from raw.odds")
+        return df
+    except Exception as e:
+        logger.warning(f"raw.odds からのオッズ取得に失敗しました: {e}")
+        return pd.DataFrame()
+
+
 def fetch_place_payouts(
     project_id: str,
     start_date: datetime.date,
@@ -221,11 +266,6 @@ def generate_predictions(
         )
     else:
         result_df["finish_position"] = np.nan
-
-    # オッズカラムの付与
-    for odds_col in ["odds_yesterday", "odds_today"]:
-        if odds_col in features_df.columns:
-            result_df[odds_col] = features_df[odds_col].values
 
     return result_df.sort_values(
         ["race_date", "race_id", "horse_number"]
@@ -368,7 +408,7 @@ def run_backtest_pipeline(
     kelly_fraction: float = 0.25,
     expected_return_threshold: float = 1.2,
     max_bet_ratio: float = 0.05,
-    odds_column: str = "odds_yesterday",
+    odds_column: str = "place_odds",
     output_csv: str | None = None,
     save_bq: bool = False,
     output_chart: str | None = None,
@@ -430,7 +470,44 @@ def run_backtest_pipeline(
         config=config,
     )
 
-    # 3. シミュレーション実行
+    # 3. オッズの取得とマージ
+    # まず raw.odds（事前オッズ）から取得を試みる。
+    # データがない場合は raw.payouts の払戻額/100 を代替として使用する
+    # （払戻額はレース後確定値のため、厳密なバックテストでは前者が望ましい）
+    race_ids = predictions_df["race_id"].unique().tolist()
+    odds_df = fetch_place_odds(project_id=project_id, race_ids=race_ids)
+
+    if len(odds_df) > 0:
+        predictions_df = predictions_df.merge(
+            odds_df[["race_id", "horse_id", "place_odds"]],
+            on=["race_id", "horse_id"],
+            how="left",
+        )
+        logger.info("raw.odds の複勝オッズを place_odds としてマージしました")
+    elif len(payouts_df) > 0:
+        logger.warning(
+            "raw.odds にオッズデータがありません。"
+            "raw.payouts の payout_amount/100 を place_odds の代替として使用します。"
+            "（レース後確定値のため、期待回収率フィルタに軽微な先読みバイアスが生じます）"
+        )
+        place_df = payouts_df[payouts_df["bet_type"] == "place"][
+            ["race_id", "horse_number_1", "payout_amount"]
+        ].copy()
+        place_df = place_df.rename(columns={"horse_number_1": "horse_number"})
+        place_df["place_odds"] = place_df["payout_amount"] / 100.0
+        predictions_df = predictions_df.merge(
+            place_df[["race_id", "horse_number", "place_odds"]],
+            on=["race_id", "horse_number"],
+            how="left",
+        )
+    else:
+        logger.error(
+            "オッズデータが取得できませんでした。"
+            "raw.odds・raw.payouts いずれも空です。バックテストを中断します。"
+        )
+        return pd.DataFrame(), {}
+
+    # 4. シミュレーション実行
     simulator = BacktestSimulator(
         initial_capital=initial_capital,
         kelly_fraction=kelly_fraction,
@@ -443,10 +520,10 @@ def run_backtest_pipeline(
         payouts_df=payouts_df if len(payouts_df) > 0 else None,
     )
 
-    # 4. 評価指標計算
+    # 5. 評価指標計算
     metrics = compute_metrics(history_df, initial_capital)
 
-    # 5. 結果保存
+    # 6. 結果保存
     if output_csv and len(history_df) > 0:
         Path(output_csv).parent.mkdir(parents=True, exist_ok=True)
         history_df.to_csv(output_csv, index=False)
@@ -530,8 +607,8 @@ def main() -> int:
     )
     parser.add_argument(
         "--odds-column",
-        default="odds_yesterday",
-        help="オッズとして使用するカラム名",
+        default="place_odds",
+        help="オッズとして使用するカラム名 (パイプラインが place_odds を自動生成)",
     )
     parser.add_argument(
         "--output-csv",

--- a/tests/test_run_backtest.py
+++ b/tests/test_run_backtest.py
@@ -1,0 +1,227 @@
+"""
+run_backtest.py のユニットテスト
+
+BigQuery アクセスをモックして、オッズ取得・マージ処理を検証する。
+"""
+
+from __future__ import annotations
+
+import datetime
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+# BigQuery をモックするためモジュールをインポート
+import scripts.run_backtest as rb
+
+
+# ---------------------------------------------------------------------------
+# テスト用ヘルパー
+# ---------------------------------------------------------------------------
+
+def _make_predictions(n_horses: int = 4) -> pd.DataFrame:
+    """テスト用の予測 DataFrame を生成する（オッズカラムなし）"""
+    rows = []
+    for i in range(1, n_horses + 1):
+        rows.append({
+            "race_id": "race_001",
+            "race_date": datetime.date(2025, 1, 5),
+            "horse_id": f"horse_{i:03d}",
+            "horse_number": i,
+            "win_place_prob": 0.4,
+            "pred_score": float(i),
+            "finish_position": i,
+        })
+    return pd.DataFrame(rows)
+
+
+def _make_odds_df(n_horses: int = 4, odds_val: float = 2.5) -> pd.DataFrame:
+    """テスト用の複勝オッズ DataFrame を生成する"""
+    rows = []
+    for i in range(1, n_horses + 1):
+        rows.append({
+            "race_id": "race_001",
+            "horse_id": f"horse_{i:03d}",
+            "horse_number": i,
+            "place_odds": odds_val,
+        })
+    return pd.DataFrame(rows)
+
+
+def _make_payouts_df(n_horses: int = 3, payout: int = 250) -> pd.DataFrame:
+    """テスト用の払戻 DataFrame を生成する（raw.payoutsフォーマット）"""
+    rows = []
+    for i in range(1, n_horses + 1):
+        rows.append({
+            "race_id": "race_001",
+            "horse_number_1": i,
+            "payout_amount": payout,
+            "bet_type": "place",
+        })
+    return pd.DataFrame(rows)
+
+
+# ---------------------------------------------------------------------------
+# fetch_place_odds のテスト
+# ---------------------------------------------------------------------------
+
+class TestFetchPlaceOdds:
+    def test_empty_race_ids_returns_empty(self):
+        """race_ids が空の場合は BigQuery を呼ばず空 DataFrame を返す"""
+        result = rb.fetch_place_odds(project_id="test", race_ids=[])
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) == 0
+
+    def test_bq_error_returns_empty(self):
+        """BigQuery クエリが失敗した場合は空 DataFrame を返す"""
+        mock_client = MagicMock()
+        mock_client.query.side_effect = Exception("BQ error")
+        with patch("scripts.run_backtest.bigquery.Client", return_value=mock_client):
+            result = rb.fetch_place_odds(project_id="test", race_ids=["r001"])
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) == 0
+
+    def test_returns_place_odds_column(self):
+        """正常取得時は place_odds カラムを持つ DataFrame を返す"""
+        mock_df = pd.DataFrame({
+            "race_id": ["r001"],
+            "horse_id": ["h001"],
+            "horse_number": [1],
+            "place_odds": [2.5],
+        })
+        mock_job = MagicMock()
+        mock_job.to_dataframe.return_value = mock_df
+        mock_client = MagicMock()
+        mock_client.query.return_value = mock_job
+        with patch("scripts.run_backtest.bigquery.Client", return_value=mock_client):
+            result = rb.fetch_place_odds(project_id="test", race_ids=["r001"])
+        assert "place_odds" in result.columns
+        assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# run_backtest_pipeline のオッズマージ処理テスト
+# ---------------------------------------------------------------------------
+
+class TestOddsMergeInPipeline:
+    """
+    run_backtest_pipeline 内でオッズが predictions_df に正しく
+    マージされることを検証する。
+    BigQuery の全呼び出しをモックする。
+    """
+
+    def _run_with_mocks(
+        self,
+        features_df,
+        results_df,
+        payouts_df,
+        odds_df,
+        captured_predictions,
+    ):
+        """
+        パイプラインをモックで実行し、シミュレーターに渡された
+        predictions_df を captured_predictions リストに格納する。
+        """
+        config = {
+            "data": {
+                "dataset": "features",
+                "table": "training_data",
+                "exclude_columns": [],
+                "categorical_columns": [],
+            }
+        }
+
+        with (
+            patch("scripts.run_backtest.fetch_historical_features", return_value=features_df),
+            patch("scripts.run_backtest.fetch_historical_results", return_value=results_df),
+            patch("scripts.run_backtest.fetch_place_payouts", return_value=payouts_df),
+            patch("scripts.run_backtest.fetch_place_odds", return_value=odds_df),
+            patch("scripts.run_backtest.generate_predictions", return_value=features_df.copy()),
+            patch("scripts.run_backtest.BacktestSimulator") as MockSim,
+            patch("scripts.run_backtest.compute_metrics", return_value={}),
+        ):
+            mock_instance = MockSim.return_value
+            mock_instance.run.side_effect = lambda predictions_df, **kw: (
+                captured_predictions.append(predictions_df) or pd.DataFrame()
+            )
+
+            rb.run_backtest_pipeline(
+                project_id="test",
+                model_path="dummy.txt",
+                start_date=datetime.date(2025, 1, 1),
+                end_date=datetime.date(2025, 12, 31),
+                config=config,
+            )
+
+    def test_place_odds_from_raw_odds_merged(self):
+        """raw.odds にデータがある場合、place_odds カラムが predictions_df に付与される"""
+        preds = _make_predictions(n_horses=3)
+        odds_df = _make_odds_df(n_horses=3, odds_val=3.0)
+        payouts_df = _make_payouts_df(n_horses=3)
+        captured = []
+
+        self._run_with_mocks(
+            features_df=preds,
+            results_df=pd.DataFrame(),
+            payouts_df=payouts_df,
+            odds_df=odds_df,
+            captured_predictions=captured,
+        )
+
+        assert len(captured) == 1, "シミュレーターが呼ばれていない"
+        merged = captured[0]
+        assert "place_odds" in merged.columns, "place_odds カラムが付与されていない"
+        assert (merged["place_odds"] == 3.0).all()
+
+    def test_fallback_to_payouts_when_odds_empty(self):
+        """raw.odds が空の場合、raw.payouts から place_odds が計算される"""
+        preds = _make_predictions(n_horses=3)
+        payouts_df = _make_payouts_df(n_horses=3, payout=280)
+        captured = []
+
+        self._run_with_mocks(
+            features_df=preds,
+            results_df=pd.DataFrame(),
+            payouts_df=payouts_df,
+            odds_df=pd.DataFrame(),   # empty → fallback
+            captured_predictions=captured,
+        )
+
+        assert len(captured) == 1
+        merged = captured[0]
+        assert "place_odds" in merged.columns
+        # payout_amount=280 → place_odds=2.8
+        non_null = merged["place_odds"].dropna()
+        assert (non_null == 2.8).all()
+
+    def test_pipeline_aborts_when_both_empty(self):
+        """raw.odds・raw.payouts 両方空の場合はパイプラインが空結果を返す"""
+        preds = _make_predictions(n_horses=3)
+        config = {
+            "data": {
+                "dataset": "features",
+                "table": "training_data",
+                "exclude_columns": [],
+                "categorical_columns": [],
+            }
+        }
+
+        with (
+            patch("scripts.run_backtest.fetch_historical_features", return_value=preds),
+            patch("scripts.run_backtest.fetch_historical_results", return_value=pd.DataFrame()),
+            patch("scripts.run_backtest.fetch_place_payouts", return_value=pd.DataFrame()),
+            patch("scripts.run_backtest.fetch_place_odds", return_value=pd.DataFrame()),
+            patch("scripts.run_backtest.generate_predictions", return_value=preds.copy()),
+        ):
+            history_df, metrics = rb.run_backtest_pipeline(
+                project_id="test",
+                model_path="dummy.txt",
+                start_date=datetime.date(2025, 1, 1),
+                end_date=datetime.date(2025, 12, 31),
+                config=config,
+            )
+
+        assert len(history_df) == 0
+        assert metrics == {}


### PR DESCRIPTION
## 問題

バックテスト実行時に以下の警告が出て賭け対象が 0 件になっていた。

```
WARNING - odds_column 'odds_yesterday' が見つかりません。
利用可能なカラム: ['race_id', 'race_date', 'horse_id', 'horse_number',
                   'venue_code', 'race_number', 'pred_score', 'win_place_prob', 'finish_position']
```

## 根本原因

1. `features.training_data` に `odds_yesterday` / `odds_today` カラムがスキーマ定義上は存在するが、`feature_query_raw.sql` で生成されていないため実データには存在しない
2. `generate_predictions()` で `result_df.merge()` 後に `features_df[odds_col].values` で代入していたが、`merge()` によるインデックスリセット後は行の対応がずれる（潜在的バグ）

## 修正内容

### `scripts/run_backtest.py`

- `fetch_place_odds()` を追加
  - `raw.odds` テーブル（`odds_type='place'`）から最新タイムスタンプの複勝オッズを取得
  - BigQuery エラー時は空 DataFrame を返す（グレースフルデグラデーション）
- `run_backtest_pipeline()` にオッズ取得・マージ処理を追加
  - `raw.odds` にデータがある場合 → `place_odds` としてマージ
  - `raw.odds` が空の場合 → `raw.payouts.payout_amount / 100` を代替として使用（警告付き）
  - 両方空の場合 → エラーログを出して空結果を返す
- `generate_predictions()` の壊れていた post-merge `.values` 代入を削除
- `odds_column` のデフォルトを `"odds_yesterday"` → `"place_odds"` に変更

### `tests/test_run_backtest.py` (新規)

- `TestFetchPlaceOdds`: BigQuery 正常取得・エラー時の空返却・空リスト入力を検証
- `TestOddsMergeInPipeline`: raw.odds優先マージ・raw.payoutsフォールバック・両方空の中断を検証

## Test plan

- [x] `python3 -m pytest tests/test_run_backtest.py -v` → 6件 passed
- [x] `python3 -m pytest` → 全 358 件 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)