### PR TITLE
fix: 日次パイプラインのBQロード対象を直近7日間（当日含む）に絞り込む

### DIFF
--- a/src/automation/data/load_to_bq.py
+++ b/src/automation/data/load_to_bq.py
@@ -692,6 +692,7 @@ class BigQueryLoader:
         prefix: Optional[str] = None,
         data_types: Optional[List[str]] = None,
         date_filter: Optional[str] = None,
+        within_days: Optional[int] = None,
     ) -> List[str]:
         """
         GCSバケット内のCSVファイルを一覧取得
@@ -700,12 +701,21 @@ class BigQueryLoader:
             prefix: GCS上のプレフィックス (オプション)
             data_types: フィルタするデータタイプのリスト (オプション)
             date_filter: ファイル名の日付文字列 yymmdd 形式 (例: "260301")
+            within_days: 実行日当日を含む直近N日分のみを対象とする (オプション)
+                例: within_days=7 の場合、実行日-6日〜実行日（当日）のファイルのみ対象
 
         Returns:
             ファイルパスのリスト
         """
         bucket = self.storage_client.bucket(self.bucket_name)
         blobs = bucket.list_blobs(prefix=prefix)
+
+        # 日付範囲フィルタの基準日を事前計算
+        date_cutoff: Optional[str] = None
+        if within_days is not None:
+            cutoff = datetime.now().date() - timedelta(days=within_days - 1)
+            date_cutoff = cutoff.strftime("%Y-%m-%d")
+            logger.info(f"日付範囲フィルタ: {date_cutoff} 以降のファイルのみ対象 (直近{within_days}日間)")
 
         csv_files = []
         for blob in blobs:
@@ -723,6 +733,12 @@ class BigQueryLoader:
             # 日付フィルタ（ファイル名に yymmdd が含まれるか）
             if date_filter and date_filter not in blob.name:
                 continue
+
+            # 日付範囲フィルタ（直近N日間）
+            if date_cutoff is not None:
+                file_date = extract_file_date(blob.name)
+                if file_date is None or file_date < date_cutoff:
+                    continue
 
             csv_files.append(blob.name)
             # GCS更新タイムスタンプをキャッシュ (load_files_batch() でのスキップ判定に使用)

--- a/src/automation/pipeline/daily_pipeline.py
+++ b/src/automation/pipeline/daily_pipeline.py
@@ -318,9 +318,10 @@ class DailyPipeline:
 
             # GCS上のサポート対象データタイプのファイルを一括取得
             # （このタイミングで _blob_updated_cache が更新される）
+            # 日次パイプラインは直近7日間（当日含む）のみを対象とする
             supported_types = list(TABLE_MAPPING.keys())
             csv_files = self.bq_loader.list_csv_files(
-                prefix="", data_types=supported_types
+                prefix="", data_types=supported_types, within_days=7
             )
 
             if not csv_files:

--- a/tests/test_daily_pipeline.py
+++ b/tests/test_daily_pipeline.py
@@ -230,10 +230,11 @@ class TestDailyPipelineStepLoadToBq:
         assert result.status == "success"
         assert result.details["files"] == 2
         assert result.details["records"] == 100
-        # data_typesフィルタが渡されていることを確認
+        # data_typesフィルタと within_days=7 が渡されていることを確認
         call_args = bq_loader.list_csv_files.call_args
         assert "data_types" in call_args[1]
         assert "BAA" in call_args[1]["data_types"]
+        assert call_args[1].get("within_days") == 7
         # skip_loadedが有効で全ファイルがバッチに渡されることを確認
         batch_call_args = bq_loader.load_files_batch.call_args
         assert len(batch_call_args[0][0]) == 3

