### PR TITLE
fix: load_historyのスキップロジック改善 - GCS更新ファイルを強制再ロード (Issue #116)

### DIFF
--- a/src/automation/data/load_to_bq.py
+++ b/src/automation/data/load_to_bq.py
@@ -19,8 +19,8 @@ import re
 import sys
 import time
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
-from typing import Dict, List, Optional, Set
+from datetime import datetime, timedelta, timezone
+from typing import Dict, List, Optional
 
 from google.cloud import bigquery, storage
 from google.cloud.exceptions import GoogleCloudError
@@ -177,6 +177,8 @@ class BigQueryLoader:
 
         self._bq_client: Optional[bigquery.Client] = None
         self._storage_client: Optional[storage.Client] = None
+        # GCS blob の更新タイムスタンプキャッシュ (list_csv_files() が設定する)
+        self._blob_updated_cache: Dict[str, Optional[datetime]] = {}
 
     @property
     def bq_client(self) -> bigquery.Client:
@@ -194,35 +196,48 @@ class BigQueryLoader:
             logger.info("Cloud Storageクライアントを初期化しました")
         return self._storage_client
 
-    def _get_loaded_files(self) -> Set[str]:
+    def _get_loaded_files(self) -> Dict[str, datetime]:
         """
-        ロード履歴テーブルから成功したファイル名のセットを取得
+        ロード履歴テーブルから成功したファイルの最終ロード日時を取得
+
+        GCS更新タイムスタンプとの比較に使用するため、
+        ファイルごとに最新の loaded_at を返す。
 
         Returns:
-            ロード済みファイル名のセット
+            {file_name: loaded_at (UTC-aware)} のDict
         """
         table_ref = f"{self.project_id}.{self.dataset_id}.{LOAD_HISTORY_TABLE}"
 
         query = f"""
-        SELECT DISTINCT file_name
+        SELECT file_name, MAX(loaded_at) AS loaded_at
         FROM `{table_ref}`
         WHERE status = 'success'
+        GROUP BY file_name
         """
 
         try:
             query_job = self.bq_client.query(query)
             results = query_job.result()
-            loaded_files = {row.file_name for row in results}
+            loaded_files: Dict[str, datetime] = {}
+            for row in results:
+                loaded_at = row.loaded_at
+                if loaded_at is not None:
+                    # UTC-aware に統一
+                    if loaded_at.tzinfo is None:
+                        loaded_at = loaded_at.replace(tzinfo=timezone.utc)
+                else:
+                    loaded_at = datetime.min.replace(tzinfo=timezone.utc)
+                loaded_files[row.file_name] = loaded_at
             logger.info(f"ロード履歴から {len(loaded_files)} 件の成功ファイルを取得しました")
             return loaded_files
         except Exception as e:
-            # テーブルが存在しない場合は空のセットを返す
+            # テーブルが存在しない場合は空のDictを返す
             if "Not found" in str(e):
                 logger.warning(
                     f"ロード履歴テーブルが見つかりません: {table_ref}. "
                     "スキップ機能は無効になります。"
                 )
-                return set()
+                return {}
             logger.error(f"ロード履歴の取得に失敗しました: {e}")
             raise
 
@@ -275,14 +290,14 @@ class BigQueryLoader:
             logger.warning(f"ロード履歴の記録に失敗しました: {e}")
 
     def _is_file_already_loaded(
-        self, file_name: str, loaded_files: Optional[Set[str]] = None
+        self, file_name: str, loaded_files: Optional[Dict[str, datetime]] = None
     ) -> bool:
         """
         ファイルが既にロード済みかどうかを確認
 
         Args:
             file_name: ファイル名
-            loaded_files: ロード済みファイルのセット (キャッシュ用)
+            loaded_files: {file_name: loaded_at} のDict (キャッシュ用)
 
         Returns:
             ロード済みの場合True
@@ -582,24 +597,55 @@ class BigQueryLoader:
 
         logger.info(f"バッチロード開始: {len(blob_names)} ファイル")
 
-        # 重複スキップが有効な場合、ロード済みファイルを取得
-        loaded_files: Set[str] = set()
+        # 重複スキップが有効な場合、ロード済みファイルと最終ロード日時を取得
+        loaded_files: Dict[str, datetime] = {}
         if skip_loaded:
             loaded_files = self._get_loaded_files()
             logger.info(f"重複スキップ機能: 有効 ({len(loaded_files)} 件のロード済みファイル)")
 
         for i, blob_name in enumerate(blob_names, 1):
-            # 重複スキップ判定
+            # 重複スキップ判定: ロード済み かつ GCS更新なし の場合にスキップ
             if skip_loaded and blob_name in loaded_files:
-                logger.info(f"スキップ ({i}/{len(blob_names)}): {blob_name} (ロード済み)")
-                result = LoadResult(
-                    file_name=blob_name,
-                    status="skipped",
-                    error="既にロード済み",
-                )
-                batch_result.results.append(result)
-                batch_result.skipped_count += 1
-                continue
+                gcs_updated = self._blob_updated_cache.get(blob_name)
+                if gcs_updated is not None:
+                    # GCS更新タイムスタンプと最終ロード日時を比較
+                    if gcs_updated.tzinfo is None:
+                        gcs_updated = gcs_updated.replace(tzinfo=timezone.utc)
+                    loaded_at = loaded_files[blob_name]
+                    if gcs_updated <= loaded_at:
+                        # GCSが古いまま → スキップ
+                        logger.info(
+                            f"スキップ ({i}/{len(blob_names)}): {blob_name} "
+                            f"(ロード済み・GCS更新なし)"
+                        )
+                        result = LoadResult(
+                            file_name=blob_name,
+                            status="skipped",
+                            error="既にロード済み",
+                        )
+                        batch_result.results.append(result)
+                        batch_result.skipped_count += 1
+                        continue
+                    else:
+                        # GCSが新しい → 再ロード
+                        logger.info(
+                            f"GCS更新検出 ({i}/{len(blob_names)}): {blob_name} "
+                            f"を再ロードします "
+                            f"(GCS更新: {gcs_updated}, 最終ロード: {loaded_at})"
+                        )
+                else:
+                    # キャッシュなし（list_csv_files()を経由しない呼び出し）→ 保守的にスキップ
+                    logger.info(
+                        f"スキップ ({i}/{len(blob_names)}): {blob_name} (ロード済み)"
+                    )
+                    result = LoadResult(
+                        file_name=blob_name,
+                        status="skipped",
+                        error="既にロード済み",
+                    )
+                    batch_result.results.append(result)
+                    batch_result.skipped_count += 1
+                    continue
 
             logger.info(f"処理中 ({i}/{len(blob_names)}): {blob_name}")
 
@@ -670,6 +716,11 @@ class BigQueryLoader:
                 continue
 
             csv_files.append(blob.name)
+            # GCS更新タイムスタンプをキャッシュ (load_files_batch() でのスキップ判定に使用)
+            updated = blob.updated
+            if updated is not None and updated.tzinfo is None:
+                updated = updated.replace(tzinfo=timezone.utc)
+            self._blob_updated_cache[blob.name] = updated
 
         logger.info(f"GCSから {len(csv_files)} 個のCSVファイルを検出しました")
         return csv_files

--- a/src/automation/pipeline/daily_pipeline.py
+++ b/src/automation/pipeline/daily_pipeline.py
@@ -289,12 +289,12 @@ class DailyPipeline:
         """
         Step 3: BigQueryにロード
 
-        GCS上の未ロードファイルをすべてBigQueryにロードする。
-        JRDBファイルはレース開催日（主に土日）で命名されるため、
-        パイプライン実行日ではなくロード履歴による重複スキップで制御する。
+        GCS上のファイルをBigQueryにロードする。
+        スキップ判定はGCS更新タイムスタンプとload_historyのloaded_atを比較して行う。
+        日曜日は当日（yymmdd）のファイルのみ skip_loaded を無視して強制再ロードする。
 
         Args:
-            target_date: 対象日付（ログ用）
+            target_date: 対象日付
 
         Returns:
             StepResult
@@ -303,9 +303,9 @@ class DailyPipeline:
         start_time = time.time()
 
         try:
-            from src.automation.data.load_to_bq import TABLE_MAPPING
+            from src.automation.data.load_to_bq import BatchLoadResult, TABLE_MAPPING
 
-            logger.info(f"BigQueryロード開始（未ロードファイル全件）: {target_date}")
+            logger.info(f"BigQueryロード開始: {target_date}")
 
             # BQテーブルの存在確認（未作成テーブルがある場合は警告ログを出す）
             table_exists = self.bq_loader.check_tables_exist()
@@ -316,7 +316,8 @@ class DailyPipeline:
                     f"scripts/setup_bigquery.sh を実行してテーブルを作成してください。"
                 )
 
