### PR TITLE
feat: Issue #105, #134 - 投資戦略パイプラインと組み合わせ馬券オッズ取得

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,80 @@ python scripts/run_backtest.py \
 | `--output-chart` | なし | 資金推移グラフ保存先パス |
 | `--save-to-bq` | False | BigQuery保存フラグ |
 
-### 7. Cloud Runデプロイ（本番環境）
+### 7. 投資戦略策定
+
+#### A. パラメータ最適化（手動、初回および月次実行）
+
+グリッドサーチで最適な投資パラメータを探索し、`config/strategy_config.yaml` に保存する。
+**この手順を一度実行するだけで、以降の日次自動実行（手順B）が正しいパラメータで動作する。**
+
+```bash
+# パラメータ最適化を実行（strategy_config.yamlを更新）
+python3 scripts/run_strategy_optimization.py \
+    --project-id <PROJECT_ID> \
+    --model-path gs://<PROJECT_ID>-keiba-models/lgbm_ranker/20260301/model.txt \
+    --start-date 2024-01-01 \
+    --end-date 2024-12-31
+
+# 詳細オプション指定
+python3 scripts/run_strategy_optimization.py \
+    --project-id <PROJECT_ID> \
+    --model-path gs://<PROJECT_ID>-keiba-models/lgbm_ranker/20260301/model.txt \
+    --start-date 2024-01-01 \
+    --end-date 2024-12-31 \
+    --metric recovery_rate \
+    --output-csv results/optimization_2024.csv \
+    --top-n 10
+```
+
+**主なオプション:**
+
+| オプション | デフォルト | 説明 |
+|-----------|-----------|------|
+| `--project-id` | 必須 | GCPプロジェクトID |
+| `--model-path` | 必須 | モデルファイルパス（ローカルまたは gs://） |
+| `--start-date` | 必須 | 最適化期間開始日 (YYYY-MM-DD) |
+| `--end-date` | 必須 | 最適化期間終了日 (YYYY-MM-DD) |
+| `--metric` | recovery_rate | 最適化指標（recovery_rate / hit_rate / sharpe_ratio / max_drawdown） |
+| `--initial-capital` | 100000 | 初期資金（円） |
+| `--output-csv` | なし | 全グリッドサーチ結果のCSV保存先 |
+| `--top-n` | 10 | 上位N件を表示 |
+
+#### B. 日次投資戦略策定（手動確認用 / Cloud Schedulerで自動実行）
+
+`config/strategy_config.yaml` のパラメータを読み込んで投資判断を実行する。
+`POST /api/v1/strategy/daily` から毎朝 AM 9:00 に Cloud Scheduler で自動実行されるが、
+スクリプトを手動実行して内容を確認することもできる。
+
+```bash
+# 当日分の投資戦略を実行（BQ保存あり）
+python3 scripts/run_strategy.py --project-id <PROJECT_ID>
+
+# 特定日を指定
+python3 scripts/run_strategy.py --project-id <PROJECT_ID> --target-date 2026-03-07
+
+# BQ保存をスキップして結果を確認のみ（dry-run）
+python3 scripts/run_strategy.py --project-id <PROJECT_ID> --dry-run
+```
+
+**主なオプション:**
+
+| オプション | デフォルト | 説明 |
+|-----------|-----------|------|
+| `--project-id` | 必須 | GCPプロジェクトID |
+| `--target-date` | 当日 | 対象日（YYYY-MM-DD） |
+| `--dry-run` | False | BQ保存をスキップして結果表示のみ |
+| `--initial-capital` | 100000 | 初期資金（円） |
+
+> **前提条件**: `predictions.daily_predictions`（予測）と `predictions.daily_odds`（オッズ）に当日データが存在すること。
+
+**investment_decisions テーブル作成（初回のみ）:**
+
+```bash
+python3 scripts/create_investment_decisions_table.py --project-id <PROJECT_ID>
+```
+
+### 8. Cloud Runデプロイ（本番環境）
 
 ```bash
 # Dockerイメージのビルド・プッシュ
@@ -475,11 +548,14 @@ keiba_prediction/
 │       ├── strategy.py               # 投資戦略（Kelly基準・期待回収率フィルタ）
 │       └── strategy_optimizer.py     # 戦略パラメータ最適化
 ├── scripts/                           # ユーティリティスクリプト
+│   ├── create_daily_odds_combo_table.py  # predictions.daily_odds_comboテーブル作成
 │   ├── create_daily_odds_table.py    # predictions.daily_oddsテーブル作成
 │   ├── create_predictions_table.py   # predictions.daily_predictionsテーブル作成
 │   ├── generate_features.py
 │   ├── reload_gcs_to_bq.py
 │   ├── run_backtest.py               # CLIバックテスト実行スクリプト
+│   ├── run_strategy.py               # 日次投資戦略策定スクリプト（手動確認用）
+│   ├── run_strategy_optimization.py  # 投資パラメータ最適化スクリプト（手動実行）
 │   ├── setup_bigquery.sh
 │   ├── setup_gcp.sh
 │   └── sync_to_gcs.sh
@@ -609,7 +685,8 @@ Cloud RunにデプロイされたFastAPIアプリケーションは以下のエ�
 | POST | `/api/v1/features/generate/async` | 特徴量生成（非同期） |
 | POST | `/api/v1/predict/daily` | 翌日レース予測 + BQ/GCS保存（Cloud Scheduler用）。`model_path` 未指定時はGCSから最新モデルを自動取得。 |
 | POST | `/api/v1/predict/on-demand` | 任意日付レース予測 + BQ/GCS保存（手動実行用） |
-| POST | `/api/v1/odds/scrape` | netkeibaから当日オッズを取得し `predictions.daily_odds` にUPSERT保存 |
+| POST | `/api/v1/odds/scrape` | netkeibaから当日オッズを取得し `predictions.daily_odds` にUPSERT保存。`include_combo=true` で組み合わせ馬券オッズも取得し `predictions.daily_odds_combo` に保存。 |
+| POST | `/api/v1/strategy/daily` | 当日の投資戦略を策定し `predictions.investment_decisions` にUPSERT保存。`config/strategy_config.yaml` のパラメータを使用。 |
 
 ---
 
@@ -895,6 +972,8 @@ gcloud scheduler jobs run daily-data-pipeline --location=asia-northeast1
 |---------|------|------|
 | `predictions.daily_predictions` | 日次予測結果 | 実装済み（Issue #117） |
 | `predictions.daily_odds` | netkeibaリアルタイム単複オッズ | 実装済み（Issue #131） |
+| `predictions.daily_odds_combo` | netkeibaリアルタイム組み合わせ馬券オッズ | 実装済み（Issue #134） |
+| `predictions.investment_decisions` | 日次投資判断結果 | 実装済み（Issue #105） |
 
 #### daily_predictions テーブルスキーマ
 
@@ -938,6 +1017,44 @@ python3 scripts/create_predictions_table.py
 ```bash
 python3 scripts/create_daily_odds_table.py --project-id <PROJECT_ID>
 ```
+
+#### daily_odds_combo テーブルスキーマ
+
+| カラム名 | 型 | 説明 |
+|---------|-----|------|
+| `race_id` | STRING | JRDB形式のレースID（パーティション連携） |
+| `race_date` | DATE | 開催日（パーティションキー） |
+| `ticket_type` | STRING | 馬券種（umaren / umatan / wide / sanrenpuku） |
+| `horse_number_1` | INTEGER | 馬番1（小さい方） |
+| `horse_number_2` | INTEGER | 馬番2 |
+| `horse_number_3` | INTEGER | 馬番3（三連複のみ、それ以外はNULL） |
+| `odds` | FLOAT64 | オッズ |
+| `scraped_at` | TIMESTAMP | netkeibaからスクレイプした日時（UTC） |
+
+テーブル作成コマンド:
+
+```bash
+python3 scripts/create_daily_odds_combo_table.py --project-id <PROJECT_ID>
+```
+
+#### investment_decisions テーブルスキーマ
+
+| カラム名 | 型 | 説明 |
+|---------|-----|------|
+| `race_id` | STRING | JRDB形式のレースID |
+| `race_date` | DATE | 開催日 |
+| `horse_id` | STRING | 馬ID |
+| `horse_number` | INTEGER | 馬番 |
+| `horse_name` | STRING | 馬名 |
+| `venue_code` | STRING | 競馬場コード |
+| `race_number` | INTEGER | レース番号 |
+| `race_pattern` | STRING | レースパターン（one_dominant / competitive / standard） |
+| `bet_type` | STRING | 馬券種（place など） |
+| `bet_amount` | FLOAT64 | 賭け金（円） |
+| `win_place_prob` | FLOAT64 | 複勝予測確率 |
+| `place_odds` | FLOAT64 | 複勝オッズ |
+| `expected_return` | FLOAT64 | 期待回収率（prob × odds） |
+| `created_at` | TIMESTAMP | 作成日時（UTC） |
 
 ### backtestsデータセット
 
@@ -1034,6 +1151,13 @@ python -m pytest tests/ --cov=src --cov-report=html
   - `POST /api/v1/odds/scrape`: netkeibaから当日全レースの単複オッズを取得
   - `predictions.daily_odds` テーブルへのUPSERT保存（race_id + horse_numberキー）
   - Playwright (Chromium) によるJS描画ページ対応
+- ✅ netkeibaスクレイパー拡張（組み合わせ馬券オッズ） - Issue #134
+  - `POST /api/v1/odds/scrape` の `include_combo=true`: 馬連・馬単・ワイド・三連複オッズ取得
+  - `predictions.daily_odds_combo` テーブルへのUPSERT保存
+- ✅ 日次投資戦略策定 - Issue #105
+  - `POST /api/v1/strategy/daily`: 予測×オッズからKelly基準で投資判断を実行
+  - `predictions.investment_decisions` テーブルへのUPSERT保存
+  - `config/strategy_config.yaml` でパラメータ管理（`run_strategy_optimization.py` で最適化）
 - ⬜ Webダッシュボード
 - ⬜ 通知システム（LINE Messaging API）
 

--- a/config/strategy_config.yaml
+++ b/config/strategy_config.yaml
@@ -1,0 +1,39 @@
+# 投資戦略パラメータ設定
+#
+# このファイルは scripts/run_strategy_optimization.py を実行することで更新されます。
+# 更新後は scripts/run_strategy.py（および POST /api/v1/strategy/daily）が
+# このファイルのパラメータを自動的に読み込んで日次実行します。
+#
+# 手動で更新する場合は以下の説明を参考にしてください。
+#
+# パターン分類パラメータ
+#   p1: 突出型（one_dominant）の判定閾値。
+#       top1_prob - top2_prob > p1 の場合に突出型と判定。
+#       小さいほど多くのレースが突出型になる（デフォルト: 0.2）
+#   p2: 拮抗型（competitive）の判定閾値。
+#       top1_prob - top3_prob < p2 の場合に拮抗型と判定。
+#       大きいほど多くのレースが拮抗型になる（デフォルト: 0.15）
+
+# パターン分類閾値
+p1: 0.2
+p2: 0.15
+
+# 期待回収率フィルタ（win_place_prob × odds がこれを超える馬のみ購入）
+expected_return_threshold: 1.2
+
+# Fractional Kelly 係数（0〜1。小さいほど保守的）
+kelly_fraction: 0.25
+
+# 1レースあたりの最大賭け金比率（総資金に対する割合）
+max_bet_ratio: 0.05
+
+# グリッドサーチで最適化した際のメタ情報（run_strategy_optimization.py が書き込む）
+optimization:
+  last_run: null          # 最後に最適化を実行した日時（ISO形式）
+  metric: recovery_rate   # 最適化に使用した評価指標
+  start_date: null        # バックテスト開始日（YYYY-MM-DD）
+  end_date: null          # バックテスト終了日（YYYY-MM-DD）
+  recovery_rate: null     # 最適化時の回収率（%）
+  hit_rate: null          # 最適化時の的中率（%）
+  max_drawdown: null      # 最適化時の最大ドローダウン（%）
+  total_bets: null        # 最適化時の総賭け数

--- a/scripts/create_daily_odds_combo_table.py
+++ b/scripts/create_daily_odds_combo_table.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""
+predictions.daily_odds_combo テーブル作成スクリプト
+
+馬連・馬単・ワイド・三連複の組み合わせ馬券オッズを保存するテーブルを作成する。
+このスクリプトは初回セットアップ時に一度だけ実行してください。
+
+Usage:
+    python scripts/create_daily_odds_combo_table.py --project-id <PROJECT_ID>
+
+Issue #134: netkeibaスクレイパー拡張 - 組み合わせ馬券オッズ取得
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+from google.cloud import bigquery
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+load_dotenv()
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+SCHEMA = [
+    bigquery.SchemaField("race_id", "STRING", mode="REQUIRED", description="JRDB形式のレースID"),
+    bigquery.SchemaField("race_date", "DATE", mode="REQUIRED", description="開催日（パーティションキー）"),
+    bigquery.SchemaField(
+        "ticket_type", "STRING", mode="REQUIRED",
+        description="馬券種 (umaren / umatan / wide / sanrenpuku)",
+    ),
+    bigquery.SchemaField("horse_number_1", "INTEGER", mode="REQUIRED", description="馬番1（小さい方）"),
+    bigquery.SchemaField("horse_number_2", "INTEGER", mode="REQUIRED", description="馬番2"),
+    bigquery.SchemaField("horse_number_3", "INTEGER", mode="NULLABLE", description="馬番3（三連複のみ）"),
+    bigquery.SchemaField("odds", "FLOAT64", mode="NULLABLE", description="オッズ"),
+    bigquery.SchemaField("scraped_at", "TIMESTAMP", mode="REQUIRED", description="スクレイプ日時（UTC）"),
+]
+
+
+def create_table(project_id: str) -> None:
+    client = bigquery.Client(project=project_id)
+    dataset_id = "predictions"
+    table_id = "daily_odds_combo"
+    full_table_id = f"{project_id}.{dataset_id}.{table_id}"
+
+    # データセットが存在しない場合は作成
+    dataset_ref = bigquery.Dataset(f"{project_id}.{dataset_id}")
+    dataset_ref.location = "US"
+    try:
+        client.get_dataset(dataset_ref)
+    except Exception:
+        client.create_dataset(dataset_ref, exists_ok=True)
+        logger.info(f"データセット作成: {dataset_id}")
+
+    table = bigquery.Table(full_table_id, schema=SCHEMA)
+
+    # パーティション設定
+    table.time_partitioning = bigquery.TimePartitioning(
+        type_=bigquery.TimePartitioningType.DAY,
+        field="race_date",
+    )
+    # クラスタリング: race_id + ticket_type で絞り込み高速化
+    table.clustering_fields = ["race_id", "ticket_type"]
+
+    table = client.create_table(table, exists_ok=True)
+    logger.info(f"テーブル作成完了: {full_table_id}")
+    logger.info(f"  パーティション: race_date (DAY)")
+    logger.info(f"  クラスタリング: race_id, ticket_type")
+    logger.info(f"  ticket_type の値: umaren / umatan / wide / sanrenpuku")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="predictions.daily_odds_combo テーブル作成")
+    parser.add_argument("--project-id", default=os.environ.get("GCP_PROJECT_ID"))
+    args = parser.parse_args()
+
+    if not args.project_id:
+        parser.error("--project-id または GCP_PROJECT_ID 環境変数を設定してください")
+
+    create_table(args.project_id)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/create_investment_decisions_table.py
+++ b/scripts/create_investment_decisions_table.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""
+predictions.investment_decisions テーブル作成スクリプト
+
+日次投資戦略策定の結果を保存するテーブルを作成する。
+このスクリプトは初回セットアップ時に一度だけ実行してください。
+
+Usage:
+    python scripts/create_investment_decisions_table.py --project-id <PROJECT_ID>
+
+Issue #105: 投資戦略モジュールをバックテストパイプラインに統合
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+from google.cloud import bigquery
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+load_dotenv()
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+SCHEMA = [
+    bigquery.SchemaField("race_id", "STRING", mode="REQUIRED", description="JRDB形式のレースID"),
+    bigquery.SchemaField("race_date", "DATE", mode="REQUIRED", description="開催日（パーティションキー）"),
+    bigquery.SchemaField("horse_id", "STRING", mode="NULLABLE", description="馬ID"),
+    bigquery.SchemaField("horse_number", "INTEGER", mode="REQUIRED", description="馬番"),
+    bigquery.SchemaField("horse_name", "STRING", mode="NULLABLE", description="馬名"),
+    bigquery.SchemaField("venue_code", "STRING", mode="NULLABLE", description="競馬場コード"),
+    bigquery.SchemaField("race_number", "INTEGER", mode="NULLABLE", description="レース番号"),
+    bigquery.SchemaField(
+        "race_pattern", "STRING", mode="NULLABLE",
+        description="レースパターン (one_dominant / competitive / standard)",
+    ),
+    bigquery.SchemaField("bet_type", "STRING", mode="NULLABLE", description="馬券種 (place など)"),
+    bigquery.SchemaField("bet_amount", "FLOAT64", mode="NULLABLE", description="賭け金（円）"),
+    bigquery.SchemaField("win_place_prob", "FLOAT64", mode="NULLABLE", description="複勝予測確率（0〜1）"),
+    bigquery.SchemaField("place_odds", "FLOAT64", mode="NULLABLE", description="複勝オッズ"),
+    bigquery.SchemaField(
+        "expected_return", "FLOAT64", mode="NULLABLE",
+        description="期待回収率（win_place_prob × place_odds）",
+    ),
+    bigquery.SchemaField("created_at", "TIMESTAMP", mode="REQUIRED", description="レコード作成日時（UTC）"),
+]
+
+
+def create_table(project_id: str) -> None:
+    client = bigquery.Client(project=project_id)
+    dataset_id = "predictions"
+    table_id = "investment_decisions"
+    full_table_id = f"{project_id}.{dataset_id}.{table_id}"
+
+    dataset_ref = bigquery.Dataset(f"{project_id}.{dataset_id}")
+    dataset_ref.location = "US"
+    try:
+        client.get_dataset(dataset_ref)
+    except Exception:
+        client.create_dataset(dataset_ref, exists_ok=True)
+        logger.info(f"データセット作成: {dataset_id}")
+
+    table = bigquery.Table(full_table_id, schema=SCHEMA)
+
+    table.time_partitioning = bigquery.TimePartitioning(
+        type_=bigquery.TimePartitioningType.DAY,
+        field="race_date",
+    )
+    table.clustering_fields = ["race_id"]
+
+    client.create_table(table, exists_ok=True)
+    logger.info(f"テーブル作成完了: {full_table_id}")
+    logger.info(f"  パーティション: race_date (DAY)")
+    logger.info(f"  クラスタリング: race_id")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="predictions.investment_decisions テーブル作成")
+    parser.add_argument("--project-id", default=os.environ.get("GCP_PROJECT_ID"))
+    args = parser.parse_args()
+
+    if not args.project_id:
+        parser.error("--project-id または GCP_PROJECT_ID 環境変数を設定してください")
+
+    create_table(args.project_id)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_strategy.py
+++ b/scripts/run_strategy.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+"""
+日次投資戦略策定スクリプト
+
+config/strategy_config.yaml のパラメータを読み込み、
+当日の予測結果（predictions.daily_predictions）とリアルタイムオッズ
+（predictions.daily_odds）を JOIN して投資判断を実行し、
+predictions.investment_decisions テーブルに保存する。
+
+Cloud Scheduler からは POST /api/v1/strategy/daily で自動実行されるが、
+このスクリプトを手動実行することで内容を確認できる。
+
+前提条件:
+  - scripts/run_strategy_optimization.py を一度実行して
+    config/strategy_config.yaml にパラメータが保存されていること
+  - 当日の predictions.daily_predictions が存在すること
+  - 当日の predictions.daily_odds が存在すること
+
+Usage:
+    # 当日分を実行
+    python scripts/run_strategy.py --project-id <PROJECT_ID>
+
+    # 特定日を指定
+    python scripts/run_strategy.py --project-id <PROJECT_ID> --target-date 2026-03-07
+
+    # BQ保存をスキップ（確認のみ）
+    python scripts/run_strategy.py --project-id <PROJECT_ID> --dry-run
+
+Issue #105: 投資戦略モジュールをバックテストパイプラインに統合
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import logging
+import os
+import sys
+from pathlib import Path
+
+import pandas as pd
+import yaml
+from dotenv import load_dotenv
+from google.cloud import bigquery
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.backtest.strategy import select_bets_for_race
+
+load_dotenv()
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+STRATEGY_CONFIG_PATH = Path(__file__).resolve().parents[1] / "config" / "strategy_config.yaml"
+
+
+def load_strategy_config() -> dict:
+    """config/strategy_config.yaml を読み込む"""
+    if not STRATEGY_CONFIG_PATH.exists():
+        raise FileNotFoundError(
+            f"strategy_config.yaml が見つかりません: {STRATEGY_CONFIG_PATH}\n"
+            "先に scripts/run_strategy_optimization.py を実行してください。"
+        )
+    with open(STRATEGY_CONFIG_PATH) as f:
+        config = yaml.safe_load(f)
+    return config
+
+
+def fetch_daily_predictions(
+    client: bigquery.Client,
+    project_id: str,
+    target_date: datetime.date,
+) -> pd.DataFrame:
+    """predictions.daily_predictions から当日の予測を取得する"""
+    query = f"""
+    SELECT
+        race_id, race_date, horse_id, horse_number, horse_name,
+        venue_code, race_number, win_place_prob, pred_score, rank_in_race
+    FROM `{project_id}.predictions.daily_predictions`
+    WHERE race_date = '{target_date.isoformat()}'
+    ORDER BY race_id, rank_in_race
+    """
+    df = client.query(query).to_dataframe()
+    logger.info(f"予測データ取得: {len(df)}行 ({target_date})")
+    return df
+
+
+def fetch_daily_odds(
+    client: bigquery.Client,
+    project_id: str,
+    target_date: datetime.date,
+) -> pd.DataFrame:
+    """predictions.daily_odds から当日のオッズを取得する"""
+    query = f"""
+    SELECT race_id, horse_number, win_odds, place_odds_min, place_odds_max, scraped_at
+    FROM `{project_id}.predictions.daily_odds`
+    WHERE race_date = '{target_date.isoformat()}'
+    """
+    df = client.query(query).to_dataframe()
+    logger.info(f"オッズデータ取得: {len(df)}行 ({target_date})")
+    return df
+
+
+def build_race_df(
+    predictions_df: pd.DataFrame,
+    odds_df: pd.DataFrame,
+) -> pd.DataFrame:
+    """
+    predictions と odds を JOIN して strategy が要求するカラム構成にする
+
+    strategy.select_bets_for_race が要求する必須カラム:
+      horse_id, horse_number, win_place_prob, odds（複勝オッズ）
+    """
+    if odds_df.empty:
+        logger.warning("オッズデータが空です。place_odds_min=NaN として続行します。")
+        predictions_df = predictions_df.copy()
+        predictions_df["odds"] = float("nan")
+        return predictions_df
+
+    merged = predictions_df.merge(
+        odds_df[["race_id", "horse_number", "place_odds_min"]],
+        on=["race_id", "horse_number"],
+        how="left",
+    )
+    merged = merged.rename(columns={"place_odds_min": "odds"})
+
+    no_odds = merged["odds"].isna().sum()
+    if no_odds > 0:
+        logger.warning(f"{no_odds}頭のオッズが取得できていません（スキップ対象）")
+
+    return merged
+
+
+def save_decisions_to_bq(
+    decisions: list[dict],
+    project_id: str,
+) -> int:
+    """
+    投資判断結果を predictions.investment_decisions テーブルに UPSERT 保存する
+
+    Args:
+        decisions: 投資判断リスト
+        project_id: GCP プロジェクト ID
+
+    Returns:
+        保存した行数
+    """
+    if not decisions:
+        logger.info("投資判断なし（保存スキップ）")
+        return 0
+
+    df = pd.DataFrame(decisions)
+    client = bigquery.Client(project=project_id)
+    table_ref = f"{project_id}.predictions.investment_decisions"
+    temp_table = f"{table_ref}_temp_{datetime.datetime.now().strftime('%Y%m%d%H%M%S')}"
+
+    job_config = bigquery.LoadJobConfig(
+        write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
+        schema=[
+            bigquery.SchemaField("race_id", "STRING", mode="REQUIRED"),
+            bigquery.SchemaField("race_date", "DATE", mode="REQUIRED"),
+            bigquery.SchemaField("horse_id", "STRING"),
+            bigquery.SchemaField("horse_number", "INTEGER", mode="REQUIRED"),
+            bigquery.SchemaField("horse_name", "STRING"),
+            bigquery.SchemaField("venue_code", "STRING"),
+            bigquery.SchemaField("race_number", "INTEGER"),
+            bigquery.SchemaField("race_pattern", "STRING"),
+            bigquery.SchemaField("bet_type", "STRING"),
+            bigquery.SchemaField("bet_amount", "FLOAT64"),
+            bigquery.SchemaField("win_place_prob", "FLOAT64"),
+            bigquery.SchemaField("place_odds", "FLOAT64"),
+            bigquery.SchemaField("expected_return", "FLOAT64"),
+            bigquery.SchemaField("created_at", "TIMESTAMP", mode="REQUIRED"),
+        ],
+    )
+    client.load_table_from_dataframe(df, temp_table, job_config=job_config).result()
+
+    merge_query = f"""
+    MERGE `{table_ref}` AS target
+    USING `{temp_table}` AS source
+    ON target.race_id = source.race_id AND target.horse_number = source.horse_number
+    WHEN MATCHED THEN UPDATE SET
+        race_date = source.race_date,
+        horse_id = source.horse_id,
+        horse_name = source.horse_name,
+        venue_code = source.venue_code,
+        race_number = source.race_number,
+        race_pattern = source.race_pattern,
+        bet_type = source.bet_type,
+        bet_amount = source.bet_amount,
+        win_place_prob = source.win_place_prob,
+        place_odds = source.place_odds,
+        expected_return = source.expected_return,
+        created_at = source.created_at
+    WHEN NOT MATCHED THEN INSERT ROW
+    """
+    client.query(merge_query).result()
+    client.delete_table(temp_table, not_found_ok=True)
+
+    logger.info(f"投資判断を保存: {len(df)}行 → {table_ref}")
+    return len(df)
+
+
+def run_daily_strategy(
+    project_id: str,
+    target_date: datetime.date,
+    dry_run: bool = False,
+    initial_capital: float = 100_000.0,
+) -> list[dict]:
+    """
+    当日の投資戦略を実行し、投資判断リストを返す
+
+    Args:
+        project_id: GCP プロジェクト ID
+        target_date: 対象日
+        dry_run: True の場合 BQ への保存をスキップ
+        initial_capital: 初期資金（Kelly 計算用）
+
+    Returns:
+        投資判断リスト
+    """
+    config = load_strategy_config()
+    p1 = config["p1"]
+    p2 = config["p2"]
+    threshold = config["expected_return_threshold"]
+    kelly_fraction = config["kelly_fraction"]
+    max_bet_ratio = config["max_bet_ratio"]
+
+    opt = config.get("optimization", {})
+    logger.info(f"=== 日次投資戦略策定 ({target_date}) ===")
+    logger.info(f"パラメータ: p1={p1}, p2={p2}, threshold={threshold}, "
+                f"kelly={kelly_fraction}, max_bet_ratio={max_bet_ratio}")
+    if opt.get("last_run"):
+        logger.info(f"最終最適化: {opt['last_run']} "
+                    f"(回収率={opt.get('recovery_rate')}%, 的中率={opt.get('hit_rate')}%)")
+
+    client = bigquery.Client(project=project_id)
+    predictions_df = fetch_daily_predictions(client, project_id, target_date)
+    odds_df = fetch_daily_odds(client, project_id, target_date)
+
+    if predictions_df.empty:
+        logger.warning(f"予測データが見つかりません: {target_date}")
+        return []
+
+    merged = build_race_df(predictions_df, odds_df)
+
+    decisions: list[dict] = []
+    capital = initial_capital
+    created_at = datetime.datetime.now(datetime.timezone.utc)
+
+    for race_id, race_group in merged.groupby("race_id"):
+        race_group = race_group.dropna(subset=["win_place_prob", "odds"])
+        if len(race_group) < 3:
+            continue
+
+        try:
+            bets, race_pattern = select_bets_for_race(
+                race_df=race_group,
+                capital=capital,
+                p1=p1,
+                p2=p2,
+                expected_return_threshold=threshold,
+                kelly_fraction=kelly_fraction,
+                max_bet_ratio=max_bet_ratio,
+            )
+        except ValueError as e:
+            logger.debug(f"レース {race_id} スキップ: {e}")
+            continue
+
+        if not bets:
+            continue
+
+        meta_row = race_group.iloc[0]
+        for bet in bets:
+            horse_row = race_group[race_group["horse_number"] == bet["horse_number"]]
+            if horse_row.empty:
+                continue
+            hr = horse_row.iloc[0]
+            odds = float(bet["odds"])
+            prob = float(hr["win_place_prob"])
+            decisions.append({
+                "race_id": str(race_id),
+                "race_date": target_date,
+                "horse_id": str(bet.get("horse_id", hr.get("horse_id", ""))),
+                "horse_number": int(bet["horse_number"]),
+                "horse_name": str(hr.get("horse_name", "")),
+                "venue_code": str(meta_row.get("venue_code", "")),
+                "race_number": int(meta_row.get("race_number", 0)),
+                "race_pattern": race_pattern.pattern,
+                "bet_type": "place",
+                "bet_amount": float(bet["bet_amount"]),
+                "win_place_prob": prob,
+                "place_odds": odds,
+                "expected_return": round(prob * odds, 4),
+                "created_at": created_at,
+            })
+            capital -= float(bet["bet_amount"])
+
+    logger.info(f"投資判断: {len(decisions)}件")
+    if decisions:
+        total_bet = sum(d["bet_amount"] for d in decisions)
+        patterns = {}
+        for d in decisions:
+            patterns[d["race_pattern"]] = patterns.get(d["race_pattern"], 0) + 1
+        logger.info(f"  総賭け金: {total_bet:,.0f}円")
+        logger.info(f"  パターン別: {patterns}")
+
+    if not dry_run:
+        save_decisions_to_bq(decisions, project_id)
+    else:
+        logger.info("(--dry-run: BQ保存をスキップ)")
+        for d in decisions:
+            logger.info(
+                f"  race={d['race_id']} 馬番={d['horse_number']} "
+                f"パターン={d['race_pattern']} 賭={d['bet_amount']:.0f}円 "
+                f"prob={d['win_place_prob']:.2%} odds={d['place_odds']:.1f} "
+                f"期待回収率={d['expected_return']:.2f}"
+            )
+
+    return decisions
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="日次投資戦略策定")
+    parser.add_argument("--project-id", default=os.environ.get("GCP_PROJECT_ID"))
+    parser.add_argument(
+        "--target-date",
+        help="対象日（YYYY-MM-DD、省略時は当日）",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="BQへの保存をスキップして結果を表示のみ",
+    )
+    parser.add_argument("--initial-capital", type=float, default=100_000.0)
+    args = parser.parse_args()
+
+    if not args.project_id:
+        parser.error("--project-id または GCP_PROJECT_ID 環境変数を設定してください")
+
+    target_date = (
+        datetime.date.fromisoformat(args.target_date)
+        if args.target_date
+        else datetime.date.today()
+    )
+
+    run_daily_strategy(
+        project_id=args.project_id,
+        target_date=target_date,
+        dry_run=args.dry_run,
+        initial_capital=args.initial_capital,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_strategy_optimization.py
+++ b/scripts/run_strategy_optimization.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""
+投資戦略パラメータ最適化スクリプト（手動実行）
+
+グリッドサーチで最適な投資戦略パラメータを探索し、
+config/strategy_config.yaml に保存する。
+
+このスクリプトを手動実行することで、以下の日次自動実行が最適パラメータで動作する:
+  - POST /api/v1/strategy/daily（Cloud Scheduler）
+  - scripts/run_strategy.py（手動確認用）
+
+Usage:
+    python scripts/run_strategy_optimization.py \\
+        --project-id <PROJECT_ID> \\
+        --model-path gs://<PROJECT_ID>-keiba-models/lgbm_ranker/20260301/model.txt \\
+        --start-date 2024-01-01 \\
+        --end-date 2024-12-31
+
+    # 出力ファイルを指定（デフォルト: config/strategy_config.yaml）
+    python scripts/run_strategy_optimization.py \\
+        --project-id <PROJECT_ID> \\
+        --model-path <MODEL_PATH> \\
+        --start-date 2024-01-01 \\
+        --end-date 2024-12-31 \\
+        --output-csv results/optimization_2024.csv \\
+        --metric recovery_rate
+
+Issue #105: 投資戦略モジュールをバックテストパイプラインに統合
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import logging
+import os
+import sys
+from pathlib import Path
+
+import pandas as pd
+import yaml
+from dotenv import load_dotenv
+from google.cloud import bigquery
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.run_backtest import (
+    fetch_historical_features,
+    fetch_historical_payouts,
+    fetch_historical_results,
+)
+from src.backtest.strategy_optimizer import StrategyOptimizer
+from src.models.lgbm_ranker import LGBMRanker
+from src.models.predict import _scores_to_place_prob
+from src.models.train import build_feature_matrix, load_config
+
+load_dotenv()
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+STRATEGY_CONFIG_PATH = Path(__file__).resolve().parents[1] / "config" / "strategy_config.yaml"
+
+
+def _load_model_and_predict(
+    model_path: str,
+    features_df: pd.DataFrame,
+    results_df: pd.DataFrame,
+    project_id: str,
+) -> pd.DataFrame:
+    """
+    モデルで予測を行い、結果と着順をJOINした DataFrame を返す
+
+    Args:
+        model_path: モデルファイルパス（ローカルまたは gs:// URI）
+        features_df: 特徴量 DataFrame
+        results_df: 着順 DataFrame
+        project_id: GCP プロジェクト ID
+
+    Returns:
+        race_id, race_date, horse_id, horse_number, win_place_prob, place_odds,
+        finish_position を含む DataFrame
+    """
+    # GCS URI の場合はダウンロード
+    if model_path.startswith("gs://"):
+        import tempfile
+        from google.cloud import storage
+        bucket_name, blob_path = model_path[5:].split("/", 1)
+        local_path = Path(tempfile.mkdtemp()) / Path(blob_path).name
+        storage.Client(project=project_id).bucket(bucket_name).blob(blob_path).download_to_filename(str(local_path))
+        model_path = str(local_path)
+        logger.info(f"GCSからモデルをダウンロード: {model_path}")
+
+    model_config = load_config()
+    feature_cols = model_config.get("feature_columns", [])
+
+    ranker = LGBMRanker()
+    ranker.load(model_path)
+
+    X, groups, meta = build_feature_matrix(features_df, feature_cols)
+    scores = ranker.predict(X)
+    place_probs = _scores_to_place_prob(scores, groups)
+
+    meta = meta.copy()
+    meta["win_place_prob"] = place_probs
+
+    # 着順をJOIN
+    if len(results_df) > 0:
+        meta = meta.merge(
+            results_df[["race_id", "horse_id", "finish_position"]],
+            on=["race_id", "horse_id"],
+            how="left",
+        )
+
+    # place_odds カラムがなければ NaN で補完
+    if "place_odds" not in meta.columns:
+        meta["place_odds"] = float("nan")
+
+    return meta
+
+
+def save_best_params_to_yaml(
+    best,
+    start_date: datetime.date,
+    end_date: datetime.date,
+    metric: str,
+) -> None:
+    """最良パラメータを config/strategy_config.yaml に上書き保存する"""
+    with open(STRATEGY_CONFIG_PATH) as f:
+        config = yaml.safe_load(f)
+
+    config["p1"] = best.params["p1"]
+    config["p2"] = best.params["p2"]
+    config["expected_return_threshold"] = best.params["expected_return_threshold"]
+    config["kelly_fraction"] = best.params["kelly_fraction"]
+    config["max_bet_ratio"] = best.params["max_bet_ratio"]
+    config["optimization"] = {
+        "last_run": datetime.datetime.now().isoformat(timespec="seconds"),
+        "metric": metric,
+        "start_date": start_date.isoformat(),
+        "end_date": end_date.isoformat(),
+        "recovery_rate": round(best.recovery_rate, 2),
+        "hit_rate": round(best.hit_rate, 2),
+        "max_drawdown": round(best.max_drawdown, 2),
+        "total_bets": best.total_bets,
+    }
+
+    with open(STRATEGY_CONFIG_PATH, "w") as f:
+        yaml.dump(config, f, allow_unicode=True, default_flow_style=False, sort_keys=False)
+
+    logger.info(f"最適パラメータを保存: {STRATEGY_CONFIG_PATH}")
+    logger.info(f"  p1={best.params['p1']}, p2={best.params['p2']}, "
+                f"threshold={best.params['expected_return_threshold']}, "
+                f"kelly={best.params['kelly_fraction']}, "
+                f"max_bet_ratio={best.params['max_bet_ratio']}")
+    logger.info(f"  回収率={best.recovery_rate:.2f}%, 的中率={best.hit_rate:.2f}%, "
+                f"最大ドローダウン={best.max_drawdown:.2f}%")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="投資戦略パラメータ最適化（グリッドサーチ）"
+    )
+    parser.add_argument("--project-id", default=os.environ.get("GCP_PROJECT_ID"))
+    parser.add_argument("--model-path", required=True, help="モデルパス（ローカルまたは gs://）")
+    parser.add_argument("--start-date", required=True, help="最適化期間開始日（YYYY-MM-DD）")
+    parser.add_argument("--end-date", required=True, help="最適化期間終了日（YYYY-MM-DD）")
+    parser.add_argument(
+        "--metric",
+        default="recovery_rate",
+        choices=["recovery_rate", "hit_rate", "sharpe_ratio", "max_drawdown"],
+        help="最適化の評価指標（デフォルト: recovery_rate）",
+    )
+    parser.add_argument("--initial-capital", type=float, default=100_000.0)
+    parser.add_argument("--output-csv", help="全グリッドサーチ結果のCSV保存先")
+    parser.add_argument("--top-n", type=int, default=10, help="上位N件の結果を表示")
+    args = parser.parse_args()
+
+    if not args.project_id:
+        parser.error("--project-id または GCP_PROJECT_ID 環境変数を設定してください")
+
+    start_date = datetime.date.fromisoformat(args.start_date)
+    end_date = datetime.date.fromisoformat(args.end_date)
+
+    logger.info(f"=== 投資戦略パラメータ最適化 ===")
+    logger.info(f"期間: {start_date} ~ {end_date}")
+    logger.info(f"評価指標: {args.metric}")
+
+    # BigQuery からデータ取得
+    features_df = fetch_historical_features(
+        project_id=args.project_id,
+        dataset="features",
+        table="training_data",
+        start_date=start_date,
+        end_date=end_date,
+    )
+    results_df = fetch_historical_results(args.project_id, start_date, end_date)
+    payouts_df = fetch_historical_payouts(args.project_id, start_date, end_date)
+
+    if features_df.empty:
+        logger.error("特徴量データが取得できませんでした。期間やテーブルを確認してください。")
+        sys.exit(1)
+
+    # モデルで予測
+    predictions_df = _load_model_and_predict(
+        model_path=args.model_path,
+        features_df=features_df,
+        results_df=results_df,
+        project_id=args.project_id,
+    )
+
+    # グリッドサーチ最適化
+    optimizer = StrategyOptimizer(
+        predictions_df=predictions_df,
+        payouts_df=payouts_df,
+        initial_capital=args.initial_capital,
+    )
+    results = optimizer.run_grid_search()
+
+    if not results:
+        logger.error("グリッドサーチ結果が空です。データを確認してください。")
+        sys.exit(1)
+
+    # 上位N件を表示
+    sorted_results = sorted(
+        results,
+        key=lambda r: getattr(r, args.metric),
+        reverse=(args.metric != "max_drawdown"),
+    )
+    logger.info(f"\n=== 上位{args.top_n}パラメータ（{args.metric} 順）===")
+    for i, res in enumerate(sorted_results[: args.top_n]):
+        logger.info(
+            f"  #{i + 1}: p1={res.params['p1']} p2={res.params['p2']} "
+            f"threshold={res.params['expected_return_threshold']} "
+            f"kelly={res.params['kelly_fraction']} "
+            f"max_ratio={res.params['max_bet_ratio']} "
+            f"→ 回収率={res.recovery_rate:.1f}% 的中率={res.hit_rate:.1f}% "
+            f"ドローダウン={res.max_drawdown:.1f}%"
+        )
+
+    # CSV 出力（任意）
+    if args.output_csv:
+        rows = [
+            {
+                **r.params,
+                "recovery_rate": r.recovery_rate,
+                "hit_rate": r.hit_rate,
+                "max_drawdown": r.max_drawdown,
+                "sharpe_ratio": r.sharpe_ratio,
+                "total_bets": r.total_bets,
+            }
+            for r in results
+        ]
+        pd.DataFrame(rows).to_csv(args.output_csv, index=False)
+        logger.info(f"グリッドサーチ結果を保存: {args.output_csv}")
+
+    # 最良パラメータを strategy_config.yaml に保存
+    best = optimizer.best_params(results, metric=args.metric)
+    save_best_params_to_yaml(best, start_date, end_date, args.metric)
+
+    logger.info("\n=== 完了 ===")
+    logger.info(f"strategy_config.yaml を更新しました。")
+    logger.info("次回の POST /api/v1/strategy/daily から新しいパラメータが適用されます。")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/automation/api/app.py
+++ b/src/automation/api/app.py
@@ -823,6 +823,10 @@ class OddsScrapeRequest(BaseModel):
         description="対象日付（YYYY-MM-DD形式、省略時は当日）",
         json_schema_extra={"example": "2026-03-07"},
     )
+    include_combo: bool = Field(
+        default=False,
+        description="組み合わせ馬券（馬連・馬単・ワイド・三連複）オッズも取得してdaily_odds_comboに保存するか",
+    )
 
     @field_validator("execution_date")
     @classmethod
@@ -845,7 +849,50 @@ class OddsScrapeResponse(BaseModel):
     execution_date: str = Field(description="対象日付")
     races_scraped: int = Field(default=0, description="オッズを取得できたレース数")
     horses_scraped: int = Field(default=0, description="取得した馬数（行数）")
-    saved_rows: int = Field(default=0, description="BigQueryに保存した行数")
+    saved_rows: int = Field(default=0, description="BigQueryに保存した行数（単複）")
+    combo_rows_saved: int = Field(default=0, description="BigQueryに保存した行数（組み合わせ馬券）")
+    error_message: Optional[str] = Field(default=None, description="エラーメッセージ")
+
+
+class StrategyDailyRequest(BaseModel):
+    """日次投資戦略リクエスト"""
+
+    execution_date: Optional[str] = Field(
+        default=None,
+        description="対象日付（YYYY-MM-DD形式、省略時は当日）",
+        json_schema_extra={"example": "2026-03-07"},
+    )
+    dry_run: bool = Field(
+        default=False,
+        description="Trueの場合BQ保存をスキップして結果のみ返す",
+    )
+    initial_capital: float = Field(
+        default=100_000.0,
+        description="初期資金（Kelly計算用、単位:円）",
+    )
+
+    @field_validator("execution_date")
+    @classmethod
+    def validate_date_format(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return v
+        try:
+            datetime.date.fromisoformat(v)
+            return v
+        except ValueError:
+            raise ValueError(
+                f"日付はYYYY-MM-DD形式の有効な日付で指定してください: '{v}'"
+            )
+
+
+class StrategyDailyResponse(BaseModel):
+    """日次投資戦略レスポンス"""
+
+    status: str = Field(description="処理ステータス (success/failed)")
+    execution_date: str = Field(description="対象日付")
+    decisions_count: int = Field(default=0, description="投資判断件数")
+    total_bet_amount: float = Field(default=0.0, description="総賭け金（円）")
+    dry_run: bool = Field(default=False, description="ドライランモードか")
     error_message: Optional[str] = Field(default=None, description="エラーメッセージ")
 
 
@@ -876,7 +923,11 @@ async def scrape_odds(request: OddsScrapeRequest):
         raise HTTPException(status_code=500, detail="GCP_PROJECT_IDが未設定です")
 
     try:
-        from src.automation.data.netkeiba_scraper import save_odds_to_bq, scrape_today_odds
+        from src.automation.data.netkeiba_scraper import (
+            save_odds_to_bq,
+            scrape_today_combo_odds,
+            scrape_today_odds,
+        )
 
         # Playwright Sync API は asyncio ループ内で直接呼び出せないため
         # スレッドプールで実行する
@@ -886,35 +937,105 @@ async def scrape_odds(request: OddsScrapeRequest):
             project_id=project_id,
         )
 
-        if odds_df.empty:
-            logger.warning(f"オッズを取得できませんでした: {execution_date_str}")
-            return OddsScrapeResponse(
-                status="success",
-                execution_date=execution_date_str,
-                races_scraped=0,
-                horses_scraped=0,
-                saved_rows=0,
+        races_scraped = 0
+        horses_scraped = 0
+        saved_rows = 0
+
+        if not odds_df.empty:
+            races_scraped = int(odds_df["race_id"].nunique())
+            horses_scraped = len(odds_df)
+            saved_rows = await asyncio.to_thread(save_odds_to_bq, odds_df, project_id=project_id)
+            logger.info(
+                f"単複オッズスクレイプ完了: {races_scraped}レース, {horses_scraped}頭, "
+                f"saved={saved_rows}行"
             )
+        else:
+            logger.warning(f"単複オッズを取得できませんでした: {execution_date_str}")
 
-        races_scraped = int(odds_df["race_id"].nunique())
-        horses_scraped = len(odds_df)
+        combo_rows_saved = 0
+        if request.include_combo:
+            combo_rows_saved = await asyncio.to_thread(
+                scrape_today_combo_odds,
+                date=execution_date,
+                project_id=project_id,
+            )
+            logger.info(f"組み合わせオッズ保存: {combo_rows_saved}行")
 
-        saved_rows = await asyncio.to_thread(save_odds_to_bq, odds_df, project_id=project_id)
-
-        logger.info(
-            f"オッズスクレイプ完了: {races_scraped}レース, {horses_scraped}頭, "
-            f"saved={saved_rows}行"
-        )
         return OddsScrapeResponse(
             status="success",
             execution_date=execution_date_str,
             races_scraped=races_scraped,
             horses_scraped=horses_scraped,
             saved_rows=saved_rows,
+            combo_rows_saved=combo_rows_saved,
         )
 
     except Exception as e:
         logger.error(f"オッズスクレイプエラー: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@app.post("/api/v1/strategy/daily", response_model=StrategyDailyResponse)
+async def run_strategy_daily(request: StrategyDailyRequest):
+    """
+    日次投資戦略を策定してBigQueryに保存する
+
+    config/strategy_config.yaml のパラメータを読み込み、当日の予測結果と
+    リアルタイムオッズを JOIN して投資判断を実行する。
+    Cloud Schedulerから毎朝AM 9:00に呼び出されることを想定。
+
+    前提条件:
+      - predictions.daily_predictions に当日の予測データが存在すること
+      - predictions.daily_odds に当日のオッズデータが存在すること
+      - config/strategy_config.yaml にパラメータが設定されていること
+        （scripts/run_strategy_optimization.py を一度実行すること）
+
+    Args:
+        request: リクエストボディ
+
+    Returns:
+        投資判断結果
+    """
+    execution_date_str = request.execution_date or date.today().isoformat()
+    execution_date = datetime.date.fromisoformat(execution_date_str)
+
+    logger.info(
+        f"日次投資戦略リクエスト受信: execution_date={execution_date_str}, "
+        f"dry_run={request.dry_run}"
+    )
+
+    project_id = os.environ.get("GCP_PROJECT_ID")
+    if not project_id:
+        raise HTTPException(status_code=500, detail="GCP_PROJECT_IDが未設定です")
+
+    try:
+        from scripts.run_strategy import run_daily_strategy
+
+        decisions = await asyncio.to_thread(
+            run_daily_strategy,
+            project_id=project_id,
+            target_date=execution_date,
+            dry_run=request.dry_run,
+            initial_capital=request.initial_capital,
+        )
+
+        total_bet = sum(d["bet_amount"] for d in decisions) if decisions else 0.0
+        logger.info(
+            f"日次投資戦略完了: {len(decisions)}件, 総賭け金={total_bet:,.0f}円"
+        )
+        return StrategyDailyResponse(
+            status="success",
+            execution_date=execution_date_str,
+            decisions_count=len(decisions),
+            total_bet_amount=total_bet,
+            dry_run=request.dry_run,
+        )
+
+    except FileNotFoundError as e:
+        logger.error(f"設定ファイルが見つかりません: {e}")
+        raise HTTPException(status_code=500, detail=str(e)) from e
+    except Exception as e:
+        logger.error(f"日次投資戦略エラー: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e)) from e
 
 

--- a/src/automation/data/netkeiba_scraper.py
+++ b/src/automation/data/netkeiba_scraper.py
@@ -1,18 +1,25 @@
 """
 netkeibaオッズスクレイパー
 
-netkeibaからリアルタイムの単勝・複勝オッズを取得し、
+netkeibaからリアルタイムの単勝・複勝および組み合わせ馬券オッズを取得し、
 JRDB形式のrace_idと紐付けてBigQueryに保存する。
 
 URL構造:
-  https://race.netkeiba.com/odds/index.html?race_id={YYYY}{PP}{NN}{DD}{RR}&type=b1
+  https://race.netkeiba.com/odds/index.html?race_id={YYYY}{PP}{NN}{DD}{RR}&type=b{KIND}
   - YYYY: 開催年
   - PP: 競馬場コード（JRDBのvenue_codeと同一）
   - NN: 回次
   - DD: 日次
   - RR: レース番号
+  - KIND: 1=単複, 4=馬連, 5=馬単, 7=ワイド, 6=三連複
+
+組み合わせ馬券のHTMLパース:
+  2頭組み合わせ（馬連・馬単・ワイド）: <span id="odds-{code}-XXYY">
+  3頭組み合わせ（三連複）: <span id="odds-{code}-XXYYZZ">
+  ここで XX/YY/ZZ は馬番の2桁ゼロ埋め表現
 
 Issue #131: netkeibaリアルタイムオッズスクレイパーの実装
+Issue #134: netkeibaスクレイパー拡張 - 組み合わせ馬券オッズ取得
 """
 
 from __future__ import annotations
@@ -46,6 +53,24 @@ VENUE_CODE_MAP: dict[str, str] = {
 }
 
 _EMPTY_ODDS_COLUMNS = ["horse_number", "win_odds", "place_odds_min", "place_odds_max"]
+
+# 組み合わせ馬券の type コードと BQ 保存用 ticket_type 名の対応
+COMBO_TICKET_TYPES: dict[str, str] = {
+    "b4": "umaren",     # 馬連（2頭・順不同）
+    "b5": "umatan",     # 馬単（2頭・順あり）
+    "b7": "wide",       # ワイド（2頭・順不同）
+    "b6": "sanrenpuku", # 三連複（3頭・順不同）
+}
+
+# b4/b5/b7 の span id における数値コード
+_COMBO_TYPE_CODE: dict[str, str] = {
+    "b4": "4",
+    "b5": "5",
+    "b7": "7",
+    "b6": "6",
+}
+
+_EMPTY_COMBO_COLUMNS = ["ticket_type", "horse_number_1", "horse_number_2", "horse_number_3", "odds"]
 
 
 def parse_netkeiba_race_id(netkeiba_race_id: str) -> dict:
@@ -471,6 +496,304 @@ def scrape_today_odds(
         f"{len(result_df)}頭のオッズを取得"
     )
     return result_df
+
+
+def scrape_today_combo_odds(
+    date: datetime.date,
+    project_id: str,
+    ticket_types: list[str] | None = None,
+    sleep_sec: float = 1.5,
+) -> int:
+    """
+    当日の全レースの組み合わせ馬券オッズを取得してBigQueryに保存する
+
+    処理フロー:
+      1. get_today_race_list() で当日のnetkeibaレースIDを取得
+      2. 各レースの組み合わせオッズを get_combo_odds() で取得
+      3. netkeiba_to_jrdb_race_id() でJRDB race_idに変換
+      4. save_combo_odds_to_bq() で保存
+
+    Args:
+        date: 対象日付
+        project_id: GCPプロジェクトID（BQ照合・保存に使用）
+        ticket_types: 取得する馬券種リスト（例: ['b4', 'b6']）
+                      None の場合は全種（馬連・馬単・ワイド・三連複）を取得
+        sleep_sec: 各レース・各馬券種のリクエスト間隔（秒）
+
+    Returns:
+        BigQueryに保存した合計行数
+    """
+    bq_client = bigquery.Client(project=project_id)
+    scraped_at = datetime.datetime.now(datetime.timezone.utc)
+
+    races = get_today_race_list(date, sleep_sec=sleep_sec)
+    if not races:
+        logger.warning(f"当日のレースが見つかりません: {date}")
+        return 0
+
+    total_saved = 0
+    for race_info in races:
+        netkeiba_race_id = race_info["netkeiba_race_id"]
+        venue_code = race_info["venue_code"]
+        race_number = race_info["race_number"]
+        venue_name = VENUE_CODE_MAP.get(venue_code, venue_code)
+
+        jrdb_race_id = netkeiba_to_jrdb_race_id(
+            race_date=date,
+            venue_code=venue_code,
+            race_number=race_number,
+            bq_client=bq_client,
+            project_id=project_id,
+        )
+        if jrdb_race_id is None:
+            logger.warning(
+                f"JRDB race_id が見つかりません: {venue_name} {race_number}R → スキップ"
+            )
+            continue
+
+        combo_df = get_combo_odds(
+            netkeiba_race_id,
+            ticket_types=ticket_types,
+            sleep_sec=sleep_sec,
+        )
+        if combo_df.empty:
+            logger.warning(f"組み合わせオッズが取得できませんでした: {venue_name} {race_number}R")
+            continue
+
+        try:
+            saved = save_combo_odds_to_bq(
+                df=combo_df,
+                race_id=jrdb_race_id,
+                race_date=date,
+                scraped_at=scraped_at,
+                project_id=project_id,
+            )
+            total_saved += saved
+            logger.info(f"  → {venue_name} {race_number}R 組み合わせオッズ: {saved}件保存")
+        except Exception as e:
+            logger.error(f"BQ保存失敗: {venue_name} {race_number}R, {e}")
+
+    logger.info(f"組み合わせオッズ取得完了: 合計{total_saved}件保存")
+    return total_saved
+
+
+def _parse_combo_odds_html(html: str, ticket_type: str) -> pd.DataFrame:
+    """
+    組み合わせ馬券（馬連・馬単・ワイド・三連複）のオッズページ HTML をパースする
+    （テスト可能な純粋関数）
+
+    HTMLの span ID 形式:
+      2頭組み合わせ: <span id="odds-{code}-XXYY">
+      3頭組み合わせ: <span id="odds-{code}-XXYYZZ">
+
+    Args:
+        html: オッズページのHTML文字列
+        ticket_type: 'b4'(馬連) / 'b5'(馬単) / 'b7'(ワイド) / 'b6'(三連複)
+
+    Returns:
+        DataFrame[ticket_type(str), horse_number_1(int), horse_number_2(int),
+                  horse_number_3(int or None), odds(float)]
+        パース失敗時は空のDataFrameを返す
+    """
+    code = _COMBO_TYPE_CODE.get(ticket_type)
+    if code is None:
+        logger.warning(f"未対応のticket_type: {ticket_type}")
+        return pd.DataFrame(columns=_EMPTY_COMBO_COLUMNS)
+
+    soup = BeautifulSoup(html, "lxml")
+    is_trio = (ticket_type == "b6")
+    # 三連複は6桁、2頭組は4桁
+    pattern = re.compile(rf'^odds-{code}-(\d{{6}})$' if is_trio else rf'^odds-{code}-(\d{{4}})$')
+
+    rows = []
+    for span in soup.find_all("span", id=pattern):
+        match = pattern.match(span["id"])
+        if not match:
+            continue
+        digits = match.group(1)
+        odds_text = span.get_text(strip=True).replace(",", "")
+        try:
+            odds_val = float(odds_text)
+        except ValueError:
+            continue
+        if odds_val <= 1.0:
+            continue
+
+        if is_trio:
+            h1, h2, h3 = int(digits[0:2]), int(digits[2:4]), int(digits[4:6])
+            rows.append({
+                "ticket_type": COMBO_TICKET_TYPES[ticket_type],
+                "horse_number_1": h1,
+                "horse_number_2": h2,
+                "horse_number_3": h3,
+                "odds": odds_val,
+            })
+        else:
+            h1, h2 = int(digits[0:2]), int(digits[2:4])
+            rows.append({
+                "ticket_type": COMBO_TICKET_TYPES[ticket_type],
+                "horse_number_1": h1,
+                "horse_number_2": h2,
+                "horse_number_3": None,
+                "odds": odds_val,
+            })
+
+    if not rows:
+        return pd.DataFrame(columns=_EMPTY_COMBO_COLUMNS)
+
+    return pd.DataFrame(rows)
+
+
+def get_combo_odds(
+    netkeiba_race_id: str,
+    ticket_types: list[str] | None = None,
+    sleep_sec: float = 1.5,
+) -> pd.DataFrame:
+    """
+    指定レースの組み合わせ馬券オッズをnetkeibaから取得する
+
+    Args:
+        netkeiba_race_id: 12桁のnetkeibaレースID
+        ticket_types: 取得する馬券種リスト（例: ['b4', 'b6']）
+                      None の場合は全種（馬連・馬単・ワイド・三連複）を取得
+        sleep_sec: 各ページのリクエスト間隔（秒）
+
+    Returns:
+        DataFrame[ticket_type, horse_number_1, horse_number_2, horse_number_3, odds]
+
+    Raises:
+        ImportError: playwright が未インストールの場合
+    """
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError as e:
+        raise ImportError(
+            "playwright が未インストールです。"
+            "`pip install playwright && playwright install chromium` を実行してください。"
+        ) from e
+
+    if ticket_types is None:
+        ticket_types = list(COMBO_TICKET_TYPES.keys())
+
+    all_dfs: list[pd.DataFrame] = []
+
+    for i, ttype in enumerate(ticket_types):
+        if ttype not in COMBO_TICKET_TYPES:
+            logger.warning(f"未対応の馬券種をスキップ: {ttype}")
+            continue
+
+        url = (
+            f"{NETKEIBA_BASE_URL}/odds/index.html"
+            f"?race_id={netkeiba_race_id}&type={ttype}"
+        )
+        logger.debug(f"組み合わせオッズ取得: {url}")
+
+        if i > 0:
+            time.sleep(sleep_sec)
+
+        with sync_playwright() as p:
+            browser = p.chromium.launch(headless=True)
+            try:
+                page = browser.new_page()
+                page.goto(url, wait_until="load", timeout=30_000)
+                time.sleep(sleep_sec)
+                html = page.content()
+            except Exception as e:
+                logger.error(f"オッズページ取得失敗: {ttype} race_id={netkeiba_race_id}, {e}")
+                html = ""
+            finally:
+                browser.close()
+
+        df = _parse_combo_odds_html(html, ttype)
+        if not df.empty:
+            all_dfs.append(df)
+            logger.debug(
+                f"  {COMBO_TICKET_TYPES[ttype]}: {len(df)}件"
+            )
+
+    if not all_dfs:
+        return pd.DataFrame(columns=_EMPTY_COMBO_COLUMNS)
+
+    return pd.concat(all_dfs, ignore_index=True)
+
+
+def save_combo_odds_to_bq(
+    df: pd.DataFrame,
+    race_id: str,
+    race_date: datetime.date,
+    scraped_at: datetime.datetime,
+    project_id: str,
+    dataset: str = "predictions",
+    table: str = "daily_odds_combo",
+) -> int:
+    """
+    組み合わせ馬券オッズ DataFrame を BigQuery に UPSERT 保存する
+
+    Args:
+        df: get_combo_odds() が返す DataFrame
+        race_id: JRDB形式のレースID
+        race_date: 開催日
+        scraped_at: スクレイプ日時（UTC）
+        project_id: GCP プロジェクト ID
+        dataset: データセット名
+        table: テーブル名
+
+    Returns:
+        保存した行数
+
+    Raises:
+        ValueError: df が空の場合
+    """
+    if df.empty:
+        raise ValueError("保存するデータがありません（空のDataFrame）")
+
+    df = df.copy()
+    df["race_id"] = race_id
+    df["race_date"] = race_date
+    df["scraped_at"] = scraped_at
+
+    client = bigquery.Client(project=project_id)
+    table_ref = f"{project_id}.{dataset}.{table}"
+    temp_table = f"{table_ref}_temp_{datetime.datetime.now().strftime('%Y%m%d%H%M%S')}"
+
+    job_config = bigquery.LoadJobConfig(
+        write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
+        schema=[
+            bigquery.SchemaField("race_id", "STRING", mode="REQUIRED"),
+            bigquery.SchemaField("race_date", "DATE", mode="REQUIRED"),
+            bigquery.SchemaField("ticket_type", "STRING", mode="REQUIRED"),
+            bigquery.SchemaField("horse_number_1", "INTEGER", mode="REQUIRED"),
+            bigquery.SchemaField("horse_number_2", "INTEGER", mode="REQUIRED"),
+            bigquery.SchemaField("horse_number_3", "INTEGER"),
+            bigquery.SchemaField("odds", "FLOAT64"),
+            bigquery.SchemaField("scraped_at", "TIMESTAMP", mode="REQUIRED"),
+        ],
+    )
+    client.load_table_from_dataframe(df, temp_table, job_config=job_config).result()
+
+    merge_query = f"""
+    MERGE `{table_ref}` AS target
+    USING `{temp_table}` AS source
+    ON target.race_id = source.race_id
+       AND target.ticket_type = source.ticket_type
+       AND target.horse_number_1 = source.horse_number_1
+       AND target.horse_number_2 = source.horse_number_2
+       AND (target.horse_number_3 = source.horse_number_3
+            OR (target.horse_number_3 IS NULL AND source.horse_number_3 IS NULL))
+    WHEN MATCHED THEN
+      UPDATE SET odds = source.odds, scraped_at = source.scraped_at
+    WHEN NOT MATCHED THEN
+      INSERT (race_id, race_date, ticket_type, horse_number_1, horse_number_2,
+              horse_number_3, odds, scraped_at)
+      VALUES (source.race_id, source.race_date, source.ticket_type,
+              source.horse_number_1, source.horse_number_2,
+              source.horse_number_3, source.odds, source.scraped_at)
+    """
+    client.query(merge_query).result()
+    client.delete_table(temp_table, not_found_ok=True)
+
+    logger.info(f"BQへの保存完了: {len(df)}行 → {table_ref}")
+    return len(df)
 
 
 def save_odds_to_bq(

--- a/tests/test_netkeiba_scraper.py
+++ b/tests/test_netkeiba_scraper.py
@@ -24,10 +24,12 @@ import pandas as pd
 import pytest
 
 from src.automation.data.netkeiba_scraper import (
+    _parse_combo_odds_html,
     _parse_race_list_html,
     _parse_win_place_odds_html,
     netkeiba_to_jrdb_race_id,
     parse_netkeiba_race_id,
+    save_combo_odds_to_bq,
     save_odds_to_bq,
     scrape_today_odds,
 )
@@ -234,6 +236,162 @@ class TestParseWinPlaceOddsHtml:
         df = _parse_win_place_odds_html(html)
         assert not df.empty
         assert df.iloc[0]["win_odds"] == pytest.approx(2.5, abs=0.01)
+
+
+# ---------------------------------------------------------------------------
+# _parse_combo_odds_html
+# ---------------------------------------------------------------------------
+
+
+def _make_combo_html(ticket_type: str, combos: list[tuple]) -> str:
+    """組み合わせオッズ span を含むHTMLを生成する
+
+    Args:
+        ticket_type: 'b4'(馬連) / 'b5'(馬単) / 'b7'(ワイド) / 'b6'(三連複)
+        combos: 2頭の場合 [(h1, h2, odds), ...]、3頭の場合 [(h1, h2, h3, odds), ...]
+    """
+    type_code = {"b4": "4", "b5": "5", "b7": "7", "b6": "6"}[ticket_type]
+    is_trio = ticket_type == "b6"
+    spans = ""
+    for combo in combos:
+        if is_trio:
+            h1, h2, h3, o = combo
+            span_id = f"odds-{type_code}-{h1:02d}{h2:02d}{h3:02d}"
+        else:
+            h1, h2, o = combo
+            span_id = f"odds-{type_code}-{h1:02d}{h2:02d}"
+        spans += f'<span id="{span_id}">{o}</span>'
+    return f"<html><body>{spans}</body></html>"
+
+
+class TestParseComboOddsHtml:
+    def test_umaren_b4(self):
+        html = _make_combo_html("b4", [(1, 2, 5.5), (1, 3, 8.0)])
+        df = _parse_combo_odds_html(html, "b4")
+        assert len(df) == 2
+        assert set(df["ticket_type"]) == {"umaren"}
+        row = df[(df["horse_number_1"] == 1) & (df["horse_number_2"] == 2)].iloc[0]
+        assert row["odds"] == pytest.approx(5.5)
+        assert row["horse_number_3"] is None
+
+    def test_umatan_b5(self):
+        html = _make_combo_html("b5", [(1, 2, 6.0)])
+        df = _parse_combo_odds_html(html, "b5")
+        assert len(df) == 1
+        assert df.iloc[0]["ticket_type"] == "umatan"
+
+    def test_wide_b7(self):
+        html = _make_combo_html("b7", [(2, 3, 3.2)])
+        df = _parse_combo_odds_html(html, "b7")
+        assert len(df) == 1
+        assert df.iloc[0]["ticket_type"] == "wide"
+
+    def test_sanrenpuku_b6(self):
+        html = _make_combo_html("b6", [(1, 2, 3, 12.5)])
+        df = _parse_combo_odds_html(html, "b6")
+        assert len(df) == 1
+        assert df.iloc[0]["ticket_type"] == "sanrenpuku"
+        assert df.iloc[0]["horse_number_1"] == 1
+        assert df.iloc[0]["horse_number_2"] == 2
+        assert df.iloc[0]["horse_number_3"] == 3
+        assert df.iloc[0]["odds"] == pytest.approx(12.5)
+
+    def test_empty_html(self):
+        df = _parse_combo_odds_html("<html><body></body></html>", "b4")
+        assert df.empty
+        assert list(df.columns) == [
+            "ticket_type", "horse_number_1", "horse_number_2", "horse_number_3", "odds"
+        ]
+
+    def test_invalid_ticket_type(self):
+        df = _parse_combo_odds_html("<html><body></body></html>", "b9")
+        assert df.empty
+
+    def test_filters_odds_lte_1(self):
+        """オッズが1.0以下の組み合わせは除外される"""
+        html = _make_combo_html("b4", [(1, 2, 1.0), (1, 3, 5.5)])
+        df = _parse_combo_odds_html(html, "b4")
+        assert len(df) == 1
+        assert df.iloc[0]["horse_number_2"] == 3
+
+    def test_skips_non_numeric_odds(self):
+        """数値でないオッズはスキップされる"""
+        type_code = "4"
+        html = (
+            f'<span id="odds-{type_code}-0102">---</span>'
+            f'<span id="odds-{type_code}-0103">5.5</span>'
+        )
+        df = _parse_combo_odds_html(html, "b4")
+        assert len(df) == 1
+        assert df.iloc[0]["odds"] == pytest.approx(5.5)
+
+    def test_comma_in_odds(self):
+        """カンマ区切りのオッズ（例: 1,234.5）を正しくパースできる"""
+        type_code = "4"
+        html = f'<span id="odds-{type_code}-0102">1,234.5</span>'
+        df = _parse_combo_odds_html(html, "b4")
+        assert len(df) == 1
+        assert df.iloc[0]["odds"] == pytest.approx(1234.5)
+
+
+# ---------------------------------------------------------------------------
+# save_combo_odds_to_bq (BQモック)
+# ---------------------------------------------------------------------------
+
+
+class TestSaveComboOddsToBq:
+    def _make_sample_df(self) -> pd.DataFrame:
+        return pd.DataFrame([
+            {
+                "ticket_type": "umaren",
+                "horse_number_1": 1,
+                "horse_number_2": 2,
+                "horse_number_3": None,
+                "odds": 5.5,
+            },
+            {
+                "ticket_type": "sanrenpuku",
+                "horse_number_1": 1,
+                "horse_number_2": 2,
+                "horse_number_3": 3,
+                "odds": 12.5,
+            },
+        ])
+
+    def test_raises_on_empty_df(self):
+        with pytest.raises(ValueError, match="空"):
+            save_combo_odds_to_bq(
+                pd.DataFrame(),
+                race_id="RACE001",
+                race_date=datetime.date(2024, 5, 26),
+                scraped_at=datetime.datetime(2024, 5, 26, 8, 0, 0),
+                project_id="test-project",
+            )
+
+    def test_calls_bq_load_and_merge(self):
+        df = self._make_sample_df()
+        mock_client = MagicMock()
+        mock_load_job = MagicMock()
+        mock_merge_job = MagicMock()
+        mock_client.load_table_from_dataframe.return_value = mock_load_job
+        mock_client.query.return_value = mock_merge_job
+
+        with patch(
+            "src.automation.data.netkeiba_scraper.bigquery.Client",
+            return_value=mock_client,
+        ):
+            result = save_combo_odds_to_bq(
+                df,
+                race_id="RACE001",
+                race_date=datetime.date(2024, 5, 26),
+                scraped_at=datetime.datetime(2024, 5, 26, 8, 0, 0),
+                project_id="test-project",
+            )
+
+        assert result == 2
+        mock_client.load_table_from_dataframe.assert_called_once()
+        mock_load_job.result.assert_called_once()
+        mock_client.query.assert_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

### Issue #134: 組み合わせ馬券オッズ取得
- `netkeiba_scraper.py` に `_parse_combo_odds_html` / `get_combo_odds` / `save_combo_odds_to_bq` / `scrape_today_combo_odds` を追加
- `POST /api/v1/odds/scrape` に `include_combo: bool` パラメータを追加（`true` にすると馬連・馬単・ワイド・三連複オッズを `predictions.daily_odds_combo` に保存）
- `scripts/create_daily_odds_combo_table.py` を追加（初回セットアップ用）

### Issue #105: 投資戦略パイプライン
- `scripts/run_strategy_optimization.py`: グリッドサーチでパラメータ最適化 → `config/strategy_config.yaml` に保存（**一度実行するだけで日次自動実行が最適パラメータで動作する**）
- `scripts/run_strategy.py`: `config/strategy_config.yaml` を読み込んで日次投資判断を実行（手動確認用）
- `config/strategy_config.yaml`: デフォルトパラメータ設定ファイル（p1=0.2, p2=0.15, threshold=1.2, kelly=0.25）
- `POST /api/v1/strategy/daily` エンドポイントを `app.py` に追加（Cloud Schedulerから AM 9:00 に自動実行）
- `scripts/create_investment_decisions_table.py` を追加（初回セットアップ用）

### テスト
- `_parse_combo_odds_html` のユニットテスト 9 件追加
- `save_combo_odds_to_bq` のユニットテスト 2 件追加
- 計 36 件全通過

### README
- 投資戦略策定（A: 最適化 / B: 日次実行）の実行コマンドを追記
- `daily_odds_combo` / `investment_decisions` テーブルスキーマを追記
- API エンドポイント一覧に `POST /api/v1/strategy/daily` を追記

## Test plan
- [ ] `python3 -m pytest tests/test_netkeiba_scraper.py -v` で 36 件全通過を確認
- [ ] `POST /api/v1/odds/scrape` に `include_combo: false`（デフォルト）でリグレッションなし確認
- [ ] `POST /api/v1/odds/scrape` に `include_combo: true` で combo_rows_saved が返ることを確認
- [ ] `POST /api/v1/strategy/daily` で 500 エラー（config ファイル不存在）が適切なメッセージで返ることを確認
- [ ] `scripts/run_strategy_optimization.py --dry-run` 相当の動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)