--- a/tests/test_load_to_bq.py
+++ b/tests/test_load_to_bq.py
@@ -3,7 +3,7 @@ load_to_bq モジュールのユニットテスト
 """
 
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -379,6 +379,68 @@ class TestBigQueryLoaderListFiles:
         # キャッシュにGCS更新日時が格納されていること
         assert "BAA260301.csv" in loader._blob_updated_cache
         assert loader._blob_updated_cache["BAA260301.csv"] == gcs_updated
+
+    @patch("google.cloud.storage.Client")
+    def test_list_csv_files_within_days_filters_old_files(self, mock_storage_client):
+        """within_days 指定時、カットオフ日より古いファイルが除外される"""
+        from datetime import date, timedelta
+        from unittest.mock import patch as mock_patch
+
+        loader = BigQueryLoader(project_id="test-project")
+
+        today = date(2026, 3, 5)
+        # 当日・6日前（境界値）は対象、7日前は除外
+        names = [
+            "Baa/BAA260305.csv",  # 当日 → 対象
+            "Baa/BAA260227.csv",  # 6日前 → 対象（境界値）
+            "Baa/BAA260226.csv",  # 7日前 → 除外
+            "Baa/BAA201017.csv",  # 2020年 → 除外
+        ]
+        mock_blobs = []
+        for name in names:
+            b = MagicMock()
+            b.name = name
+            b.updated = datetime(2026, 3, 5, 0, 0, 0, tzinfo=timezone.utc)
+            mock_blobs.append(b)
+
+        mock_bucket = MagicMock()
+        mock_bucket.list_blobs.return_value = mock_blobs
+        mock_client = MagicMock()
+        mock_client.bucket.return_value = mock_bucket
+        mock_storage_client.return_value = mock_client
+
+        with mock_patch("src.automation.data.load_to_bq.datetime") as mock_dt:
+            mock_dt.now.return_value.date.return_value = today
+            result = loader.list_csv_files(within_days=7)
+
+        assert "Baa/BAA260305.csv" in result   # 当日
+        assert "Baa/BAA260227.csv" in result   # 境界値（含む）
+        assert "Baa/BAA260226.csv" not in result  # 境界外（除外）
+        assert "Baa/BAA201017.csv" not in result  # 古いファイル（除外）
+
+    @patch("google.cloud.storage.Client")
+    def test_list_csv_files_within_days_none_returns_all(self, mock_storage_client):
+        """within_days=None（デフォルト）の場合、日付フィルタなしで全件返す"""
+        loader = BigQueryLoader(project_id="test-project")
+
+        names = ["Baa/BAA260305.csv", "Baa/BAA201017.csv"]
+        mock_blobs = []
+        for name in names:
+            b = MagicMock()
+            b.name = name
+            b.updated = datetime(2026, 3, 5, 0, 0, 0, tzinfo=timezone.utc)
+            mock_blobs.append(b)
+
+        mock_bucket = MagicMock()
+        mock_bucket.list_blobs.return_value = mock_blobs
+        mock_client = MagicMock()
+        mock_client.bucket.return_value = mock_bucket
+        mock_storage_client.return_value = mock_client
+
+        result = loader.list_csv_files()  # within_days 未指定
+
+        assert "Baa/BAA260305.csv" in result
+        assert "Baa/BAA201017.csv" in result
 
 
 class TestBigQueryLoaderBatchLoad:


### PR DESCRIPTION
## 概要

日次パイプラインのBQロード処理でGCSから14,326件のファイルを検出していた問題を修正。ファイル名の日付を基準に直近7日間のみを対象とし、処理件数を大幅に削減する。

Closes #127

## 変更内容

### `src/automation/data/load_to_bq.py`

`list_csv_files()` に `within_days: Optional[int] = None` パラメータを追加。

- 指定時: ファイル名から日付を抽出（既存の `extract_file_date()` を利用）し、`実行日 - (N-1)日` 以降のファイルのみ返す
- 実行日（当日）は必ず対象に含まれる
- 日付が抽出できないファイルは除外
- `None`（デフォルト）で従来通り全件返す

```
within_days=7, 実行日=2026-03-05 の場合:
  2026-02-27 〜 2026-03-05 → 対象
  2026-02-26 以前          → 除外
```

### `src/automation/pipeline/daily_pipeline.py`

`list_csv_files()` 呼び出しに `within_days=7` を追加。

### テスト追加

| テストケース | 内容 |
|------------|------|
| `test_list_csv_files_within_days_filters_old_files` | 境界値テスト（当日・6日前は対象、7日前・2020年は除外） |
| `test_list_csv_files_within_days_none_returns_all` | デフォルト動作（全件返す）の確認 |
| `test_step_load_to_bq_success` のアサーション追加 | `within_days=7` が呼び出し時に渡されること |

## 期待される効果

| 指標 | 変更前 | 変更後（推定） |
|------|--------|---------------|
| 検出ファイル数 | 14,326件 | 〜50件 |
| BQロード処理時間 | 約1〜2時間 | 数分程度 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)