### PR TITLE
feat: 日次予測パイプラインを実装 (Issue #20)

### DIFF
--- a/src/automation/api/app.py
+++ b/src/automation/api/app.py
@@ -5,12 +5,15 @@ Cloud Run用HTTPエンドポイントを提供する。
 - 日次パイプライン: Cloud Schedulerからトリガー
 - 全件ロード: 手動トリガー（初回セットアップ/データ補完）
 - 特徴量生成: 手動トリガーまたはパイプライン統合
+- 予測実行: 翌日レース予測 + BigQuery保存
 
 Issue #57: 日次パイプラインの実装
 Issue #58: 過去分全件ロード処理の実装
 Issue #59: 特徴量生成パイプラインのCloud Run統合
+Issue #20: 日次予測パイプラインの実装
 """
 
+import datetime
 import logging
 import os
 import uuid
@@ -150,6 +153,60 @@ class FeatureGenerateResponse(BaseModel):
     deleted_rows: int = Field(default=0, description="削除した行数")
     inserted_rows: int = Field(default=0, description="挿入した行数")
     elapsed_time: float = Field(default=0.0, description="処理時間（秒）")
+    error_message: Optional[str] = Field(default=None, description="エラーメッセージ")
+
+
+class PredictDailyRequest(BaseModel):
+    """翌日予測リクエスト"""
+
+    model_path: str = Field(
+        description="モデルファイルパス（ローカル）",
+        json_schema_extra={"example": "/models/lgbm_ranker.txt"},
+    )
+    save_to_bq: bool = Field(
+        default=True,
+        description="予測結果をBigQueryに保存するか",
+    )
+
+
+class PredictOnDemandRequest(BaseModel):
+    """任意日付予測リクエスト"""
+
+    model_path: str = Field(
+        description="モデルファイルパス（ローカル）",
+        json_schema_extra={"example": "/models/lgbm_ranker.txt"},
+    )
+    target_dates: list[str] = Field(
+        description="予測対象日（YYYY-MM-DD形式、複数指定可）",
+        json_schema_extra={"example": ["2026-02-14", "2026-02-15"]},
+    )
+    save_to_bq: bool = Field(
+        default=True,
+        description="予測結果をBigQueryに保存するか",
+    )
+
+    @field_validator("target_dates")
+    @classmethod
+    def validate_target_dates(cls, v: list[str]) -> list[str]:
+        for d in v:
+            try:
+                datetime.date.fromisoformat(d)
+            except ValueError:
+                raise ValueError(
+                    f"日付はYYYY-MM-DD形式の有効な日付で指定してください: '{d}'"
+                )
+        return v
+
+
+class PredictResponse(BaseModel):
+    """予測レスポンス"""
+
+    status: str = Field(description="処理ステータス (success/failed)")
+    target_dates: list[str] = Field(description="予測対象日のリスト")
+    num_races: int = Field(default=0, description="予測したレース数")
+    num_horses: int = Field(default=0, description="予測した頭数")
+    saved_to_bq: bool = Field(default=False, description="BigQueryに保存されたか")
+    saved_rows: int = Field(default=0, description="BigQueryに保存した行数")
     error_message: Optional[str] = Field(default=None, description="エラーメッセージ")
 
 
@@ -473,6 +530,156 @@ async def generate_features_async(
         "end_date": request.end_date,
         "message": "特徴量生成をバックグラウンドで実行中",
     }
+
+
+def _run_predict(
+    model_path: str,
+    target_dates: list[datetime.date],
+    save_to_bq: bool,
+    project_id: str,
+) -> dict:
+    """
+    予測パイプラインを実行して結果を返す内部関数
+
+    Args:
+        model_path: モデルファイルパス
+        target_dates: 予測対象日のリスト
+        save_to_bq: BigQueryに保存するか
+        project_id: GCPプロジェクトID
+
+    Returns:
+        予測結果の辞書（num_races, num_horses, saved_to_bq, saved_rows）
+    """
+    from src.models.predict import predict_pipeline, save_predictions_to_bq
+    from src.models.train import load_config
+
+    config = load_config()
+    result_df = predict_pipeline(
+        project_id=project_id,
+        execution_date=datetime.date.today(),
+        config=config,
+        model_path=model_path,
+        target_dates=target_dates,
+    )
+
+    num_races = int(result_df["race_id"].nunique()) if len(result_df) > 0 else 0
+    num_horses = len(result_df)
+    saved_to_bq = False
+    saved_rows = 0
+
+    if save_to_bq and len(result_df) > 0:
+        saved_rows = save_predictions_to_bq(
+            result_df=result_df,
+            project_id=project_id,
+        )
+        saved_to_bq = True
+
+    return {
+        "num_races": num_races,
+        "num_horses": num_horses,
+        "saved_to_bq": saved_to_bq,
+        "saved_rows": saved_rows,
+    }
+
+
+@app.post("/api/v1/predict/daily", response_model=PredictResponse)
+async def predict_daily(request: PredictDailyRequest):
+    """
+    翌日レースの予測を実行してBigQueryに保存する
+
+    実行日の翌日（土日）のレースを予測対象とする。
+    Cloud Schedulerから前日PM 9:00に呼び出されることを想定。
+
+    Args:
+        request: リクエストボディ
+
+    Returns:
+        予測結果
+    """
+    logger.info(f"日次予測リクエスト受信: model_path={request.model_path}")
+
+    project_id = os.environ.get("GCP_PROJECT_ID")
+    if not project_id:
+        raise HTTPException(status_code=500, detail="GCP_PROJECT_IDが未設定です")
+
+    try:
+        from src.models.train import compute_week_boundaries
+
+        # 翌日を基準に今週の土日を算出
+        tomorrow = datetime.date.today() + datetime.timedelta(days=1)
+        saturday, sunday = compute_week_boundaries(tomorrow)
+        target_dates = [saturday, sunday]
+
+        result = _run_predict(
+            model_path=request.model_path,
+            target_dates=target_dates,
+            save_to_bq=request.save_to_bq,
+            project_id=project_id,
+        )
+
+        logger.info(
+            f"日次予測完了: {result['num_races']}レース, {result['num_horses']}頭, "
+            f"saved={result['saved_to_bq']}"
+        )
+        return PredictResponse(
+            status="success",
+            target_dates=[d.isoformat() for d in target_dates],
+            **result,
+        )
+
+    except Exception as e:
+        logger.error(f"日次予測エラー: {e}")
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@app.post("/api/v1/predict/on-demand", response_model=PredictResponse)
+async def predict_on_demand(request: PredictOnDemandRequest):
+    """
+    任意日付を指定してレース予測を実行し、BigQueryに保存する
+
+    指定した日付のレースを予測対象とする。
+    手動実行やバックテスト用途での利用を想定。
+
+    Args:
+        request: リクエストボディ
+
+    Returns:
+        予測結果
+    """
+    logger.info(
+        f"オンデマンド予測リクエスト受信: "
+        f"target_dates={request.target_dates}, model_path={request.model_path}"
+    )
+
+    project_id = os.environ.get("GCP_PROJECT_ID")
+    if not project_id:
+        raise HTTPException(status_code=500, detail="GCP_PROJECT_IDが未設定です")
+
+    try:
+        target_dates = [
+            datetime.date.fromisoformat(d) for d in request.target_dates
+        ]
+
+        result = _run_predict(
+            model_path=request.model_path,
+            target_dates=target_dates,
+            save_to_bq=request.save_to_bq,
+            project_id=project_id,
+        )
+
+        logger.info(
+            f"オンデマンド予測完了: {result['num_races']}レース, {result['num_horses']}頭, "
+            f"saved={result['saved_to_bq']}"
+        )
+        return PredictResponse(
+            status="success",
+            target_dates=request.target_dates,
+            **result,
+        )
+
+    except Exception as e:
+        logger.error(f"オンデマンド予測エラー: {e}")
+        raise HTTPException(status_code=500, detail=str(e)) from e
 
 
 def create_app() -> FastAPI:

--- a/src/models/predict.py
+++ b/src/models/predict.py
@@ -7,6 +7,7 @@ LightGBM LambdaRank 推論スクリプト
 Usage:
     python src/models/predict.py --project-id <PROJECT_ID> --model-path <MODEL_PATH>
     python src/models/predict.py --project-id <PROJECT_ID> --model-path <MODEL_PATH> --execution-date 2026-02-15
+    python src/models/predict.py --project-id <PROJECT_ID> --model-path <MODEL_PATH> --save-to-bq
 """
 
 from __future__ import annotations
@@ -294,6 +295,126 @@ def predict_pipeline(
     return result_df
 
 
+def save_predictions_to_bq(
+    result_df: pd.DataFrame,
+    project_id: str,
+    dataset: str = "predictions",
+    table: str = "race_predictions",
+) -> int:
+    """
+    予測結果をBigQueryのpredictions.race_predictionsテーブルにUPSERTする
+
+    保存するカラム: race_id, race_date, horse_id, horse_number, horse_name,
+                   venue_code, race_number, win_place_prob, pred_score,
+                   place_odds, created_at
+
+    一意キー: (race_id, horse_id) の組み合わせでUPSERT（MERGE）を実行する。
+
+    Args:
+        result_df: 予測結果のDataFrame（predict_pipelineの出力）
+        project_id: GCPプロジェクトID
+        dataset: 保存先データセット名（デフォルト: "predictions"）
+        table: 保存先テーブル名（デフォルト: "race_predictions"）
+
+    Returns:
+        保存した行数
+
+    Raises:
+        ValueError: 必須カラムが不足している場合
+    """
+    if len(result_df) == 0:
+        logger.warning("保存するデータがありません")
+        return 0
+
+    required_columns = ["race_id", "horse_id", "win_place_prob", "pred_score"]
+    missing = [c for c in required_columns if c not in result_df.columns]
+    if missing:
+        raise ValueError(f"必須カラムが不足しています: {missing}")
+
+    # 保存対象カラムを選択（存在するもののみ）
+    save_columns = [
+        "race_id", "race_date", "horse_id", "horse_number", "horse_name",
+        "venue_code", "race_number", "win_place_prob", "pred_score",
+    ]
+    # place_oddsカラムがあれば含める
+    for col in ["place_odds", "odds_yesterday", "odds_today"]:
+        if col in result_df.columns:
+            save_columns.append(col)
+            break
+
+    available_columns = [c for c in save_columns if c in result_df.columns]
+    save_df = result_df[available_columns].copy()
+
+    # created_atを追加
+    save_df["created_at"] = pd.Timestamp.now(tz="UTC")
+
+    # 型の整合
+    if "horse_number" in save_df.columns:
+        save_df["horse_number"] = save_df["horse_number"].astype("Int64")
+    if "race_number" in save_df.columns:
+        save_df["race_number"] = save_df["race_number"].astype("Int64")
+
+    client = bigquery.Client(project=project_id)
+    table_ref = f"{project_id}.{dataset}.{table}"
+    temp_table_ref = (
+        f"{project_id}.{dataset}._temp_{table}_"
+        f"{pd.Timestamp.now(tz='UTC').strftime('%Y%m%d%H%M%S')}"
+    )
+
+    logger.info(f"BigQuery保存開始: {table_ref} ({len(save_df)}行)")
+
+    try:
+        # 一時テーブルを作成してデータをロード（スキーマはautodetect）
+        client.create_table(bigquery.Table(temp_table_ref))
+        logger.debug(f"一時テーブルを作成しました: {temp_table_ref}")
+
+        try:
+            job_config = bigquery.LoadJobConfig(
+                write_disposition="WRITE_APPEND",
+                autodetect=True,
+            )
+            job = client.load_table_from_dataframe(save_df, temp_table_ref, job_config=job_config)
+            job.result()
+            logger.debug(f"一時テーブルに {len(save_df)} 行をロードしました")
+
+            # MERGE文を構築（一意キー: race_id + horse_id）
+            unique_keys = ["race_id", "horse_id"]
+            columns = list(save_df.columns)
+            join_conditions = " AND ".join(
+                [f"T.{key} = S.{key}" for key in unique_keys]
+            )
+            update_columns = [col for col in columns if col not in unique_keys]
+            update_set = ", ".join([f"T.{col} = S.{col}" for col in update_columns])
+            insert_columns = ", ".join(columns)
+            insert_values = ", ".join([f"S.{col}" for col in columns])
+
+            merge_query = f"""
+            MERGE `{table_ref}` T
+            USING `{temp_table_ref}` S
+            ON {join_conditions}
+            WHEN MATCHED THEN
+                UPDATE SET {update_set}
+            WHEN NOT MATCHED THEN
+                INSERT ({insert_columns})
+                VALUES ({insert_values})
+            """
+
+            logger.debug("MERGEクエリを実行中...")
+            query_job = client.query(merge_query)
+            query_job.result()
+            logger.info(f"BigQuery保存完了: {len(save_df)}行を {table_ref} にUPSERTしました")
+
+        finally:
+            client.delete_table(temp_table_ref, not_found_ok=True)
+            logger.debug(f"一時テーブルを削除しました: {temp_table_ref}")
+
+        return len(save_df)
+
+    except Exception as e:
+        logger.error(f"BigQuery保存エラー: {e}")
+        raise
+
+
 def format_predictions(result_df: pd.DataFrame) -> str:
     """予測結果を見やすい文字列に整形する"""
     if len(result_df) == 0:
@@ -378,6 +499,12 @@ def main():
         help="結果をCSV出力するパス",
     )
     parser.add_argument("--verbose", "-v", action="store_true", help="詳細ログ")
+    parser.add_argument(
+        "--save-to-bq",
+        action="store_true",
+        default=False,
+        help="予測結果をBigQuery（predictions.race_predictions）に保存する",
+    )
 
     args = parser.parse_args()
 
@@ -419,6 +546,14 @@ def main():
     if args.output_csv and len(result_df) > 0:
         result_df.to_csv(args.output_csv, index=False)
         print(f"\n結果をCSVに保存しました: {args.output_csv}")
+
+    # BigQuery保存
+    if args.save_to_bq and len(result_df) > 0:
+        saved_rows = save_predictions_to_bq(
+            result_df=result_df,
+            project_id=args.project_id,
+        )
+        print(f"\n{saved_rows}行をBigQuery（predictions.race_predictions）に保存しました")
 
     # サマリー
     if len(result_df) > 0:

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -14,6 +14,7 @@ from src.models.predict import (
     format_predictions,
     fetch_race_results,
     predict_pipeline,
+    save_predictions_to_bq,
 )
 
 
@@ -319,3 +320,109 @@ class TestFormatPredictions:
         horse_lines = [l for l in result.split("\n") if "テスト馬" in l]
         assert len(horse_lines) == 1
         assert horse_lines[0].strip().endswith("-")
+
+
+class TestSavePredictionsToBQ:
+    """save_predictions_to_bqのテスト"""
+
+    @pytest.fixture
+    def sample_result_df(self):
+        """予測結果のサンプルDataFrame"""
+        return pd.DataFrame({
+            "race_id": ["race_20260214_01", "race_20260214_01", "race_20260214_01"],
+            "race_date": [datetime.date(2026, 2, 14)] * 3,
+            "horse_id": ["h1", "h2", "h3"],
+            "horse_number": [1, 2, 3],
+            "horse_name": ["テスト馬1", "テスト馬2", "テスト馬3"],
+            "venue_code": ["05", "05", "05"],
+            "race_number": [1, 1, 1],
+            "win_place_prob": [0.7, 0.5, 0.3],
+            "pred_score": [0.8, 0.5, 0.2],
+            "pred_rank": [1, 2, 3],
+        })
+
+    @pytest.fixture
+    def mock_bq_client(self):
+        """BigQueryクライアントのモック"""
+        mock_job = type("Job", (), {"result": lambda self: None})()
+        mock_query_job = type("QueryJob", (), {"result": lambda self: None})()
+
+        with patch("src.models.predict.bigquery.Client") as mock_client_cls:
+            with patch("src.models.predict.bigquery.Table") as mock_table_cls:
+                with patch("src.models.predict.bigquery.LoadJobConfig"):
+                    mock_client = mock_client_cls.return_value
+                    mock_client.create_table.return_value = mock_table_cls.return_value
+                    mock_client.load_table_from_dataframe.return_value = mock_job
+                    mock_client.query.return_value = mock_query_job
+                    mock_client.delete_table.return_value = None
+                    yield mock_client
+
+    def test_save_predictions_success(self, sample_result_df, mock_bq_client):
+        """正常にBigQuery保存が呼び出されること"""
+        saved_rows = save_predictions_to_bq(
+            result_df=sample_result_df,
+            project_id="test-project",
+        )
+
+        assert saved_rows == len(sample_result_df)
+        mock_bq_client.create_table.assert_called_once()
+        mock_bq_client.load_table_from_dataframe.assert_called_once()
+        mock_bq_client.query.assert_called_once()
+        # MERGE文が正しいキーを含んでいること
+        merge_query = mock_bq_client.query.call_args[0][0]
+        assert "race_id" in merge_query
+        assert "horse_id" in merge_query
+        assert "MERGE" in merge_query
+
+    def test_save_predictions_empty_df(self):
+        """空DataFrameは0行を返すこと（BigQuery呼び出しなし）"""
+        with patch("src.models.predict.bigquery.Client") as mock_client_cls:
+            saved_rows = save_predictions_to_bq(
+                result_df=pd.DataFrame(),
+                project_id="test-project",
+            )
+        assert saved_rows == 0
+        mock_client_cls.assert_not_called()
+
+    def test_save_predictions_missing_required_columns(self):
+        """必須カラムが不足している場合はValueErrorが発生すること"""
+        df = pd.DataFrame({"race_id": ["r1"], "horse_id": ["h1"]})
+        # win_place_prob と pred_score が欠けている
+        with pytest.raises(ValueError, match="必須カラムが不足しています"):
+            save_predictions_to_bq(result_df=df, project_id="test-project")
+
+    def test_save_predictions_with_place_odds(self, sample_result_df, mock_bq_client):
+        """place_oddsカラムがある場合も保存DataFrame内にplace_oddsが含まれること"""
+        df_with_odds = sample_result_df.copy()
+        df_with_odds["place_odds"] = [3.2, 5.1, 8.4]
+
+        saved_rows = save_predictions_to_bq(
+            result_df=df_with_odds,
+            project_id="test-project",
+        )
+
+        assert saved_rows == len(df_with_odds)
+        # load_table_from_dataframeに渡されたDataFrameにplace_oddsが含まれること
+        call_args = mock_bq_client.load_table_from_dataframe.call_args
+        saved_df = call_args[0][0]
+        assert "place_odds" in saved_df.columns
+
+    def test_save_predictions_temp_table_cleanup_on_error(self, sample_result_df):
+        """エラー発生時でも一時テーブルが削除されること"""
+        with patch("src.models.predict.bigquery.Client") as mock_client_cls:
+            with patch("src.models.predict.bigquery.Table"):
+                with patch("src.models.predict.bigquery.LoadJobConfig"):
+                    mock_client = mock_client_cls.return_value
+                    mock_client.create_table.return_value = mock_client_cls.return_value
+                    # load_table_from_dataframe でエラーを発生させる
+                    mock_client.load_table_from_dataframe.side_effect = Exception("BQ Error")
+                    mock_client.delete_table.return_value = None
+
+                    with pytest.raises(Exception, match="BQ Error"):
+                        save_predictions_to_bq(
+                            result_df=sample_result_df,
+                            project_id="test-project",
+                        )
+
+        # delete_tableが呼ばれたことを確認（finallyブロック）
+        mock_client.delete_table.assert_called_once()


### PR DESCRIPTION
## Summary
- `predict.py` に `save_predictions_to_bq()` 関数を追加（`predictions.race_predictions` テーブルへのUPSERT）
- `predict.py` に `--save-to-bq` CLIフラグを追加
- `app.py` に予測エンドポイント2件を追加（`POST /api/v1/predict/daily`, `POST /api/v1/predict/on-demand`）
- `tests/test_predict.py` に `save_predictions_to_bq` のテスト5件を追加

## 変更詳細

### predict.py
- `save_predictions_to_bq(result_df, project_id, dataset, table)` を実装
  - 保存カラム: race_id, race_date, horse_id, horse_number, horse_name, venue_code, race_number, win_place_prob, pred_score, place_odds（存在する場合）, created_at
  - 一意キー `(race_id, horse_id)` でMERGE（UPSERT）
  - 一時テーブル経由でのバルクロード → MERGE という安全なパターン
- `main()` に `--save-to-bq` フラグを追加

### app.py
- `POST /api/v1/predict/daily`: 翌日（今週土日）のレースを予測 + BQ保存
- `POST /api/v1/predict/on-demand`: 任意の日付を指定して予測 + BQ保存
- Pydanticモデル: `PredictDailyRequest`, `PredictOnDemandRequest`, `PredictResponse` を追加

## Test plan
- [x] `python3 -m pytest tests/test_predict.py -v` → 13件すべてパス
- [x] 全テスト（関連モジュール）: 255件パス確認済み
- [ ] ローカルでの `--save-to-bq` 動作確認（GCP認証環境が必要）

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)