### PR TITLE
fix: generate_evaluation_report の categorical_feature 不一致エラーを修正

### DIFF
--- a/scripts/generate_evaluation_report.py
+++ b/scripts/generate_evaluation_report.py
@@ -136,9 +136,9 @@ def compute_metrics(
     for col in categorical_columns:
         if col in X.columns:
             X[col] = X[col].astype("category")
-    # object型をcategory型に変換
-    for col in X.select_dtypes(include="object").columns:
-        X[col] = X[col].astype("category")
+    # 残存するobject列を除外する（学習時と同様の処理）
+    # object列をcategoryに変換するとモデルのcategorical_featureと不一致になるため
+    X = X.select_dtypes(exclude="object")
 
     positions = df["finish_position"].values.astype(int)
     y_binary = np.where((positions >= 1) & (positions <= 3), 1, 0)
@@ -249,8 +249,8 @@ def plot_monthly_metrics(
         for col in categorical_columns:
             if col in X.columns:
                 X[col] = X[col].astype("category")
-        for col in X.select_dtypes(include="object").columns:
-            X[col] = X[col].astype("category")
+        # 残存するobject列を除外する（学習時と同様の処理）
+        X = X.select_dtypes(exclude="object")
 
         positions = monthly["finish_position"].values.astype(int)
         y_binary = np.where((positions >= 1) & (positions <= 3), 1, 0)


### PR DESCRIPTION
## Summary

- `compute_metrics` および `plot_monthly_metrics` で、指定した `categorical_columns` に加えて **残存するすべての object 列も `category` 型に変換** していたため、モデルの `pandas_categorical` と不一致が発生し `ValueError` が起きていた
- 学習時の `build_feature_matrix`（`train.py`）と同様に、明示的に指定した列のみを `category` 型に変換し、残存する object 列は `select_dtypes(exclude="object")` で除外するよう修正

## Root Cause

```python
# 問題のコード（削除）
# course_type, track_condition 以外の horse_name 等もcategoryに変換していた
for col in X.select_dtypes(include="object").columns:
    X[col] = X[col].astype("category")
```

LightGBM は `booster.predict()` 時にモデルの `pandas_categorical`（学習時に記録されたカテゴリ数）と入力の category dtype 列数を照合する。学習時は 2 列（`course_type`, `track_condition`）のみ category なのに、評価スクリプトは追加の object 列（`horse_name` 等）も category に変換するため数が不一致になっていた。

## Test plan

- [ ] `python scripts/generate_evaluation_report.py --model-path src/models/lgbm_ranker_20260217.txt --project-id keiba-prediction-1768734113` を実行し、`ValueError: train and valid dataset categorical_feature do not match.` が解消されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)