### PR TITLE
fix: finish_positionのNA値によるastype(int)エラーを修正

### DIFF
--- a/scripts/generate_evaluation_report.py
+++ b/scripts/generate_evaluation_report.py
@@ -128,6 +128,9 @@ def compute_metrics(
     """
     from sklearn.metrics import roc_auc_score
 
+    # finish_positionがNAの行（競走除外・中止馬など）を除外
+    df = df[df["finish_position"].notna()].copy()
+
     feature_cols = [c for c in df.columns if c not in exclude_columns]
     X = df[feature_cols].copy()
     for col in categorical_columns:
@@ -236,6 +239,8 @@ def plot_monthly_metrics(
 
     for month in months:
         monthly = df[df["year_month"] == month]
+        # finish_positionがNAの行（競走除外・中止馬など）を除外
+        monthly = monthly[monthly["finish_position"].notna()].copy()
         if len(monthly) < 10:
             continue
 


### PR DESCRIPTION
## Summary
- `generate_evaluation_report.py` の `compute_metrics` と `plot_monthly_metrics` で `finish_position` 列のNA値を `astype(int)` する際に `ValueError: cannot convert NA to integer` が発生していた問題を修正
- 競走除外・中止馬などで `finish_position` がNAとなる行を、各関数の処理開始前にフィルタリングするよう変更

## 変更箇所
- `compute_metrics` 関数: `df = df[df["finish_position"].notna()].copy()` を冒頭に追加
- `plot_monthly_metrics` 関数: ループ内で `monthly = monthly[monthly["finish_position"].notna()].copy()` を追加

## 設計上の注意点
`X`（特徴量）・`positions`・`groups` はすべて同じ DataFrame から生成されるため、NAの除外を最初にまとめて行うことで行数の整合性を維持している。

## Test plan
- [ ] `python scripts/generate_evaluation_report.py --model-path ... --project-id ...` が完走することを確認
- [ ] `python3 -m py_compile scripts/generate_evaluation_report.py` で構文エラーなし（確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)