### PR TITLE
fix: predict.py で --project-id 未指定時に ADC からプロジェクトIDを自動検出

### DIFF
--- a/src/models/predict.py
+++ b/src/models/predict.py
@@ -567,9 +567,20 @@ def main():
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     )
 
-    if not args.project_id:
-        logger.error("GCP_PROJECT_IDが設定されていません")
+    project_id = args.project_id
+    if not project_id:
+        try:
+            import google.auth
+            _, project_id = google.auth.default()
+        except Exception:
+            pass
+    if not project_id:
+        logger.error(
+            "GCPプロジェクトIDを特定できません。"
+            "--project-id オプションまたは GCP_PROJECT_ID 環境変数を設定してください。"
+        )
         return 1
+    logger.info(f"使用するGCPプロジェクトID: {project_id}")
 
     config = load_config(args.config)
     execution_date = datetime.date.fromisoformat(args.execution_date)
@@ -585,7 +596,7 @@ def main():
             return 1
 
     result_df = predict_pipeline(
-        project_id=args.project_id,
+        project_id=project_id,
         execution_date=execution_date,
         config=config,
         model_path=args.model_path,
@@ -604,7 +615,7 @@ def main():
     if args.save_to_bq and len(result_df) > 0:
         saved_rows = save_predictions_to_bq(
             result_df=result_df,
-            project_id=args.project_id,
+            project_id=project_id,
         )
         print(f"\n{saved_rows}行をBigQuery（predictions.daily_predictions）に保存しました")
 


### PR DESCRIPTION
## Summary

- `--project-id` が未指定または空の場合、`google.auth.default()` を使って ADC（Application Default Credentials）からプロジェクトIDを自動取得するフォールバックを追加
- 優先順位: `--project-id` 引数 → `GCP_PROJECT_ID` 環境変数 → ADC 自動検出
- 起動時に使用するプロジェクトIDをINFOログで表示するようにした

## 背景

`--project-id keiba-prediction-176873411`（誤ったID）を指定した際、BigQuery API が "ProjectId must be non-empty" という紛らわしいエラーを返し原因特定が困難だった。正しいプロジェクトIDは gcloud config に `keiba-prediction-1768734113` として設定されている。本修正により、`--project-id` を省略しても gcloud の設定から自動検出されるため、同様のタイポを防げる。

## Test plan

- [x] `--project-id` 未指定で実行 → `keiba-prediction-1768734113` が自動検出され BQ クエリが正常実行されることを確認
- [x] 正しいプロジェクトIDを `--project-id` で明示指定しても正常動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)