### PR TITLE
fix: JRDBダウンロード 403 Forbidden のログレベルを WARNING に降格

### DIFF
--- a/src/automation/data/jrdb_downloader.py
+++ b/src/automation/data/jrdb_downloader.py
@@ -14,6 +14,7 @@ import re
 import shutil
 import subprocess
 import tempfile
+import urllib.error
 import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
@@ -137,6 +138,12 @@ class JRDBDownloader:
         try:
             response = urllib.request.urlopen(url, timeout=30)
             html = response.read().decode("utf-8", errors="ignore")
+        except urllib.error.HTTPError as e:
+            if e.code == 403:
+                logger.warning(f"{url} へのアクセスが禁止されています（403 Forbidden）。このデータタイプは利用できません。")
+            else:
+                logger.error(f"{url}の取得に失敗: {e}")
+            return []
         except Exception as e:
             logger.error(f"{url}の取得に失敗: {e}")
             return []


### PR DESCRIPTION
## 概要

JRDB データダウンロード時に HTTP 403 Forbidden が発生した場合のログレベルを `ERROR` → `WARNING` に変更。

Closes #124

## 変更内容

### 変更ファイル: `src/automation/data/jrdb_downloader.py`

`get_available_dates()` メソッドの例外ハンドリングを改善。

**変更前**: 全 HTTP エラーを `Exception` で一括キャッチし `logger.error` で記録

**変更後**: `urllib.error.HTTPError` を個別キャッチし、ステータスコードで分岐
- **403**: `logger.warning`（アクセス不可として記録、パイプラインは継続）
- **その他（404 等）**: 引き続き `logger.error` で記録
- **非 HTTP エラー（タイムアウト等）**: 引き続き `logger.error` で記録

## 期待されるログ変化

```
# Before
ERROR - http://www.jrdb.com/member/data/Ska/の取得に失敗: HTTP Error 403: Forbidden

# After
WARNING - http://www.jrdb.com/member/data/Ska/ へのアクセスが禁止されています（403 Forbidden）。このデータタイプは利用できません。
```

## テスト計画

- [ ] `urllib.error.HTTPError(code=403)` で WARNING ログが出ること
- [ ] `urllib.error.HTTPError(code=404)` で ERROR ログが出ること
- [ ] `Exception` で ERROR ログが出ること（非 HTTP エラー）

🤖 Generated with [Claude Code](https://claude.com/claude-code)