### PR TITLE
feat: raw.odds への OZ（基準オッズ）データロードパイプラインを実装 (#100)

### DIFF
--- a/scripts/run_backtest.py
+++ b/scripts/run_backtest.py
@@ -128,7 +128,8 @@ def fetch_place_odds(
     """
     複勝オッズを raw.odds から取得する
 
-    各 (race_id, horse_id) ごとに最新タイムスタンプのオッズを1行に集約する。
+    各 (race_id, horse_number) ごとに最新タイムスタンプのオッズを1行に集約する。
+    OZ ファイルには horse_id が含まれないため horse_number をキーとして使用する。
     raw.odds にデータがない場合は空 DataFrame を返す。
 
     Args:
@@ -136,7 +137,7 @@ def fetch_place_odds(
         race_ids: オッズを取得するレース ID のリスト
 
     Returns:
-        複勝オッズ DataFrame (race_id, horse_id, horse_number, place_odds)
+        複勝オッズ DataFrame (race_id, horse_number, place_odds)
     """
     if not race_ids:
         return pd.DataFrame()
@@ -144,11 +145,11 @@ def fetch_place_odds(
     client = bigquery.Client(project=project_id)
     ids_str = ", ".join(f"'{r}'" for r in race_ids)
     query = f"""
-    SELECT race_id, horse_id, horse_number, odds_value AS place_odds
+    SELECT race_id, horse_number, odds_value AS place_odds
     FROM (
-        SELECT race_id, horse_id, horse_number, odds_value,
+        SELECT race_id, horse_number, odds_value,
                ROW_NUMBER() OVER (
-                   PARTITION BY race_id, horse_id
+                   PARTITION BY race_id, horse_number
                    ORDER BY odds_timestamp DESC
                ) AS rn
         FROM `{project_id}.raw.odds`
@@ -479,8 +480,8 @@ def run_backtest_pipeline(
 
     if len(odds_df) > 0:
         predictions_df = predictions_df.merge(
-            odds_df[["race_id", "horse_id", "place_odds"]],
-            on=["race_id", "horse_id"],
+            odds_df[["race_id", "horse_number", "place_odds"]],
+            on=["race_id", "horse_number"],
             how="left",
         )
         logger.info("raw.odds の複勝オッズを place_odds としてマージしました")

--- a/src/automation/data/jrdb_parser.py
+++ b/src/automation/data/jrdb_parser.py
@@ -1464,6 +1464,111 @@ class JRDBParser:
         return rows
 
     @staticmethod
+    def parse_oz_line(line: str) -> Optional[Dict]:
+        """
+        OZ（基準オッズ）の1行をパースし、win/place オッズを格納した辞書を返す。
+
+        1行 = 1レース分（最大18頭）のオッズ。
+        仕様書: OZ第4版, レコード長 957バイト
+
+        フォーマット (0-based 文字位置, 全て ASCII 数値文字):
+          0-7   : レースキー (8文字)
+          8-9   : 登録頭数 (2文字)
+          10-99 : 単勝オッズ 18頭分 (5文字×18, 形式: ###.# 例: "046.6")
+          100-189: 複勝オッズ 18頭分 (5文字×18, 形式: ###.# 例: "008.5")
+          190-954: 馬連オッズ 153通り (5文字×153) ← スコープ外
+
+        Args:
+            line: 固定長レコード文字列 (UTF-8変換済み)
+
+        Returns:
+            {race_id, registered_count, win_odds_list, place_odds_list, created_at}
+            or None
+        """
+        try:
+            if len(line) < 100:
+                logger.warning(f"OZ line too short: {len(line)} chars")
+                return None
+
+            race_key = line[0:8].strip()
+            if not race_key:
+                return None
+
+            race_info = JRDBParser.parse_race_id(race_key)
+            registered_count = JRDBParser.safe_int(line[8:10], default=18)
+
+            # 単勝オッズ (18頭分: 各5文字)
+            win_odds_list: list = []
+            for i in range(18):
+                start = 10 + i * 5
+                end = start + 5
+                val = JRDBParser.safe_float(line[start:end]) if end <= len(line) else None
+                win_odds_list.append(val)
+
+            # 複勝オッズ (18頭分: 各5文字)
+            place_odds_list: list = []
+            if len(line) >= 190:
+                for i in range(18):
+                    start = 100 + i * 5
+                    end = start + 5
+                    val = JRDBParser.safe_float(line[start:end]) if end <= len(line) else None
+                    place_odds_list.append(val)
+
+            return {
+                'race_id': race_key,
+                'registered_count': registered_count,
+                'win_odds_list': win_odds_list,
+                'place_odds_list': place_odds_list,
+                'created_at': datetime.utcnow().isoformat(),
+            }
+
+        except Exception as e:
+            logger.error(f"Error parsing OZ line: {e}", exc_info=True)
+            return None
+
+    @staticmethod
+    def expand_oz_to_odds_rows(oz_record: Dict, file_date: Optional[str] = None) -> List[Dict]:
+        """
+        OZの1レースレコードを raw.odds スキーマの行リストに展開する。
+
+        1レースレコードから馬番×馬券種の組み合わせ分の行を生成する。
+        odds_value が None または 0 以下の馬はスキップする。
+
+        Args:
+            oz_record: parse_oz_line() の返り値
+            file_date: ファイル名から抽出した日付文字列 (YYYY-MM-DD)
+                       指定時は "{file_date}T19:00:00+00:00" を odds_timestamp に使用する
+
+        Returns:
+            raw.odds テーブルの行リスト
+        """
+        rows = []
+        race_id = oz_record['race_id']
+        created_at = oz_record['created_at']
+
+        # odds_timestamp: ファイル配信日時 (金/土の19:00 UTC+0 を代表値として使用)
+        odds_timestamp = f"{file_date}T19:00:00+00:00" if file_date else created_at
+
+        for odds_type, odds_list in [
+            ('win', oz_record.get('win_odds_list', [])),
+            ('place', oz_record.get('place_odds_list', [])),
+        ]:
+            for horse_number, odds_value in enumerate(odds_list, start=1):
+                if odds_value is None or odds_value <= 0:
+                    continue
+                rows.append({
+                    'race_id': race_id,
+                    'horse_id': None,
+                    'horse_number': horse_number,
+                    'odds_type': odds_type,
+                    'odds_value': odds_value,
+                    'odds_timestamp': odds_timestamp,
+                    'created_at': created_at,
+                })
+
+        return rows
+
+    @staticmethod
     def parse_file(file_content: str, data_type: str) -> List[Dict]:
         """
         ファイル全体を解析
@@ -1491,6 +1596,7 @@ class JRDBParser:
             'KAA': JRDBParser.parse_kaa_line,
             'HJB': JRDBParser.parse_hjb_line,
             'HJC': JRDBParser.parse_hjb_line,
+            'OZ': JRDBParser.parse_oz_line,
         }
 
         parser_func = parser_map.get(data_type.upper())

--- a/src/automation/data/load_to_bq.py
+++ b/src/automation/data/load_to_bq.py
@@ -49,6 +49,7 @@ TABLE_MAPPING = {
     "KAA": "venue_info",
     "HJB": "payouts",
     "HJC": "payouts",
+    "OZ": "odds",
 }
 
 # テーブルごとの一意キー (MERGE文で使用)
@@ -60,10 +61,11 @@ TABLE_UNIQUE_KEYS = {
     "horse_extended": ["race_id", "horse_number"],
     "venue_info": ["venue_id"],
     "payouts": ["race_id", "bet_type", "rank"],
+    "odds": ["race_id", "horse_number", "odds_type"],
 }
 
 # パース後に行展開が必要なデータタイプ
-EXPAND_DATA_TYPES = {"HJB", "HJC"}
+EXPAND_DATA_TYPES = {"HJB", "HJC", "OZ"}
 
 # ロード履歴テーブル名
 LOAD_HISTORY_TABLE = "load_history"
@@ -123,6 +125,33 @@ def get_table_name(data_type: str) -> Optional[str]:
         テーブル名 or None
     """
     return TABLE_MAPPING.get(data_type.upper())
+
+
+def extract_file_date(filename: str) -> Optional[str]:
+    """
+    ファイル名から日付文字列 (YYYY-MM-DD) を抽出する
+
+    ファイル名の形式: <TYPE><YYMMDD>.csv (例: OZ241231.csv → 2024-12-31)
+
+    Args:
+        filename: ファイル名またはGCSパス
+
+    Returns:
+        ISO形式の日付文字列 (YYYY-MM-DD) or None
+    """
+    basename = os.path.basename(filename)
+    match = re.match(r"^[A-Z]{2,3}(\d{6})\.csv$", basename, re.IGNORECASE)
+    if not match:
+        return None
+    yymmdd = match.group(1)
+    try:
+        year = int(yymmdd[0:2])
+        month = int(yymmdd[2:4])
+        day = int(yymmdd[4:6])
+        year += 2000 if year <= 50 else 1900
+        return f"{year:04d}-{month:02d}-{day:02d}"
+    except ValueError:
+        return None
 
 
 class BigQueryLoader:
@@ -458,16 +487,25 @@ class BigQueryLoader:
                 logger.warning(f"ファイルからデータをパースできませんでした: {blob_name}")
                 return result
 
-            # HJB/HJCは1レース分のレコードを複数ペイアウト行に展開する
+            # HJB/HJC/OZ は1レコードを複数行に展開する
             if data_type.upper() in EXPAND_DATA_TYPES:
                 expanded: List[Dict] = []
-                for record in parsed_data:
-                    expanded.extend(JRDBParser.expand_hjb_to_payout_rows(record))
+                if data_type.upper() in {"HJB", "HJC"}:
+                    for record in parsed_data:
+                        expanded.extend(JRDBParser.expand_hjb_to_payout_rows(record))
+                    empty_label = "HJB"
+                elif data_type.upper() == "OZ":
+                    file_date = extract_file_date(blob_name)
+                    for record in parsed_data:
+                        expanded.extend(JRDBParser.expand_oz_to_odds_rows(record, file_date))
+                    empty_label = "OZ"
+                else:
+                    empty_label = data_type.upper()
                 parsed_data = expanded
                 if not parsed_data:
                     result.status = "skipped"
-                    result.error = "HJB展開結果が空"
-                    logger.warning(f"HJBデータの展開結果が空でした: {blob_name}")
+                    result.error = f"{empty_label}展開結果が空"
+                    logger.warning(f"{empty_label}データの展開結果が空でした: {blob_name}")
                     return result
 
             # BigQueryにロード

--- a/tests/test_jrdb_parser_oz.py
+++ b/tests/test_jrdb_parser_oz.py
@@ -1,0 +1,261 @@
+"""
+JRDBParser の OZ（基準オッズ）パーサーのユニットテスト
+
+parse_oz_line() および expand_oz_to_odds_rows() の動作を検証する。
+"""
+
+import pytest
+
+from src.automation.data.jrdb_parser import JRDBParser
+
+
+# ---------------------------------------------------------------------------
+# テスト用ヘルパー
+# ---------------------------------------------------------------------------
+
+def _build_oz_line(
+    race_key: str = "05261101",
+    registered_count: int = 8,
+    win_odds: list = None,
+    place_odds: list = None,
+) -> str:
+    """
+    テスト用 OZ 行文字列を構築するヘルパー。
+
+    フォーマット:
+        0-7   : レースキー (8文字)
+        8-9   : 登録頭数 (2文字)
+        10-99 : 単勝オッズ 18頭分 (5文字×18, 例: "046.6")
+        100-189: 複勝オッズ 18頭分 (5文字×18)
+        190+  : 馬連オッズ (今回はスペース埋め)
+
+    Args:
+        race_key: 8文字のレースキー
+        registered_count: 登録頭数 (1-18)
+        win_odds: 馬番1始まりの単勝オッズリスト (float or None)。
+                  未指定部分は "     " で埋める。
+        place_odds: 馬番1始まりの複勝オッズリスト (float or None)。
+    """
+    win_odds = win_odds or []
+    place_odds = place_odds or []
+
+    def _fmt_odds(odds_list: list) -> str:
+        """18頭分のオッズを5文字×18の文字列に変換"""
+        result = ""
+        for i in range(18):
+            val = odds_list[i] if i < len(odds_list) else None
+            if val is None or val <= 0:
+                result += "     "
+            else:
+                result += f"{val:05.1f}"
+        return result
+
+    body = (
+        race_key
+        + f"{registered_count:02d}"
+        + _fmt_odds(win_odds)
+        + _fmt_odds(place_odds)
+        + "0" * 765  # 馬連オッズ部分 (今回はスコープ外; 末尾スペースによる strip 問題を防ぐため 0 で埋める)
+    )
+    return body
+
+
+# ---------------------------------------------------------------------------
+# parse_oz_line()
+# ---------------------------------------------------------------------------
+
+class TestParseOzLine:
+    """parse_oz_line() の基本動作テスト"""
+
+    def test_returns_dict_with_correct_race_id(self):
+        """レースキーが正しく取得される"""
+        line = _build_oz_line(race_key="05261101")
+        result = JRDBParser.parse_oz_line(line)
+        assert result is not None
+        assert result["race_id"] == "05261101"
+
+    def test_registered_count_parsed(self):
+        """登録頭数が正しく取得される"""
+        line = _build_oz_line(registered_count=12)
+        result = JRDBParser.parse_oz_line(line)
+        assert result is not None
+        assert result["registered_count"] == 12
+
+    def test_win_odds_parsed_correctly(self):
+        """単勝オッズが正しくパースされる"""
+        odds = [46.6, 3.2, 15.0, None, None, None, None, None]
+        line = _build_oz_line(win_odds=odds)
+        result = JRDBParser.parse_oz_line(line)
+        assert result is not None
+        win_list = result["win_odds_list"]
+        assert len(win_list) == 18
+        assert win_list[0] == pytest.approx(46.6, rel=1e-3)
+        assert win_list[1] == pytest.approx(3.2, rel=1e-3)
+        assert win_list[2] == pytest.approx(15.0, rel=1e-3)
+
+    def test_place_odds_parsed_correctly(self):
+        """複勝オッズが正しくパースされる"""
+        odds = [8.5, 1.5, 4.0, None, None, None, None, None]
+        line = _build_oz_line(place_odds=odds)
+        result = JRDBParser.parse_oz_line(line)
+        assert result is not None
+        place_list = result["place_odds_list"]
+        assert len(place_list) == 18
+        assert place_list[0] == pytest.approx(8.5, rel=1e-3)
+        assert place_list[1] == pytest.approx(1.5, rel=1e-3)
+
+    def test_empty_odds_parsed_as_none(self):
+        """オッズが空白の馬番は None になる"""
+        line = _build_oz_line(win_odds=[10.0], place_odds=[2.0])
+        result = JRDBParser.parse_oz_line(line)
+        assert result is not None
+        # 馬番2以降は空白 → None
+        assert result["win_odds_list"][1] is None
+        assert result["place_odds_list"][1] is None
+
+    def test_returns_none_for_short_line(self):
+        """短すぎる行は None を返す"""
+        result = JRDBParser.parse_oz_line("05261101" + "08" + "046.6")
+        assert result is None
+
+    def test_returns_none_for_empty_race_key(self):
+        """レースキーが空白の行は None を返す"""
+        line = "        " + "08" + " " * 945
+        result = JRDBParser.parse_oz_line(line)
+        assert result is None
+
+    def test_created_at_present(self):
+        """created_at フィールドが含まれる"""
+        line = _build_oz_line()
+        result = JRDBParser.parse_oz_line(line)
+        assert result is not None
+        assert "created_at" in result
+
+
+# ---------------------------------------------------------------------------
+# expand_oz_to_odds_rows()
+# ---------------------------------------------------------------------------
+
+class TestExpandOzToOddsRows:
+    """expand_oz_to_odds_rows() の動作テスト"""
+
+    def _make_oz_record(self, race_id="05261101", win_odds=None, place_odds=None):
+        """テスト用 OZ レコードを作成するヘルパー"""
+        win_list = [None] * 18
+        place_list = [None] * 18
+        if win_odds:
+            for i, v in enumerate(win_odds):
+                if i < 18:
+                    win_list[i] = v
+        if place_odds:
+            for i, v in enumerate(place_odds):
+                if i < 18:
+                    place_list[i] = v
+        return {
+            "race_id": race_id,
+            "registered_count": 8,
+            "win_odds_list": win_list,
+            "place_odds_list": place_list,
+            "created_at": "2024-12-31T10:00:00",
+        }
+
+    def test_generates_correct_number_of_rows(self):
+        """有効なオッズ行のみ生成される"""
+        record = self._make_oz_record(
+            win_odds=[46.6, 3.2, 15.0],
+            place_odds=[8.5, 1.5],
+        )
+        rows = JRDBParser.expand_oz_to_odds_rows(record)
+        # win 3行 + place 2行 = 5行
+        assert len(rows) == 5
+
+    def test_horse_number_starts_at_1(self):
+        """horse_number は 1 始まり"""
+        record = self._make_oz_record(win_odds=[46.6])
+        rows = JRDBParser.expand_oz_to_odds_rows(record)
+        win_rows = [r for r in rows if r["odds_type"] == "win"]
+        assert win_rows[0]["horse_number"] == 1
+
+    def test_odds_type_set_correctly(self):
+        """odds_type が win / place で正しく設定される"""
+        record = self._make_oz_record(win_odds=[10.0], place_odds=[3.0])
+        rows = JRDBParser.expand_oz_to_odds_rows(record)
+        types = {r["odds_type"] for r in rows}
+        assert types == {"win", "place"}
+
+    def test_horse_id_is_none(self):
+        """horse_id は None (OZ ファイルに含まれないため)"""
+        record = self._make_oz_record(win_odds=[10.0])
+        rows = JRDBParser.expand_oz_to_odds_rows(record)
+        assert all(r["horse_id"] is None for r in rows)
+
+    def test_zero_odds_skipped(self):
+        """0以下のオッズはスキップされる"""
+        record = self._make_oz_record(win_odds=[0.0, 10.0])
+        rows = JRDBParser.expand_oz_to_odds_rows(record)
+        win_rows = [r for r in rows if r["odds_type"] == "win"]
+        assert len(win_rows) == 1
+        assert win_rows[0]["horse_number"] == 2
+
+    def test_none_odds_skipped(self):
+        """None オッズはスキップされる"""
+        record = self._make_oz_record(win_odds=[None, None])
+        rows = JRDBParser.expand_oz_to_odds_rows(record)
+        assert len(rows) == 0
+
+    def test_odds_timestamp_uses_file_date(self):
+        """file_date が渡された場合 odds_timestamp に反映される"""
+        record = self._make_oz_record(win_odds=[10.0])
+        rows = JRDBParser.expand_oz_to_odds_rows(record, file_date="2024-12-31")
+        assert rows[0]["odds_timestamp"] == "2024-12-31T19:00:00+00:00"
+
+    def test_odds_timestamp_fallback_to_created_at(self):
+        """file_date が None の場合 created_at にフォールバックする"""
+        record = self._make_oz_record(win_odds=[10.0])
+        rows = JRDBParser.expand_oz_to_odds_rows(record, file_date=None)
+        assert rows[0]["odds_timestamp"] == record["created_at"]
+
+    def test_odds_value_matches_input(self):
+        """odds_value が入力値と一致する"""
+        record = self._make_oz_record(win_odds=[46.6], place_odds=[8.5])
+        rows = JRDBParser.expand_oz_to_odds_rows(record)
+        win_row = next(r for r in rows if r["odds_type"] == "win")
+        place_row = next(r for r in rows if r["odds_type"] == "place")
+        assert win_row["odds_value"] == pytest.approx(46.6, rel=1e-3)
+        assert place_row["odds_value"] == pytest.approx(8.5, rel=1e-3)
+
+    def test_race_id_propagated(self):
+        """race_id が全行に伝播する"""
+        record = self._make_oz_record(race_id="09261205", win_odds=[5.0])
+        rows = JRDBParser.expand_oz_to_odds_rows(record)
+        assert all(r["race_id"] == "09261205" for r in rows)
+
+
+# ---------------------------------------------------------------------------
+# parse_file() での OZ 統合テスト
+# ---------------------------------------------------------------------------
+
+class TestParseFileOZ:
+    """parse_file() が OZ を正しく処理することを確認"""
+
+    def test_oz_recognized_by_parse_file(self):
+        """parse_file() が OZ データタイプを認識してパースする"""
+        line = _build_oz_line(
+            race_key="05261101",
+            registered_count=3,
+            win_odds=[5.0, 10.0, 20.0],
+            place_odds=[2.0, 3.0, 5.0],
+        )
+        results = JRDBParser.parse_file(line + "\n", "OZ")
+        assert len(results) == 1
+        assert results[0]["race_id"] == "05261101"
+
+    def test_oz_multiple_lines_parsed(self):
+        """複数行のOZファイルが全行パースされる"""
+        line1 = _build_oz_line(race_key="05261101", win_odds=[5.0])
+        line2 = _build_oz_line(race_key="05261102", win_odds=[8.0])
+        content = line1 + "\n" + line2
+        results = JRDBParser.parse_file(content, "OZ")
+        assert len(results) == 2
+        race_ids = {r["race_id"] for r in results}
+        assert race_ids == {"05261101", "05261102"}

--- a/tests/test_load_to_bq.py
+++ b/tests/test_load_to_bq.py
@@ -15,6 +15,7 @@ from src.automation.data.load_to_bq import (
     LoadResult,
     create_loader_from_env,
     extract_data_type,
+    extract_file_date,
     get_table_name,
 )
 
@@ -93,6 +94,9 @@ class TestGetTableName:
 
     def test_hjc_maps_to_payouts(self):
         assert get_table_name("HJC") == "payouts"
+
+    def test_oz_maps_to_odds(self):
+        assert get_table_name("OZ") == "odds"
 
     def test_unknown_data_type(self):
         """未知のデータタイプはNoneを返す"""
@@ -766,6 +770,28 @@ class TestLoadFileWithHistory:
         mock_history.assert_not_called()
 
 
+class TestExtractFileDate:
+    """extract_file_date 関数のテスト"""
+
+    def test_oz_filename_returns_correct_date(self):
+        """OZ ファイル名から日付が正しく抽出される (2000年以降)"""
+        assert extract_file_date("OZ241231.csv") == "2024-12-31"
+
+    def test_oz_filename_2016(self):
+        assert extract_file_date("OZ160101.csv") == "2016-01-01"
+
+    def test_oz_with_directory_path(self):
+        """GCS パスを含む場合も正しく抽出される"""
+        assert extract_file_date("OZ/OZ241231.csv") == "2024-12-31"
+
+    def test_baa_filename_returns_correct_date(self):
+        assert extract_file_date("BAA260104.csv") == "2026-01-04"
+
+    def test_invalid_filename_returns_none(self):
+        assert extract_file_date("invalid.csv") is None
+        assert extract_file_date("OZ12345.csv") is None
+
+
 class TestExpandDataTypes:
     """EXPAND_DATA_TYPESの確認とHJBロード展開処理のテスト"""
 
@@ -773,6 +799,10 @@ class TestExpandDataTypes:
         """EXPAND_DATA_TYPESにHJBとHJCが含まれる"""
         assert "HJB" in EXPAND_DATA_TYPES
         assert "HJC" in EXPAND_DATA_TYPES
+
+    def test_expand_data_types_contains_oz(self):
+        """EXPAND_DATA_TYPES に OZ が含まれる"""
+        assert "OZ" in EXPAND_DATA_TYPES
 
     def test_expand_data_types_does_not_contain_sec(self):
         """SECなど通常タイプはEXPAND_DATA_TYPESに含まれない"""

--- a/tests/test_run_backtest.py
+++ b/tests/test_run_backtest.py
@@ -38,12 +38,12 @@ def _make_predictions(n_horses: int = 4) -> pd.DataFrame:
 
 
 def _make_odds_df(n_horses: int = 4, odds_val: float = 2.5) -> pd.DataFrame:
-    """テスト用の複勝オッズ DataFrame を生成する"""
+    """テスト用の複勝オッズ DataFrame を生成する。
+    OZ ファイルには horse_id が含まれないため horse_number をキーとする。"""
     rows = []
     for i in range(1, n_horses + 1):
         rows.append({
             "race_id": "race_001",
-            "horse_id": f"horse_{i:03d}",
             "horse_number": i,
             "place_odds": odds_val,
         })


### PR DESCRIPTION
## Summary

- `jrdb_parser.py` に `parse_oz_line()` / `expand_oz_to_odds_rows()` を追加し、OZ ファイル（金/土配信の基準オッズ）を `raw.odds` スキーマに変換する処理を実装
- `load_to_bq.py` の `TABLE_MAPPING` / `TABLE_UNIQUE_KEYS` / `EXPAND_DATA_TYPES` に OZ を追加し、既存パイプライン経由でロード可能に
- `run_backtest.py` の `fetch_place_odds()` と merge キーを `horse_id` → `horse_number` に変更（OZ ファイルに horse_id が含まれないため）
- テスト 20 件新規追加（`test_jrdb_parser_oz.py`）、既存テストも更新

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `src/automation/data/jrdb_parser.py` | `parse_oz_line()` / `expand_oz_to_odds_rows()` / `parse_file()` 更新 |
| `src/automation/data/load_to_bq.py` | TABLE_MAPPING・UNIQUE_KEYS・EXPAND_DATA_TYPES 追加、`extract_file_date()` 追加 |
| `scripts/run_backtest.py` | `fetch_place_odds()` を `horse_number` ベースに変更 |
| `tests/test_jrdb_parser_oz.py` | 新規 20 件 |
| `tests/test_load_to_bq.py` | OZ マッピング・extract_file_date テスト追加 |
| `tests/test_run_backtest.py` | `_make_odds_df` から horse_id 削除 |

## Test plan

- [x] `python3 -m pytest tests/test_jrdb_parser_oz.py` — 20 passed
- [x] `python3 -m pytest tests/test_load_to_bq.py tests/test_run_backtest.py tests/test_jrdb_parser_hjb.py` — 102 passed
- [x] 全体 122 passed, 0 failed

## 残作業（このPRのスコープ外）

- GCS にある 2016年以降の OZ ファイルを一括ロードする（本番データ投入）
  → 既存の `full_load_pipeline.py` 経由で `data_types=["OZ"]` 指定で実行可能

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)