### PR TITLE
fix: raw.odds の horse_id を NULLABLE に変更（OZファイル対応）

### DIFF
--- a/config/bq_schema_odds.json
+++ b/config/bq_schema_odds.json
@@ -8,8 +8,8 @@
   {
     "name": "horse_id",
     "type": "STRING",
-    "mode": "REQUIRED",
-    "description": "馬ID"
+    "mode": "NULLABLE",
+    "description": "馬ID (OZファイル由来の場合は NULL)"
   },
   {
     "name": "odds_type",

--- a/scripts/alter_odds_horse_id_nullable.py
+++ b/scripts/alter_odds_horse_id_nullable.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""
+raw.odds テーブルの horse_id カラムを REQUIRED → NULLABLE に変更する
+
+OZ（基準オッズ）ファイルには horse_id が含まれないため、
+BigQuery テーブルのカラム制約を緩和する必要がある。
+
+Usage:
+    python3 scripts/alter_odds_horse_id_nullable.py
+    python3 scripts/alter_odds_horse_id_nullable.py --project-id YOUR_PROJECT_ID
+"""
+
+import argparse
+import os
+import sys
+
+from dotenv import load_dotenv
+from google.cloud import bigquery
+
+
+def main() -> int:
+    load_dotenv()
+
+    parser = argparse.ArgumentParser(
+        description="raw.odds の horse_id を NULLABLE に変更する"
+    )
+    parser.add_argument(
+        "--project-id",
+        default=os.environ.get("GCP_PROJECT_ID"),
+        help="GCP プロジェクト ID",
+    )
+    parser.add_argument(
+        "--dataset",
+        default="raw",
+        help="データセット名 (デフォルト: raw)",
+    )
+    args = parser.parse_args()
+
+    if not args.project_id:
+        print("エラー: GCP_PROJECT_ID が設定されていません", file=sys.stderr)
+        return 1
+
+    client = bigquery.Client(project=args.project_id)
+    table_ref = f"{args.project_id}.{args.dataset}.odds"
+
+    # BigQuery は REQUIRED → NULLABLE の緩和を ALTER COLUMN ... DROP NOT NULL でサポート
+    query = f"ALTER TABLE `{table_ref}` ALTER COLUMN horse_id DROP NOT NULL"
+
+    print(f"実行: {query}")
+    job = client.query(query)
+    job.result()
+    print(f"✓ {table_ref} の horse_id を NULLABLE に変更しました")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- `config/bq_schema_odds.json` の `horse_id.mode` を `REQUIRED` → `NULLABLE` に変更
- `scripts/alter_odds_horse_id_nullable.py` を追加（既存 BigQuery テーブルの制約を緩和するスクリプト）

## 背景

OZファイル（基準オッズ）には `horse_id` が含まれず `NULL` が挿入されるが、`raw.odds.horse_id` が `REQUIRED` だったため `Field value of horse_id cannot be empty` エラーが発生していた。

## 変更内容

| ファイル | 変更内容 |
|----------|----------|
| `config/bq_schema_odds.json` | `horse_id.mode`: `REQUIRED` → `NULLABLE` |
| `scripts/alter_odds_horse_id_nullable.py` | 既存 BQ テーブルへ `ALTER COLUMN horse_id DROP NOT NULL` を実行するスクリプト |

## テスト計画

- [ ] 既存テスト (`pytest tests/`) がすべてパスすること
- [ ] `python3 scripts/alter_odds_horse_id_nullable.py` を実行して BQ テーブルの制約を緩和できること
- [ ] OZ ファイルのロードが成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)