-            # GCS上のサポート対象データタイプのファイルのみを取得
+            # GCS上のサポート対象データタイプのファイルを一括取得
+            # （このタイミングで _blob_updated_cache が更新される）
             supported_types = list(TABLE_MAPPING.keys())
             csv_files = self.bq_loader.list_csv_files(
                 prefix="", data_types=supported_types
@@ -331,13 +332,64 @@ class DailyPipeline:
                     details={"files": 0, "records": 0, "skipped": 0},
                 )
 
-            # バッチロード実行（重複スキップ有効）
-            result = self.bq_loader.load_files_batch(
-                csv_files,
-                continue_on_error=True,
-                skip_loaded=True,
-                record_history=True,
-            )
+            # 日曜日は当日ファイルを強制再ロード（解決策B）
+            # JRDBは土曜19:00に全レース分を更新するため、日曜バッチでは当日データを必ず再取得する
+            is_sunday = target_date.weekday() == 6
+            date_str = self.date_to_yymmdd(target_date)
+
+            if is_sunday:
+                logger.info(
+                    f"日曜日のため当日ファイル（{date_str}）を強制再ロードします"
+                )
+                today_files = [f for f in csv_files if date_str in f]
+                other_files = [f for f in csv_files if date_str not in f]
+
+                # 当日ファイルは skip_loaded=False で強制再ロード
+                if today_files:
+                    logger.info(
+                        f"当日ファイル {len(today_files)} 件を強制再ロード: {today_files}"
+                    )
+                    today_batch = self.bq_loader.load_files_batch(
+                        today_files,
+                        continue_on_error=True,
+                        skip_loaded=False,
+                        record_history=True,
+                    )
+                else:
+                    today_batch = BatchLoadResult(total_files=0)
+
+                # 当日以外は通常スキップロジック（GCSタイムスタンプ比較）
+                if other_files:
+                    other_batch = self.bq_loader.load_files_batch(
+                        other_files,
+                        continue_on_error=True,
+                        skip_loaded=True,
+                        record_history=True,
+                    )
+                else:
+                    other_batch = BatchLoadResult(total_files=0)
+
+                # 2バッチの結果を集計
+                result = BatchLoadResult(
+                    total_files=today_batch.total_files + other_batch.total_files,
+                    success_count=today_batch.success_count + other_batch.success_count,
+                    skipped_count=today_batch.skipped_count + other_batch.skipped_count,
+                    failed_count=today_batch.failed_count + other_batch.failed_count,
+                    total_records=today_batch.total_records + other_batch.total_records,
+                    results=today_batch.results + other_batch.results,
+                    failed_files=today_batch.failed_files + other_batch.failed_files,
+                    duration_seconds=(
+                        today_batch.duration_seconds + other_batch.duration_seconds
+                    ),
+                )
+            else:
+                # 通常ロード: GCSタイムスタンプ比較によるスキップ（解決策A）
+                result = self.bq_loader.load_files_batch(
+                    csv_files,
+                    continue_on_error=True,
+                    skip_loaded=True,
+                    record_history=True,
+                )
 
             details = {
                 "files": result.success_count,

--- a/tests/test_daily_pipeline.py
+++ b/tests/test_daily_pipeline.py
@@ -305,6 +305,118 @@ class TestDailyPipelineStepLoadToBq:
         assert result.status == "partial"
         assert result.details["failed"] == 1
 
+    def test_step_load_to_bq_sunday_forces_reload_today_files(self):
+        """日曜日は当日yymmddのファイルのみ skip_loaded=False で強制再ロードされる（解決策B）"""
+        bq_loader = MagicMock()
+        # 2024-01-14（日曜）に実行: 当日ファイル240114 と前日ファイル240113 が存在
+        bq_loader.list_csv_files.return_value = [
+            "Baa/BAA240114.csv",  # 当日
+            "Baa/BAA240113.csv",  # 前日
+            "Kyf/KYF240113.csv",  # 前日
+        ]
+        # 当日バッチと前日バッチの結果を個別に返す
+        today_batch_result = BatchLoadResult(
+            total_files=1,
+            success_count=1,
+            skipped_count=0,
+            failed_count=0,
+            total_records=36,
+            results=[],
+            failed_files=[],
+            duration_seconds=3.0,
+        )
+        other_batch_result = BatchLoadResult(
+            total_files=2,
+            success_count=0,
+            skipped_count=2,
+            failed_count=0,
+            total_records=0,
+            results=[],
+            failed_files=[],
+            duration_seconds=1.0,
+        )
+        bq_loader.load_files_batch.side_effect = [today_batch_result, other_batch_result]
+
+        pipeline = DailyPipeline(bq_loader=bq_loader)
+        result = pipeline._step_load_to_bq(date(2024, 1, 14))  # 日曜日
+
+        assert result.status == "success"
+        # 当日 1 件成功 + 前日 2 件スキップ
+        assert result.details["files"] == 1
+        assert result.details["records"] == 36
+        assert result.details["skipped"] == 2
+
+        # load_files_batch が 2 回呼ばれていること
+        assert bq_loader.load_files_batch.call_count == 2
+
+        # 1回目（当日ファイル）は skip_loaded=False で呼ばれること
+        first_call = bq_loader.load_files_batch.call_args_list[0]
+        assert first_call[0][0] == ["Baa/BAA240114.csv"]
+        assert first_call[1]["skip_loaded"] is False
+
+        # 2回目（前日ファイル）は skip_loaded=True で呼ばれること
+        second_call = bq_loader.load_files_batch.call_args_list[1]
+        assert set(second_call[0][0]) == {"Baa/BAA240113.csv", "Kyf/KYF240113.csv"}
+        assert second_call[1]["skip_loaded"] is True
+
+    def test_step_load_to_bq_sunday_no_today_files(self):
+        """日曜日に当日ファイルがない場合は前日ファイルのみ通常ロード"""
+        bq_loader = MagicMock()
+        # 当日ファイルなし、前日ファイルのみ
+        bq_loader.list_csv_files.return_value = [
+            "Baa/BAA240113.csv",
+        ]
+        other_batch_result = BatchLoadResult(
+            total_files=1,
+            success_count=0,
+            skipped_count=1,
+            failed_count=0,
+            total_records=0,
+            results=[],
+            failed_files=[],
+            duration_seconds=1.0,
+        )
+        bq_loader.load_files_batch.return_value = other_batch_result
+
+        pipeline = DailyPipeline(bq_loader=bq_loader)
+        result = pipeline._step_load_to_bq(date(2024, 1, 14))  # 日曜日
+
+        assert result.status == "success"
+        # 当日ファイルなし → 当日バッチ呼ばれない、前日バッチのみ
+        # load_files_batch は other_files 分のみ呼ばれる
+        assert bq_loader.load_files_batch.call_count == 1
+        call_args = bq_loader.load_files_batch.call_args
+        assert call_args[1]["skip_loaded"] is True
+
+    def test_step_load_to_bq_weekday_uses_skip_loaded(self):
+        """平日（月〜土）は通常のGCSタイムスタンプ比較ロジックが使われる"""
+        bq_loader = MagicMock()
+        bq_loader.list_csv_files.return_value = [
+            "Baa/BAA240115.csv",
+            "Baa/BAA240114.csv",
+        ]
+        batch_result = BatchLoadResult(
+            total_files=2,
+            success_count=1,
+            skipped_count=1,
+            failed_count=0,
+            total_records=18,
+            results=[],
+            failed_files=[],
+            duration_seconds=2.0,
+        )
+        bq_loader.load_files_batch.return_value = batch_result
+
+        pipeline = DailyPipeline(bq_loader=bq_loader)
+        result = pipeline._step_load_to_bq(date(2024, 1, 15))  # 月曜日
+
+        assert result.status == "success"
+        # load_files_batch は 1 回のみ呼ばれ skip_loaded=True
+        assert bq_loader.load_files_batch.call_count == 1
+        call_args = bq_loader.load_files_batch.call_args
+        assert call_args[0][0] == ["Baa/BAA240115.csv", "Baa/BAA240114.csv"]
+        assert call_args[1]["skip_loaded"] is True
+
 
 class TestDailyPipelineRun:
     """DailyPipeline.runのテスト"""

--- a/tests/test_load_to_bq.py
+++ b/tests/test_load_to_bq.py
@@ -3,6 +3,7 @@ load_to_bq モジュールのユニットテスト
 """
 
 import os
+from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -354,6 +355,31 @@ class TestBigQueryLoaderListFiles:
         assert "KYF260104.csv" in result
         assert "SEC260104.csv" not in result
 
+    @patch("google.cloud.storage.Client")
+    def test_list_csv_files_populates_blob_updated_cache(self, mock_storage_client):
+        """list_csv_files()実行後に_blob_updated_cacheにGCS更新タイムスタンプが設定される"""
+        from datetime import timezone
+
+        loader = BigQueryLoader(project_id="test-project")
+        gcs_updated = datetime(2026, 3, 1, 19, 0, 0, tzinfo=timezone.utc)
+
+        mock_blob = MagicMock()
+        mock_blob.name = "BAA260301.csv"
+        mock_blob.updated = gcs_updated
+
+        mock_bucket = MagicMock()
+        mock_bucket.list_blobs.return_value = [mock_blob]
+
+        mock_client = MagicMock()
+        mock_client.bucket.return_value = mock_bucket
+        mock_storage_client.return_value = mock_client
+
+        loader.list_csv_files()
+
+        # キャッシュにGCS更新日時が格納されていること
+        assert "BAA260301.csv" in loader._blob_updated_cache
+        assert loader._blob_updated_cache["BAA260301.csv"] == gcs_updated
+
 
 class TestBigQueryLoaderBatchLoad:
     """BigQueryLoaderのload_files_batchメソッドテスト"""
@@ -518,17 +544,25 @@ class TestGetLoadedFiles:
 
     @patch("google.cloud.bigquery.Client")
     def test_get_loaded_files_success(self, mock_bq_client):
-        """ロード済みファイル一覧を取得する"""
+        """ロード済みファイルの最終ロード日時を Dict で取得する"""
+        from datetime import timezone
+
         loader = BigQueryLoader(project_id="test-project")
 
         mock_client = MagicMock()
         mock_bq_client.return_value = mock_client
 
-        # クエリ結果をモック
+        # クエリ結果をモック (file_name と loaded_at を返す)
+        loaded_at_1 = datetime(2026, 3, 1, 6, 0, 0, tzinfo=timezone.utc)
+        loaded_at_2 = datetime(2026, 3, 1, 7, 0, 0, tzinfo=timezone.utc)
+
         mock_row1 = MagicMock()
         mock_row1.file_name = "BAA260104.csv"
+        mock_row1.loaded_at = loaded_at_1
+
         mock_row2 = MagicMock()
         mock_row2.file_name = "KYF260104.csv"
+        mock_row2.loaded_at = loaded_at_2
 
         mock_query_job = MagicMock()
         mock_query_job.result.return_value = [mock_row1, mock_row2]
@@ -536,16 +570,46 @@ class TestGetLoadedFiles:
 
         result = loader._get_loaded_files()
 
-        assert result == {"BAA260104.csv", "KYF260104.csv"}
+        assert isinstance(result, dict)
+        assert set(result.keys()) == {"BAA260104.csv", "KYF260104.csv"}
+        assert result["BAA260104.csv"] == loaded_at_1
+        assert result["KYF260104.csv"] == loaded_at_2
         mock_client.query.assert_called_once()
-        # クエリが正しいテーブルを参照していることを確認
+        # クエリが正しいテーブルを参照し、GROUP BY / MAX を使っていることを確認
         query_call = mock_client.query.call_args[0][0]
         assert LOAD_HISTORY_TABLE in query_call
         assert "status = 'success'" in query_call
+        assert "MAX(loaded_at)" in query_call
+        assert "GROUP BY file_name" in query_call
+
+    @patch("google.cloud.bigquery.Client")
+    def test_get_loaded_files_naive_datetime_becomes_utc_aware(self, mock_bq_client):
+        """loaded_at が timezone-naive の場合も UTC-aware に変換される"""
+        from datetime import timezone
+
+        loader = BigQueryLoader(project_id="test-project")
+
+        mock_client = MagicMock()
+        mock_bq_client.return_value = mock_client
+
+        # naive datetime (tzinfo なし)
+        naive_dt = datetime(2026, 3, 1, 6, 0, 0)
+
+        mock_row = MagicMock()
+        mock_row.file_name = "BAA260104.csv"
+        mock_row.loaded_at = naive_dt
+
+        mock_query_job = MagicMock()
+        mock_query_job.result.return_value = [mock_row]
+        mock_client.query.return_value = mock_query_job
+
+        result = loader._get_loaded_files()
+
+        assert result["BAA260104.csv"].tzinfo == timezone.utc
 
     @patch("google.cloud.bigquery.Client")
     def test_get_loaded_files_table_not_found(self, mock_bq_client):
-        """テーブルが存在しない場合は空のセットを返す"""
+        """テーブルが存在しない場合は空のDictを返す"""
         loader = BigQueryLoader(project_id="test-project")
 
         mock_client = MagicMock()
@@ -556,7 +620,7 @@ class TestGetLoadedFiles:
 
         result = loader._get_loaded_files()
 
-        assert result == set()
+        assert result == {}
 
     @patch("google.cloud.bigquery.Client")
     def test_get_loaded_files_other_error(self, mock_bq_client):
@@ -631,8 +695,13 @@ class TestIsFileAlreadyLoaded:
 
     def test_file_is_loaded(self):
         """ファイルがロード済みの場合Trueを返す"""
+        from datetime import timezone
+
         loader = BigQueryLoader(project_id="test-project")
-        loaded_files = {"BAA260104.csv", "KYF260104.csv"}
+        loaded_files = {
+            "BAA260104.csv": datetime(2026, 3, 1, tzinfo=timezone.utc),
+            "KYF260104.csv": datetime(2026, 3, 1, tzinfo=timezone.utc),
+        }
 
         result = loader._is_file_already_loaded("BAA260104.csv", loaded_files)
 
@@ -640,8 +709,13 @@ class TestIsFileAlreadyLoaded:
 
     def test_file_is_not_loaded(self):
         """ファイルが未ロードの場合Falseを返す"""
+        from datetime import timezone
+
         loader = BigQueryLoader(project_id="test-project")
-        loaded_files = {"BAA260104.csv", "KYF260104.csv"}
+        loaded_files = {
+            "BAA260104.csv": datetime(2026, 3, 1, tzinfo=timezone.utc),
+            "KYF260104.csv": datetime(2026, 3, 1, tzinfo=timezone.utc),
+        }
 
         result = loader._is_file_already_loaded("SEC260104.csv", loaded_files)
 
@@ -651,13 +725,90 @@ class TestIsFileAlreadyLoaded:
 class TestLoadFilesWithSkip:
     """重複スキップ機能を含むload_files_batchメソッドのテスト"""
 
-    def test_batch_load_with_skip_loaded(self):
-        """skip_loaded=Trueでロード済みファイルをスキップする"""
-        loader = BigQueryLoader(project_id="test-project")
+    def test_batch_load_skip_when_gcs_not_updated(self):
+        """GCS更新日時がloaded_at以前の場合はスキップされる（解決策A）"""
+        from datetime import timezone
 
-        # ロード済みファイルを返すモック
+        loader = BigQueryLoader(project_id="test-project")
+        loaded_at = datetime(2026, 3, 1, 6, 0, 0, tzinfo=timezone.utc)
+        gcs_updated = datetime(2026, 3, 1, 5, 0, 0, tzinfo=timezone.utc)  # GCSが古い
+
+        # ロード済みファイルと GCS タイムスタンプをセット
+        loader._blob_updated_cache["file1.csv"] = gcs_updated
+
         with patch.object(
-            loader, "_get_loaded_files", return_value={"file1.csv", "file2.csv"}
+            loader, "_get_loaded_files", return_value={"file1.csv": loaded_at}
+        ):
+            with patch.object(loader, "load_file") as mock_load:
+                result = loader.load_files_batch(["file1.csv"], skip_loaded=True)
+
+        # GCS が古いのでスキップ
+        assert result.skipped_count == 1
+        assert result.success_count == 0
+        mock_load.assert_not_called()
+
+    def test_batch_load_reload_when_gcs_is_newer(self):
+        """GCS更新日時がloaded_atより新しければ再ロードされる（解決策A）"""
+        from datetime import timezone
+
+        loader = BigQueryLoader(project_id="test-project")
+        loaded_at = datetime(2026, 3, 1, 6, 0, 0, tzinfo=timezone.utc)
+        gcs_updated = datetime(2026, 3, 1, 19, 30, 0, tzinfo=timezone.utc)  # GCSが新しい
+
+        loader._blob_updated_cache["file1.csv"] = gcs_updated
+
+        with patch.object(
+            loader, "_get_loaded_files", return_value={"file1.csv": loaded_at}
+        ):
+            with patch.object(loader, "load_file") as mock_load:
+                mock_load.return_value = LoadResult(
+                    file_name="file1.csv", status="success", records_processed=36
+                )
+                result = loader.load_files_batch(["file1.csv"], skip_loaded=True)
+
+        # GCS が新しいので再ロード
+        assert result.success_count == 1
+        assert result.skipped_count == 0
+        mock_load.assert_called_once_with("file1.csv", record_history=True)
+
+    def test_batch_load_skip_when_no_cache(self):
+        """GCSキャッシュがない場合は保守的にスキップする"""
+        from datetime import timezone
+
+        loader = BigQueryLoader(project_id="test-project")
+        loaded_at = datetime(2026, 3, 1, 6, 0, 0, tzinfo=timezone.utc)
+
+        # _blob_updated_cache にエントリなし
+
+        with patch.object(
+            loader, "_get_loaded_files", return_value={"file1.csv": loaded_at}
+        ):
+            with patch.object(loader, "load_file") as mock_load:
+                result = loader.load_files_batch(["file1.csv"], skip_loaded=True)
+
+        # キャッシュなし → スキップ
+        assert result.skipped_count == 1
+        assert result.success_count == 0
+        mock_load.assert_not_called()
+
+    def test_batch_load_with_skip_loaded(self):
+        """skip_loaded=True でロード済み（GCS更新なし）のファイルはスキップ、未ロードはロード"""
+        from datetime import timezone
+
+        loader = BigQueryLoader(project_id="test-project")
+        loaded_at = datetime(2026, 3, 1, 6, 0, 0, tzinfo=timezone.utc)
+        gcs_updated = datetime(2026, 3, 1, 5, 0, 0, tzinfo=timezone.utc)  # GCSが古い
+
+        loader._blob_updated_cache["file1.csv"] = gcs_updated
+        loader._blob_updated_cache["file2.csv"] = gcs_updated
+
+        with patch.object(
+            loader,
+            "_get_loaded_files",
+            return_value={
+                "file1.csv": loaded_at,
+                "file2.csv": loaded_at,
+            },
         ):
             with patch.object(loader, "load_file") as mock_load:
                 mock_load.return_value = LoadResult(
@@ -703,10 +854,15 @@ class TestLoadFilesWithSkip:
 
     def test_batch_load_skip_reason_in_result(self):
         """スキップされたファイルの理由が結果に含まれる"""
+        from datetime import timezone
+
         loader = BigQueryLoader(project_id="test-project")
+        loaded_at = datetime(2026, 3, 1, 6, 0, 0, tzinfo=timezone.utc)
+        gcs_updated = datetime(2026, 3, 1, 5, 0, 0, tzinfo=timezone.utc)
+        loader._blob_updated_cache["file1.csv"] = gcs_updated
 
         with patch.object(
-            loader, "_get_loaded_files", return_value={"file1.csv"}
+            loader, "_get_loaded_files", return_value={"file1.csv": loaded_at}
         ):
             with patch.object(loader, "load_file"):
                 result = loader.load_files_batch(


### PR DESCRIPTION
## Summary

- **解決策A**: `_get_loaded_files()` の戻り値を `Set[str]` → `Dict[str, datetime]` に変更し、`load_files_batch()` でGCS更新タイムスタンプと `loaded_at` を比較してスキップ判定するよう改善
- **解決策B**: `_step_load_to_bq()` に日曜日判定を追加し、当日（yymmdd）のファイルのみ `skip_loaded=False` で強制再ロードする
- `list_csv_files()` で `_blob_updated_cache` に `blob.updated` をキャッシュし、GCS追加API呼び出しなしでタイムスタンプ比較を実現

## 変更内容

### `src/automation/data/load_to_bq.py`
- `_get_loaded_files()`: `Set[str]` → `Dict[str, datetime]`（`MAX(loaded_at) GROUP BY file_name` クエリに変更）
- `_blob_updated_cache`: インスタンス変数として追加
- `list_csv_files()`: ブロブの `updated` タイムスタンプをキャッシュに格納
- `load_files_batch()`: GCSキャッシュと `loaded_at` を比較してスキップ/再ロードを判定

### `src/automation/pipeline/daily_pipeline.py`
- `_step_load_to_bq()`: 日曜日は当日ファイルを `skip_loaded=False`、当日以外は `skip_loaded=True` で処理

### テスト追加・更新
- `test_batch_load_skip_when_gcs_not_updated`: GCS古い → スキップ
- `test_batch_load_reload_when_gcs_is_newer`: GCS新しい → 再ロード
- `test_batch_load_skip_when_no_cache`: キャッシュなし → 保守的スキップ
- `test_list_csv_files_populates_blob_updated_cache`: キャッシュ更新確認
- `test_get_loaded_files_success`: Dict形式の戻り値を確認
- `test_step_load_to_bq_sunday_forces_reload_today_files`: 日曜当日ファイル強制再ロード
- `test_step_load_to_bq_sunday_no_today_files`: 日曜当日ファイルなしのケース
- `test_step_load_to_bq_weekday_uses_skip_loaded`: 平日の通常ロジック確認

## Test plan
- [ ] `tests/test_load_to_bq.py` 全テストがパスすること (既存 + 新規テスト)
- [ ] `tests/test_daily_pipeline.py` 全テストがパスすること (既存 + 新規テスト)
- [ ] 受け入れ条件を全て確認:
  - GCS更新日時がloaded_atより新しければ再ロードされる
  - GCS更新日時がloaded_at以前の場合はスキップされる
  - 日曜日の当日ファイルはskip_loadedを無視して強制再ロード
  - 日曜日の当日以外ファイルはスキップロジックが適用される
  - 平日は解決策Aのタイムスタンプ比較のみ

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)