### PR TITLE
fix: Playwrightのwait_until=networkidleをloadに変更してタイムアウトを解消

### DIFF
--- a/src/automation/data/netkeiba_scraper.py
+++ b/src/automation/data/netkeiba_scraper.py
@@ -284,7 +284,7 @@ def get_today_race_list(date: datetime.date, sleep_sec: float = 1.0) -> list[dic
         browser = p.chromium.launch(headless=True)
         try:
             page = browser.new_page()
-            page.goto(url, wait_until="networkidle", timeout=30_000)
+            page.goto(url, wait_until="load", timeout=60_000)
             if sleep_sec > 0:
                 time.sleep(sleep_sec)
             html = page.content()
@@ -336,7 +336,7 @@ def get_win_place_odds(
         browser = p.chromium.launch(headless=True)
         try:
             page = browser.new_page()
-            page.goto(url, wait_until="networkidle", timeout=30_000)
+            page.goto(url, wait_until="load", timeout=60_000)
 
             # JavaScriptによるオッズテーブルの描画を待つ
             try:


### PR DESCRIPTION
## 原因

`get_today_race_list` と `get_win_place_odds` で `wait_until="networkidle"` を使用していた。

`networkidle` はページ上のネットワーク接続が500ms以上ゼロになるまで待機する最も厳しい条件だが、netkeibaはアナリティクス等のバックグラウンド通信が継続するため、この条件が達成されずタイムアウトが発生していた。

## 修正内容

| 関数 | 修正前 | 修正後 |
|------|--------|--------|
| `get_today_race_list` | `wait_until="networkidle", timeout=30_000` | `wait_until="load", timeout=60_000` |
| `get_win_place_odds` | `wait_until="networkidle", timeout=30_000` | `wait_until="load", timeout=60_000` |

`get_combo_odds` はすでに `wait_until="load"` を使用しており問題なし → 3関数を統一。

## 動作確認

- `get_today_race_list(2026-03-07)`: 24レース正常取得 ✅
- `get_win_place_odds("202606020301")`: 16頭の単複オッズ正常取得 ✅
- ユニットテスト36件全通過 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)