### PR TITLE
fix: 評価レポート生成スクリプトのValueError修正（特徴量行列が空になる問題）

### DIFF
--- a/scripts/generate_evaluation_report.py
+++ b/scripts/generate_evaluation_report.py
@@ -131,14 +131,15 @@ def compute_metrics(
     # finish_positionがNAの行（競走除外・中止馬など）を除外
     df = df[df["finish_position"].notna()].copy()
 
-    feature_cols = [c for c in df.columns if c not in exclude_columns]
+    # モデルが学習時に使用した特徴量名を取得し、対応する列のみを選択する
+    # select_dtypes(exclude="object") は学習時に行われておらず、
+    # BigQueryからのデータでは数値列がobject型で読み込まれることがあるため使用しない
+    model_feature_names = booster.feature_name()
+    feature_cols = [c for c in model_feature_names if c in df.columns]
     X = df[feature_cols].copy()
     for col in categorical_columns:
         if col in X.columns:
             X[col] = X[col].astype("category")
-    # 残存するobject列を除外する（学習時と同様の処理）
-    # object列をcategoryに変換するとモデルのcategorical_featureと不一致になるため
-    X = X.select_dtypes(exclude="object")
 
     positions = df["finish_position"].values.astype(int)
     y_binary = np.where((positions >= 1) & (positions <= 3), 1, 0)
@@ -244,13 +245,12 @@ def plot_monthly_metrics(
         if len(monthly) < 10:
             continue
 
-        feature_cols = [c for c in monthly.columns if c not in exclude_columns and c != "year_month"]
+        model_feature_names = booster.feature_name()
+        feature_cols = [c for c in model_feature_names if c in monthly.columns]
         X = monthly[feature_cols].copy()
         for col in categorical_columns:
             if col in X.columns:
                 X[col] = X[col].astype("category")
-        # 残存するobject列を除外する（学習時と同様の処理）
-        X = X.select_dtypes(exclude="object")
 
         positions = monthly["finish_position"].values.astype(int)
         y_binary = np.where((positions >= 1) & (positions <= 3), 1, 0)


### PR DESCRIPTION
## Summary

- `compute_metrics` と `plot_monthly_metrics` で `select_dtypes(exclude=\"object\")` を使用していたため、BigQueryから取得したデータの数値列が `object` 型として読み込まれた場合に全列が除外されていた
- 結果として特徴量行列 `X` が0列になり `ValueError: Input data must be 2 dimensional and non empty.` が発生していた
- `booster.feature_name()` でモデルが学習時に使用した特徴量名を正確に取得し、その列のみを選択する方式に変更した（学習時の `train.py` と同様の処理）

## 変更箇所

- `scripts/generate_evaluation_report.py`
  - `compute_metrics`: `select_dtypes(exclude="object")` を削除し `booster.feature_name()` による列選択に変更
  - `plot_monthly_metrics`: 同様の修正

## Test plan

- [ ] `python scripts/generate_evaluation_report.py --model-path src/models/lgbm_ranker_20260217.txt --project-id <PROJECT_ID>` が正常終了することを確認
- [ ] `booster.feature_name()` の返す列名がDataFrameに存在することを確認（ログや警告なし）
- [ ] 評価指標（NDCG@3, Recall@3, AUC）が正常に計算されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)