### PR TITLE
fix: raw.odds horse_id NULLABLE 対応 & バックテストログ改善

### DIFF
--- a/scripts/run_backtest.py
+++ b/scripts/run_backtest.py
@@ -247,7 +247,7 @@ def generate_predictions(
         ["race_id", "race_date", "horse_id", "horse_number"]
     ].copy()
 
-    for col in ["venue_code", "race_number"]:
+    for col in ["venue_code", "race_number", "horse_name"]:
         if col in features_df.columns:
             result_df[col] = features_df[col]
 
@@ -410,6 +410,7 @@ def run_backtest_pipeline(
     expected_return_threshold: float = 1.2,
     max_bet_ratio: float = 0.05,
     odds_column: str = "place_odds",
+    show_race_summary: bool = True,
     output_csv: str | None = None,
     save_bq: bool = False,
     output_chart: str | None = None,
@@ -429,6 +430,7 @@ def run_backtest_pipeline(
         expected_return_threshold: 期待回収率フィルタ閾値
         max_bet_ratio: 1レースあたり最大賭け金比率
         odds_column: オッズカラム名
+        show_race_summary: True のときレース単位のサマリーログを出力する
         output_csv: CSV 出力パス (None でスキップ)
         save_bq: BigQuery 保存フラグ
         output_chart: グラフ出力パス (None でスキップ)
@@ -502,6 +504,7 @@ def run_backtest_pipeline(
         expected_return_threshold=expected_return_threshold,
         max_bet_ratio=max_bet_ratio,
         odds_column=odds_column,
+        show_race_summary=show_race_summary,
     )
     history_df = simulator.run(
         predictions_df=predictions_df,
@@ -616,6 +619,11 @@ def main() -> int:
         help="資金推移グラフの PNG 出力パス",
     )
     parser.add_argument(
+        "--no-race-summary",
+        action="store_true",
+        help="レース単位のサマリーログを非表示にする",
+    )
+    parser.add_argument(
         "--config",
         default=None,
         help="設定ファイルパス",
@@ -667,6 +675,7 @@ def main() -> int:
         expected_return_threshold=args.expected_return_threshold,
         max_bet_ratio=args.max_bet_ratio,
         odds_column=args.odds_column,
+        show_race_summary=not args.no_race_summary,
         output_csv=args.output_csv,
         save_bq=args.save_to_bq,
         output_chart=args.output_chart,

--- a/src/backtest/simulator.py
+++ b/src/backtest/simulator.py
@@ -22,6 +22,19 @@ import pandas as pd
 
 logger = logging.getLogger(__name__)
 
+_VENUE_NAME_MAP: dict[str, str] = {
+    "01": "札幌",
+    "02": "函館",
+    "03": "福島",
+    "04": "新潟",
+    "05": "東京",
+    "06": "中山",
+    "07": "中京",
+    "08": "京都",
+    "09": "阪神",
+    "10": "小倉",
+}
+
 
 def kelly_criterion(win_prob: float, odds: float) -> float:
     """
@@ -65,6 +78,7 @@ class BetRecord:
     race_date: object
     horse_id: str
     horse_number: int
+    horse_name: Optional[str]
     win_place_prob: float
     odds: float
     expected_return: float
@@ -93,6 +107,7 @@ class BacktestSimulator:
         max_bet_ratio: float = 0.05,
         min_bet_amount: float = 100.0,
         odds_column: str = "odds_yesterday",
+        show_race_summary: bool = True,
     ):
         """
         初期化
@@ -105,6 +120,7 @@ class BacktestSimulator:
             max_bet_ratio: 1レースあたりの最大賭け金比率 (例: 0.05 = 5%)
             min_bet_amount: 最低賭け金 (円)
             odds_column: 意思決定に使用するオッズカラム名
+            show_race_summary: True のときレース単位のサマリーログを出力する
         """
         self.initial_capital = initial_capital
         self.kelly_fraction = kelly_fraction
@@ -112,6 +128,7 @@ class BacktestSimulator:
         self.max_bet_ratio = max_bet_ratio
         self.min_bet_amount = min_bet_amount
         self.odds_column = odds_column
+        self.show_race_summary = show_race_summary
 
     def run(
         self,
@@ -161,8 +178,39 @@ class BacktestSimulator:
         odds_series = pd.to_numeric(df[self.odds_column], errors="coerce")
         df = df.assign(_odds=odds_series)
 
+        has_venue_code = "venue_code" in df.columns
+        has_race_number = "race_number" in df.columns
+        has_horse_name = "horse_name" in df.columns
+
         for race_id, race_df in df.groupby("race_id", sort=False):
             race_date = race_df["race_date"].iloc[0]
+
+            # 競馬場名・レース番号ラベルを構築
+            if has_venue_code:
+                venue_code = str(race_df["venue_code"].iloc[0])
+                venue_name = _VENUE_NAME_MAP.get(venue_code, venue_code)
+            else:
+                venue_name = "不明"
+            if has_race_number:
+                race_num_str = f"{int(race_df['race_number'].iloc[0])}R"
+            else:
+                race_num_str = "?R"
+            race_label = f"{race_date} {venue_name} {race_num_str}"
+
+            # レース着順の完全性チェック:
+            # 有効な着順（1以上の整数）を持つ馬が1頭もいない場合は
+            # 着順データが集計できていないレースとしてスキップする
+            if "finish_position" in race_df.columns:
+                valid_finish = pd.to_numeric(
+                    race_df["finish_position"], errors="coerce"
+                )
+                if (valid_finish >= 1).sum() == 0:
+                    logger.info(
+                        f"[スキップ] {race_label}"
+                        " | 有効な着順データがないためシミュレーション対象外"
+                    )
+                    continue
+
             race_records: list[BetRecord] = []
 
             for idx, row in race_df.iterrows():
@@ -194,6 +242,9 @@ class BacktestSimulator:
                 if finish_raw is None or pd.isna(finish_raw):
                     finish_position = None
                     is_hit = False
+                elif int(finish_raw) == 0:
+                    # 着順0 = 出走取消・競走中止などの無効データ → 賭け対象外
+                    continue
                 else:
                     finish_position = int(finish_raw)
                     is_hit = (1 <= finish_position <= 3)
@@ -201,6 +252,11 @@ class BacktestSimulator:
                 # 払戻金の計算
                 horse_number = int(row["horse_number"])
                 payout_per_100 = payout_map.get((str(race_id), horse_number), None)
+                horse_name: Optional[str] = (
+                    str(row["horse_name"])
+                    if has_horse_name and pd.notna(row.get("horse_name"))
+                    else None
+                )
 
                 if is_hit:
                     if payout_per_100 is not None:
@@ -219,6 +275,7 @@ class BacktestSimulator:
                     race_date=race_date,
                     horse_id=str(row["horse_id"]),
                     horse_number=horse_number,
+                    horse_name=horse_name,
                     win_place_prob=win_place_prob,
                     odds=odds,
                     expected_return=expected_return,
@@ -237,21 +294,22 @@ class BacktestSimulator:
                 # 馬単位のログ
                 hit_mark = "◎" if is_hit else "×"
                 finish_str = f"{finish_position}着" if finish_position is not None else "不明"
+                horse_name_str = f" {horse_name}" if horse_name else ""
                 logger.info(
-                    f"  {hit_mark} {race_id} 馬番{horse_number:2d}"
+                    f"  {hit_mark} {race_label} 馬番{horse_number:2d}{horse_name_str}"
                     f" | 複勝率:{win_place_prob:.3f} オッズ:{odds:.1f}"
                     f" | 賭け:{bet_amount:,.0f}円 → 払戻:{return_amount:,.0f}円"
                     f" | 損益:{profit:+,.0f}円 [{finish_str}]"
                 )
 
             # レース単位のサマリーログ
-            if race_records:
+            if race_records and self.show_race_summary:
                 race_bets = sum(r.bet_amount for r in race_records)
                 race_returns = sum(r.return_amount for r in race_records)
                 race_profit = race_returns - race_bets
                 n_hits = sum(1 for r in race_records if r.is_hit)
                 logger.info(
-                    f"[レースサマリー] {race_id} ({race_date})"
+                    f"[レースサマリー] {race_label}"
                     f" | {len(race_records)}頭購入 {n_hits}頭的中"
                     f" | 賭け計:{race_bets:,.0f}円 払戻計:{race_returns:,.0f}円"
                     f" | レース損益:{race_profit:+,.0f}円 残高:{capital:,.0f}円"


### PR DESCRIPTION
## Summary

- **raw.odds スキーマ修正**: OZファイル由来のオッズは `horse_id` を持たないため、`horse_id` カラムを `REQUIRED → NULLABLE` に変更
- **バックテストログ改善**: ログ出力にレース実施日・競馬場名・レース番号・馬名を表示（レースIDは非表示）
- **着順不正データの除外**: 着順0（出走取消・競走中止）の馬、および有効な着順データが存在しないレースをシミュレーション対象外に
- **レースサマリー表示切替**: `BacktestSimulator` に `show_race_summary` オプション、CLI に `--no-race-summary` フラグを追加

## Changes

### `config/bq_schema_odds.json`
- `horse_id` の `mode` を `REQUIRED` → `NULLABLE` に変更

### `scripts/alter_odds_horse_id_nullable.py` (新規)
- 既存の BigQuery テーブルに対して `ALTER COLUMN horse_id DROP NOT NULL` を実行するスクリプト

### `src/backtest/simulator.py`
- `_VENUE_NAME_MAP` 定数を追加（競馬場コード → 競馬場名）
- `BetRecord` に `horse_name` フィールドを追加
- `BacktestSimulator.__init__` に `show_race_summary: bool = True` を追加
- レースループ先頭で競馬場名・レース番号ラベルを生成
- 有効着順（`>= 1`）が0頭のレースをスキップ
- 着順0の馬を賭け対象外に
- 馬ログ・レースサマリーのフォーマットを変更

### `scripts/run_backtest.py`
- `generate_predictions` で `horse_name` を `predictions_df` に含めるよう変更
- `run_backtest_pipeline` に `show_race_summary` 引数を追加
- CLI に `--no-race-summary` フラグを追加

## Test plan

- [ ] `python scripts/run_backtest.py` でログに競馬場名・馬名が表示されることを確認
- [ ] `--no-race-summary` オプションでレースサマリーが非表示になることを確認
- [ ] 着順0の馬・着順データなしのレースがスキップされることを確認
- [ ] 既存テストが通ることを確認（`pytest tests/test_backtest_simulator.py`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)