### PR TITLE
fix: LINE送信テストコマンドのKeyError修正

### DIFF
--- a/docs/LINE_SETUP.md
+++ b/docs/LINE_SETUP.md
@@ -93,6 +93,9 @@ for t in tests:
 ```bash
 python3 -c "
 import os
+from dotenv import load_dotenv
+load_dotenv()  # .env から環境変数を読み込む
+
 from src.utils.line_notify import push_messages, text_message
 
 push_messages(
@@ -128,9 +131,10 @@ ngrokが発行した `https://xxxx.ngrok.io` を LINE Developers コンソール
 
 ```bash
 python3 -c "
-import hashlib, hmac, json, requests
+import hashlib, hmac, json, requests, os
 from base64 import b64encode
-import os
+from dotenv import load_dotenv
+load_dotenv()  # .env から環境変数を読み込む
 
 secret = os.environ.get('LINE_CHANNEL_SECRET', '')
 body = json.dumps({
@@ -165,10 +169,7 @@ BQ に当日の予測データとオッズデータが入っている状態で�
 # BQ 認証
 gcloud auth application-default login
 
-# ローカルサーバー起動
-GCP_PROJECT_ID=your_project_id \
-LINE_CHANNEL_ACCESS_TOKEN=your_token \
-LINE_CHANNEL_SECRET=your_secret \
+# ローカルサーバー起動（.env の値が自動で読み込まれる）
 uvicorn src.automation.api.app:app --reload --port 8080
 ```
 


### PR DESCRIPTION
## 原因

`os.environ['LINE_CHANNEL_ACCESS_TOKEN']` は shell の環境変数しか参照しないため、
`.env` ファイルに値があっても `KeyError` が発生していた。

## 修正内容

`docs/LINE_SETUP.md` の各テストコマンドに `load_dotenv()` を追加し、
`.env` の値を明示的に読み込むように変更。

- 3.3 送信テスト（プッシュ通知）
- 3.4 Webhook 模擬リクエスト
- 3.5 E2Eテスト（サーバー起動コマンドを簡略化）

## Test plan

- [x] `load_dotenv()` 追加後に `LINE_CHANNEL_ACCESS_TOKEN` / `LINE_USER_ID` が正常に読み込まれることをローカルで確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)