### PR TITLE
fix: 一時テーブルに有効期限を設定してCloud Runタイムアウト時の残留を防止

### DIFF
--- a/scripts/reload_gcs_to_bq.py
+++ b/scripts/reload_gcs_to_bq.py
@@ -11,7 +11,7 @@ import sys
 import logging
 import argparse
 from typing import List, Optional
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from dotenv import load_dotenv
 from google.cloud import storage, bigquery
@@ -115,7 +115,9 @@ def load_file_to_bigquery(
         target_table = bq_client.get_table(table_ref)
         schema = target_table.schema
 
+        # 1時間後に自動削除される有効期限を設定し、プロセス強制終了時の残留を防ぐ
         temp_table = bigquery.Table(temp_table_ref, schema=schema)
+        temp_table.expires = datetime.utcnow() + timedelta(hours=1)
         temp_table = bq_client.create_table(temp_table)
 
         try:

--- a/src/automation/data/load_to_bq.py
+++ b/src/automation/data/load_to_bq.py
@@ -19,7 +19,7 @@ import re
 import sys
 import time
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Set
 
 from google.cloud import bigquery, storage
@@ -373,8 +373,9 @@ class BigQueryLoader:
                 )
             schema = target_table.schema
 
-            # 一時テーブルを作成
+            # 一時テーブルを作成（1時間後に自動削除される有効期限を設定）
             temp_table = bigquery.Table(temp_table_ref, schema=schema)
+            temp_table.expires = datetime.utcnow() + timedelta(hours=1)
             temp_table = self.bq_client.create_table(temp_table)
             logger.debug(f"一時テーブルを作成しました: {temp_table_ref}")
 

--- a/src/models/predict.py
+++ b/src/models/predict.py
@@ -365,7 +365,10 @@ def save_predictions_to_bq(
 
     try:
         # 一時テーブルを作成してデータをロード（スキーマはautodetect）
-        client.create_table(bigquery.Table(temp_table_ref))
+        # 1時間後に自動削除される有効期限を設定し、プロセス強制終了時の残留を防ぐ
+        _temp_table_obj = bigquery.Table(temp_table_ref)
+        _temp_table_obj.expires = datetime.datetime.utcnow() + datetime.timedelta(hours=1)
+        client.create_table(_temp_table_obj)
         logger.debug(f"一時テーブルを作成しました: {temp_table_ref}")
 
         try:


### PR DESCRIPTION
## Summary

- Cloud Runのタイムアウト/強制終了時に `_temp_race_info` 等の一時テーブルが BigQuery に残留する問題を修正
- 一時テーブル作成時に `expires = UTC+1時間` を設定し、BigQuery による自動削除を保証
- 対象: `load_to_bq.py` / `predict.py` / `reload_gcs_to_bq.py` の3ファイル

## 根本原因

MERGE UPSERT の中間テーブルは通常 `finally` ブロックで削除されるが、Cloud Run がタイムアウト（デフォルト60分）やOOMでプロセスを強制終了した場合、`finally` が実行されず一時テーブルが残留していた。

## Test plan

- [x] `tests/test_predict.py` 13件全パス（既存テスト）
- [x] `test_generate_evaluation_report.py` の失敗は今回の変更と無関係な既存の失敗であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)