### PR TITLE
fix: 評価レポート生成スクリプトのValueError修正（finish_position NULL・カテゴリエンコーディング不一致）

### DIFF
--- a/scripts/generate_evaluation_report.py
+++ b/scripts/generate_evaluation_report.py
@@ -51,13 +51,21 @@ REPORT_PATH = REPORT_DIR / "model_evaluation_report.md"
 # ---------------------------------------------------------------------------
 
 def fetch_training_data_bq(project_id: str, dataset: str = "features", table: str = "training_data") -> pd.DataFrame:
-    """BigQueryからtraining_dataを取得する"""
+    """BigQueryからtraining_dataを取得する。
+
+    features.training_data の finish_position は常にNULLのため、
+    raw.race_results から finish_position を LEFT JOIN して取得する。
+    """
     from google.cloud import bigquery
     client = bigquery.Client(project=project_id)
     query = f"""
-    SELECT *
-    FROM `{project_id}.{dataset}.{table}`
-    ORDER BY race_date, race_id, horse_number
+    SELECT
+      t.* EXCEPT(finish_position),
+      r.finish_position
+    FROM `{project_id}.{dataset}.{table}` t
+    LEFT JOIN `{project_id}.raw.race_results` r
+      ON t.race_id = r.race_id AND t.horse_number = r.horse_number
+    ORDER BY t.race_date, t.race_id, t.horse_number
     """
     logger.info(f"Fetching data from {project_id}.{dataset}.{table}...")
     df = client.query(query).to_dataframe()
@@ -114,6 +122,37 @@ def load_model_local(model_path: str) -> tuple[lgb.Booster, dict]:
 # 評価計算
 # ---------------------------------------------------------------------------
 
+def _build_feature_matrix(booster: lgb.Booster, df: pd.DataFrame) -> pd.DataFrame:
+    """
+    モデルの特徴量情報を使って予測用の特徴量行列を構築する。
+
+    Booster.predict() に渡す DataFrame は、学習時のカテゴリカル特徴量と
+    pandas_categorical が一致している必要があるため、モデルファイルから
+    categorical_feature インデックスと pandas_categorical を取得して
+    正確にエンコードする。
+    """
+    import re
+
+    feature_names = booster.feature_name()
+    feature_cols = [c for c in feature_names if c in df.columns]
+    X = df[feature_cols].copy()
+
+    # モデルのカテゴリカル特徴量インデックスを取得
+    model_str = booster.model_to_string()
+    match = re.search(r'\[categorical_feature: ([\d,]+)\]', model_str)
+    if match and booster.pandas_categorical:
+        cat_indices = [int(i) for i in match.group(1).split(',')]
+        pandas_cat = booster.pandas_categorical
+        for i, cat_idx in enumerate(cat_indices):
+            if i >= len(pandas_cat):
+                break
+            col_name = feature_names[cat_idx]
+            if col_name in X.columns:
+                X[col_name] = pd.Categorical(X[col_name], categories=pandas_cat[i])
+
+    return X
+
+
 def compute_metrics(
     booster: lgb.Booster,
     df: pd.DataFrame,
@@ -131,15 +170,7 @@ def compute_metrics(
     # finish_positionがNAの行（競走除外・中止馬など）を除外
     df = df[df["finish_position"].notna()].copy()
 
-    # モデルが学習時に使用した特徴量名を取得し、対応する列のみを選択する
-    # select_dtypes(exclude="object") は学習時に行われておらず、
-    # BigQueryからのデータでは数値列がobject型で読み込まれることがあるため使用しない
-    model_feature_names = booster.feature_name()
-    feature_cols = [c for c in model_feature_names if c in df.columns]
-    X = df[feature_cols].copy()
-    for col in categorical_columns:
-        if col in X.columns:
-            X[col] = X[col].astype("category")
+    X = _build_feature_matrix(booster, df)
 
     positions = df["finish_position"].values.astype(int)
     y_binary = np.where((positions >= 1) & (positions <= 3), 1, 0)
@@ -245,12 +276,7 @@ def plot_monthly_metrics(
         if len(monthly) < 10:
             continue
 
-        model_feature_names = booster.feature_name()
-        feature_cols = [c for c in model_feature_names if c in monthly.columns]
-        X = monthly[feature_cols].copy()
-        for col in categorical_columns:
-            if col in X.columns:
-                X[col] = X[col].astype("category")
+        X = _build_feature_matrix(booster, monthly)
 
         positions = monthly["finish_position"].values.astype(int)
         y_binary = np.where((positions >= 1) & (positions <= 3), 1, 0)


### PR DESCRIPTION
## Summary

### 問題1: `finish_position` が全行NULLだった
- `features.training_data` の `finish_position` 列は全479,669行がNULL
- 実際の着順は `raw.race_results` にのみ存在する
- `fetch_training_data_bq()` を修正し、`raw.race_results` を `race_id` + `horse_number` で LEFT JOIN して正しい `finish_position` を取得するよう変更
- 結果: 479,669行中 478,131行に着順データが取得できることを確認済み

### 問題2: カテゴリカル特徴量エンコーディング不一致
- `booster.predict()` は学習時に保存された `pandas_categorical` と一致するカテゴリエンコーディングが必要
- 学習時と異なるカテゴリ型変換を行うと `ValueError: train and valid dataset categorical_feature do not match.` が発生
- `_build_feature_matrix()` ヘルパー関数を追加し、モデルファイルの `categorical_feature` インデックスと `booster.pandas_categorical` を使って正確にエンコードするよう修正

## 変更箇所

- `scripts/generate_evaluation_report.py`
  - `fetch_training_data_bq`: `raw.race_results` LEFT JOIN でfinish_positionを取得
  - `_build_feature_matrix()`: 新規追加（モデルのpandas_categoricalを使った特徴量行列構築）
  - `compute_metrics`: `_build_feature_matrix()` を使用するよう変更
  - `plot_monthly_metrics`: `_build_feature_matrix()` を使用するよう変更

## 実行結果（正常完了を確認）

```
評価指標（検証データ）:
  NDCG@3:   0.5659
  Recall@3: 0.5175
  AUC:      0.8084
  レース数: 1,487
```

## Test plan

- [x] `python scripts/generate_evaluation_report.py --model-path ... --project-id ...` が正常終了することを確認済み
- [x] 評価指標（NDCG@3, Recall@3, AUC）が正常に計算されることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)