### PR TITLE
fix: 日次パイプラインのダウンロード・特徴量生成の日付範囲を翌日まで拡張

### DIFF
--- a/src/automation/pipeline/daily_pipeline.py
+++ b/src/automation/pipeline/daily_pipeline.py
@@ -196,13 +196,15 @@ class DailyPipeline:
             DOWNLOAD_LOOKBACK_DAYS = 7
             lookback_date = target_date - timedelta(days=DOWNLOAD_LOOKBACK_DAYS)
             start_yymmdd = self.date_to_yymmdd(lookback_date)
+            # 翌日分（翌日のレースデータ）までダウンロード
+            end_yymmdd = self.date_to_yymmdd(target_date + timedelta(days=1))
             logger.info(
-                f"ダウンロード開始: {start_yymmdd}〜 "
+                f"ダウンロード開始: {start_yymmdd}〜{end_yymmdd} "
                 f"（{DOWNLOAD_LOOKBACK_DAYS}日間ルックバック、対象日: {self.date_to_yymmdd(target_date)}）"
             )
 
-            # 全データタイプをダウンロード（7日前から最新まで）
-            results = self.downloader.download_all_from_date(start_yymmdd)
+            # 全データタイプをダウンロード（7日前から翌日まで）
+            results = self.downloader.download_all_from_date(start_yymmdd, end_yymmdd)
 
             # 結果集計
             total_downloaded = sum(r.downloaded_files for r in results.values())
@@ -425,11 +427,13 @@ class DailyPipeline:
 
         try:
             date_str = target_date.strftime("%Y-%m-%d")
-            logger.info(f"特徴量生成開始: {date_str}")
+            # 翌日分の特徴量まで生成（予測パイプラインが当日+翌日を対象とするため）
+            next_date_str = (target_date + timedelta(days=1)).strftime("%Y-%m-%d")
+            logger.info(f"特徴量生成開始: {date_str} 〜 {next_date_str}")
 
             result = self.feature_pipeline.run(
                 start_date=date_str,
-                end_date=date_str,
+                end_date=next_date_str,
             )
 
             details = {

--- a/tests/test_daily_pipeline.py
+++ b/tests/test_daily_pipeline.py
@@ -84,8 +84,8 @@ class TestDailyPipelineStepDownload:
         assert result.details["downloaded"] == 5
         assert result.details["skipped"] == 3
         assert result.details["failed"] == 0
-        # 7日前 (2024-01-15 - 7日 = 2024-01-08) が渡されること
-        downloader.download_all_from_date.assert_called_once_with("240108")
+        # 7日前 (2024-01-15 - 7日 = 2024-01-08) が start_date, 翌日 (240116) が end_date として渡されること
+        downloader.download_all_from_date.assert_called_once_with("240108", "240116")
 
     def test_step_download_partial(self):
         """一部ダウンロード失敗"""
@@ -129,8 +129,8 @@ class TestDailyPipelineStepDownload:
         pipeline = DailyPipeline(downloader=downloader)
         pipeline._step_download(date(2024, 1, 15))  # 240115
 
-        # 7日前 = 240108 が渡されること
-        downloader.download_all_from_date.assert_called_once_with("240108")
+        # start_date=240108 (7日前), end_date=240116 (翌日) が渡されること
+        downloader.download_all_from_date.assert_called_once_with("240108", "240116")
 
     def test_step_download_lookback_crosses_month_boundary(self):
         """月をまたぐルックバックが正しく計算される: 2024-03-05 - 7日 = 2024-02-27"""
@@ -146,8 +146,8 @@ class TestDailyPipelineStepDownload:
         pipeline = DailyPipeline(downloader=downloader)
         pipeline._step_download(date(2024, 3, 5))  # 240305
 
-        # 7日前 = 240227 が渡されること
-        downloader.download_all_from_date.assert_called_once_with("240227")
+        # start_date=240227 (7日前), end_date=240306 (翌日) が渡されること
+        downloader.download_all_from_date.assert_called_once_with("240227", "240306")
 
 
 class TestDailyPipelineStepUpload:
@@ -486,7 +486,7 @@ class TestDailyPipelineRun:
         assert len(result.steps) == 4
         downloader.cleanup.assert_called_once()
         feature_pipeline.run.assert_called_once_with(
-            start_date="2024-01-15", end_date="2024-01-15"
+            start_date="2024-01-15", end_date="2024-01-16"
         )
 
     def test_run_download_failure(self):
@@ -533,7 +533,7 @@ class TestDailyPipelineStepGenerateFeatures:
         assert result.details["inserted_rows"] == 50
         assert result.details["deleted_rows"] == 10
         feature_pipeline.run.assert_called_once_with(
-            start_date="2024-01-15", end_date="2024-01-15"
+            start_date="2024-01-15", end_date="2024-01-16"
         )
 
     def test_step_generate_features_error(self):


### PR DESCRIPTION
## 背景

2026-03-07の Cloud Run 日次バッチ（6:00 JST）と手動実行（`full_load_pipeline --start-date 2026-03-06 --end-date 2026-03-07`）のログを比較した結果、2つの差異が判明した。

## 問題

### 問題1: ダウンロードの `end_date` が `None` で際限なくダウンロード

`_step_download` で `download_all_from_date(start_yymmdd)` を `end_date=None` で呼んでいたため、JRDBに存在する最新ファイル（翌日翌日分など）まで際限なくダウンロードしていた。

- 手動実行: `--end-date 2026-03-07`（翌日まで）
- Cloud Run: `end_date=None` → 260308（翌々日）まで取得

### 問題2: 特徴量生成が `target_date` の1日分のみ → 予測が0行

`_step_generate_features` で `end_date=target_date` の1日分しか特徴量を生成していなかった。
予測パイプライン（`POST /api/v1/predict/daily`）は `compute_week_boundaries(target_date)` で**当週土曜・日曜**を推論対象とするため、翌日分の特徴量がないと 0 行を返す。

| 項目 | 手動実行（期待動作） | Cloud Run（修正前） |
|------|-------------|------------|
| ダウンロード対象 | 〜260307（翌日まで） | 〜260308以降（際限なし） |
| 特徴量生成 | 2026-03-06〜**2026-03-07** | 2026-03-06のみ |
| 予測結果 | - | **0行**（3/7, 3/8の特徴量欠如） |

## 修正内容

`src/automation/pipeline/daily_pipeline.py` の2箇所を修正。

### `_step_download`
```python
# 修正前
results = self.downloader.download_all_from_date(start_yymmdd)

# 修正後
end_yymmdd = self.date_to_yymmdd(target_date + timedelta(days=1))
results = self.downloader.download_all_from_date(start_yymmdd, end_yymmdd)
```

### `_step_generate_features`
```python
# 修正前
result = self.feature_pipeline.run(start_date=date_str, end_date=date_str)

# 修正後
next_date_str = (target_date + timedelta(days=1)).strftime("%Y-%m-%d")
result = self.feature_pipeline.run(start_date=date_str, end_date=next_date_str)
```

これにより手動実行（`--start-date 2026-03-06 --end-date 2026-03-07`）と同等の動作になる。Cloud Scheduler が毎日6AM実行する場合も「当日＋翌日分」を確実にカバーする。

## Issue #116（ロード履歴スキップ改善）との整合性

- 解決策A（GCSタイムスタンプ比較）・解決策B（日曜強制再ロード）は `load_to_bq.py` / `daily_pipeline._step_load_to_bq` に既に実装済み
- 今回の修正は両解決策と互換性あり。`end_date=翌日` に制限することで先取りロードが減り、解決策Aがより素直に機能する
- 日曜バッチの解決策Bは `date_str=target_date` をフィルタに使うため、翌日（+1日）ファイルの強制再ロード混入は起きない

## テスト

- `tests/test_daily_pipeline.py` の関連アサーション3箇所を新しい引数（`end_date`付き）に更新
- `python3 -m pytest tests/test_daily_pipeline.py` → 39件 全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)