### PR TITLE
feat: LINE自動プッシュ通知を実装（土日限定・AM9:00）

### DIFF
--- a/infrastructure/scripts/setup_scheduler.sh
+++ b/infrastructure/scripts/setup_scheduler.sh
@@ -10,6 +10,7 @@
 #   2. race-day-predict      AM 8:00 JST  翌日レース予測
 #   3. race-day-odds-scrape  AM 8:15 JST  netkeibaオッズ取得（単複＋組み合わせ）
 #   4. race-day-strategy     AM 8:30 JST  投資戦略策定・investment_decisions保存
+#   5. race-day-notify       AM 9:00 JST  LINE推奨馬券通知（土日のみ）
 #
 # 使用方法:
 #   ./infrastructure/scripts/setup_scheduler.sh
@@ -78,6 +79,9 @@ ODDS_SCRAPE_SCHEDULE="15 8 * * *"
 # 投資戦略ジョブ
 STRATEGY_JOB_NAME="race-day-strategy"
 STRATEGY_SCHEDULE="30 8 * * *"
+# LINE通知ジョブ（土日のみ）
+NOTIFY_JOB_NAME="race-day-notify"
+NOTIFY_SCHEDULE="0 9 * * 0,6"
 TIME_ZONE="Asia/Tokyo"
 
 # サービスアカウントのメールアドレス
@@ -92,6 +96,7 @@ log_info "データロードジョブ: ${LOAD_JOB_NAME} (${LOAD_SCHEDULE})"
 log_info "予測ジョブ: ${PREDICT_JOB_NAME} (${PREDICT_SCHEDULE})"
 log_info "オッズ取得ジョブ: ${ODDS_SCRAPE_JOB_NAME} (${ODDS_SCRAPE_SCHEDULE})"
 log_info "投資戦略ジョブ: ${STRATEGY_JOB_NAME} (${STRATEGY_SCHEDULE})"
+log_info "LINE通知ジョブ: ${NOTIFY_JOB_NAME} (${NOTIFY_SCHEDULE}) ※土日のみ"
 log_info "タイムゾーン: ${TIME_ZONE}"
 log_info "サービスアカウント: ${PIPELINE_SA_EMAIL}"
 log_info "=========================================="
@@ -129,6 +134,9 @@ log_info "オッズ取得URI: ${ODDS_SCRAPE_TARGET_URI}"
 # ターゲットURL（投資戦略: 日次投資戦略エンドポイント）
 STRATEGY_TARGET_URI="${SERVICE_URL}/api/v1/strategy/daily"
 log_info "投資戦略URI: ${STRATEGY_TARGET_URI}"
+# ターゲットURL（LINE通知: 土日AM9:00プッシュ通知エンドポイント）
+NOTIFY_TARGET_URI="${SERVICE_URL}/api/v1/line/notify/daily"
+log_info "LINE通知URI: ${NOTIFY_TARGET_URI}"
 
 # ========================================
 # 2. Cloud Scheduler APIの有効化確認
@@ -256,6 +264,16 @@ create_or_update_job \
     "${STRATEGY_TARGET_URI}" \
     "800s"
 
+# 4-5. LINE通知ジョブ（race-day-notify）
+# investment_decisions を参照してLINEプッシュ通知を送信
+# 土日 AM 9:00 のみ実行（平日はエンドポイント側でスキップ）
+log_info "--- LINE通知ジョブの設定 ---"
+create_or_update_job \
+    "${NOTIFY_JOB_NAME}" \
+    "${NOTIFY_SCHEDULE}" \
+    "${NOTIFY_TARGET_URI}" \
+    "60s"
+
 # ========================================
 # 5. ジョブの確認
 # ========================================
@@ -297,8 +315,11 @@ log_info "  一時停止:    gcloud scheduler jobs pause ${STRATEGY_JOB_NAME} --
 log_info "  再開:        gcloud scheduler jobs resume ${STRATEGY_JOB_NAME} --location=${GCP_REGION}"
 log_info "  実行履歴:    gcloud logging read 'resource.type=\"cloud_scheduler_job\" AND resource.labels.job_id=\"${STRATEGY_JOB_NAME}\"' --limit=10"
 log_info ""
-log_info "注意: 以下のジョブは依存Issueの完了後に追加予定です:"
-log_info "  race-day-notify (AM 9:00) - Issue #25 完了後"
+log_info "【LINE通知ジョブ (${NOTIFY_JOB_NAME})】 ※土日 AM 9:00 のみ"
+log_info "  手動実行:    gcloud scheduler jobs run ${NOTIFY_JOB_NAME} --location=${GCP_REGION}"
+log_info "  一時停止:    gcloud scheduler jobs pause ${NOTIFY_JOB_NAME} --location=${GCP_REGION}"
+log_info "  再開:        gcloud scheduler jobs resume ${NOTIFY_JOB_NAME} --location=${GCP_REGION}"
+log_info "  実行履歴:    gcloud logging read 'resource.type=\"cloud_scheduler_job\" AND resource.labels.job_id=\"${NOTIFY_JOB_NAME}\"' --limit=10"
 log_info ""
 
 # ========================================

--- a/src/automation/api/app.py
+++ b/src/automation/api/app.py
@@ -1039,6 +1039,74 @@ async def run_strategy_daily(request: StrategyDailyRequest):
         raise HTTPException(status_code=500, detail=str(e)) from e
 
 
+class LineNotifyDailyResponse(BaseModel):
+    """LINE日次プッシュ通知レスポンス"""
+
+    status: str = Field(description="処理ステータス (sent/skipped/no_decisions)")
+    execution_date: str = Field(description="対象日付")
+    messages_sent: int = Field(default=0, description="送信したメッセージ数")
+
+
+@app.post("/api/v1/line/notify/daily", response_model=LineNotifyDailyResponse)
+async def line_notify_daily(
+    execution_date: Optional[str] = None,
+):
+    """
+    当日が土曜・日曜の場合のみ、推奨馬券をLINEプッシュ通知で送信する。
+
+    Cloud Scheduler から毎週土日 AM 9:00 に呼び出されることを想定。
+    平日に呼び出された場合は status=skipped を返す。
+
+    前提条件:
+      - predictions.investment_decisions に当日分のデータが存在すること
+        （POST /api/v1/strategy/daily 完了後）
+
+    環境変数:
+      LINE_CHANNEL_ACCESS_TOKEN : プッシュ送信用アクセストークン
+      LINE_USER_ID              : 送信先ユーザーID
+      GCP_PROJECT_ID            : BigQuery プロジェクト ID
+    """
+    target_date = (
+        datetime.date.fromisoformat(execution_date)
+        if execution_date
+        else datetime.date.today()
+    )
+    execution_date_str = target_date.isoformat()
+
+    logger.info(f"LINE日次通知リクエスト受信: execution_date={execution_date_str}")
+
+    channel_access_token = os.environ.get("LINE_CHANNEL_ACCESS_TOKEN", "")
+    user_id = os.environ.get("LINE_USER_ID", "")
+    project_id = os.environ.get("GCP_PROJECT_ID")
+
+    if not project_id:
+        raise HTTPException(status_code=500, detail="GCP_PROJECT_IDが未設定です")
+    if not channel_access_token:
+        raise HTTPException(status_code=500, detail="LINE_CHANNEL_ACCESS_TOKENが未設定です")
+    if not user_id:
+        raise HTTPException(status_code=500, detail="LINE_USER_IDが未設定です")
+
+    try:
+        from src.automation.api.line_webhook import send_daily_push_notification
+
+        result = await asyncio.to_thread(
+            send_daily_push_notification,
+            project_id=project_id,
+            channel_access_token=channel_access_token,
+            user_id=user_id,
+            target_date=target_date,
+        )
+        logger.info(f"LINE日次通知完了: status={result['status']}, messages={result['messages_sent']}")
+        return LineNotifyDailyResponse(
+            status=result["status"],
+            execution_date=execution_date_str,
+            messages_sent=result["messages_sent"],
+        )
+    except Exception as e:
+        logger.error(f"LINE日次通知エラー: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
 class LineWebhookResponse(BaseModel):
     """LINE Webhook レスポンス"""
 

--- a/src/automation/api/line_webhook.py
+++ b/src/automation/api/line_webhook.py
@@ -503,3 +503,148 @@ def process_webhook_events(
             reply_messages(channel_access_token, reply_token, messages)
         except Exception as e:
             logger.error(f"LINE リプライ送信失敗: {e}", exc_info=True)
+
+
+# --- 日次プッシュ通知（土日限定）--------------------------------------------------
+
+def _fetch_investment_decisions(
+    project_id: str,
+    target_date: date,
+) -> list[dict[str, Any]]:
+    """
+    predictions.investment_decisions から当日の投資判断を取得する
+    """
+    from google.cloud import bigquery
+
+    client = bigquery.Client(project=project_id)
+    query = f"""
+    SELECT
+        venue_code,
+        race_number,
+        race_pattern,
+        horse_number,
+        horse_name,
+        bet_type,
+        bet_amount,
+        win_place_prob,
+        place_odds,
+        expected_return
+    FROM `{project_id}.predictions.investment_decisions`
+    WHERE race_date = '{target_date.isoformat()}'
+    ORDER BY venue_code, race_number, expected_return DESC
+    """
+    rows = client.query(query).result()
+    return [dict(row) for row in rows]
+
+
+def format_push_notification(
+    target_date: date,
+    decisions: list[dict[str, Any]],
+) -> list[dict[str, str]]:
+    """
+    投資判断リストから LINE プッシュ通知用のメッセージを生成する。
+
+    レース数が多い場合は最大 4 メッセージ（LINE上限 5 件のうち 1 件はヘッダー）に収める。
+
+    Args:
+        target_date: 対象日
+        decisions: investment_decisions の行リスト
+
+    Returns:
+        LINE メッセージオブジェクトのリスト
+    """
+    if not decisions:
+        return [{"type": "text", "text": f"🏇 {target_date.isoformat()} の推奨馬券はありません。"}]
+
+    # レースごとにグループ化
+    races: dict[tuple[str, int], list[dict]] = {}
+    for d in decisions:
+        key = (str(d.get("venue_code", "")), int(d.get("race_number", 0)))
+        races.setdefault(key, []).append(d)
+
+    total_bet = sum(float(d.get("bet_amount", 0)) for d in decisions)
+
+    # ヘッダーメッセージ
+    header = (
+        f"🏇 本日の推奨馬券 ({target_date.isoformat()})\n"
+        f"レース数: {len(races)}  総投資額: ¥{total_bet:,.0f}"
+    )
+    messages: list[dict[str, str]] = [{"type": "text", "text": header}]
+
+    # レースブロックを最大 4 メッセージに分割
+    race_blocks: list[str] = []
+    for (venue_code, race_number), bets in races.items():
+        venue_name = VENUE_CODE_TO_NAME.get(venue_code, venue_code)
+        pattern_label = PATTERN_LABELS.get(str(bets[0].get("race_pattern", "")), "")
+        lines = [f"【{venue_name} {race_number}R】{pattern_label}"]
+        for b in bets:
+            bet_label = BET_TYPE_LABELS.get(str(b.get("bet_type", "")), str(b.get("bet_type", "")))
+            prob = float(b.get("win_place_prob", 0)) * 100
+            odds = float(b.get("place_odds", 0))
+            ev = float(b.get("expected_return", 0))
+            amount = float(b.get("bet_amount", 0))
+            lines.append(
+                f"  [{bet_label}] 馬番{b.get('horse_number')} {b.get('horse_name', '')}\n"
+                f"    複勝率:{prob:.1f}% / オッズ:{odds:.1f}倍 / 期待値:{ev:.2f}\n"
+                f"    推奨: ¥{amount:,.0f}"
+            )
+        race_blocks.append("\n".join(lines))
+
+    # 4 メッセージに収まるよう複数ブロックをまとめる
+    chunk: list[str] = []
+    chunk_len = 0
+    for block in race_blocks:
+        if chunk_len + len(block) > 4500 or len(messages) + 1 > 4:
+            if chunk:
+                messages.append({"type": "text", "text": "\n\n".join(chunk)})
+                chunk = []
+                chunk_len = 0
+            if len(messages) >= 5:
+                break
+        chunk.append(block)
+        chunk_len += len(block)
+
+    if chunk and len(messages) < 5:
+        messages.append({"type": "text", "text": "\n\n".join(chunk)})
+
+    return messages
+
+
+def is_weekend_in_jst(target_date: date) -> bool:
+    """土曜（weekday=5）または日曜（weekday=6）か判定する"""
+    return target_date.weekday() in (5, 6)
+
+
+def send_daily_push_notification(
+    project_id: str,
+    channel_access_token: str,
+    user_id: str,
+    target_date: date,
+) -> dict[str, Any]:
+    """
+    当日が土日の場合のみ、投資判断をLINEプッシュ通知で送信する。
+
+    Args:
+        project_id: GCP プロジェクト ID
+        channel_access_token: LINE チャネルアクセストークン
+        user_id: 送信先 LINE ユーザー ID
+        target_date: 対象日
+
+    Returns:
+        {"status": "sent"|"skipped"|"no_decisions", "messages_sent": int}
+    """
+    from src.utils.line_notify import push_messages
+
+    if not is_weekend_in_jst(target_date):
+        logger.info(f"平日のためLINE通知をスキップ: {target_date} (weekday={target_date.weekday()})")
+        return {"status": "skipped", "messages_sent": 0}
+
+    decisions = _fetch_investment_decisions(project_id, target_date)
+    if not decisions:
+        logger.info(f"投資判断なし: {target_date}")
+        return {"status": "no_decisions", "messages_sent": 0}
+
+    messages = format_push_notification(target_date, decisions)
+    push_messages(channel_access_token, user_id, messages)
+    logger.info(f"LINE プッシュ通知送信完了: {len(messages)}件")
+    return {"status": "sent", "messages_sent": len(messages)}

--- a/tests/test_line_notify_daily.py
+++ b/tests/test_line_notify_daily.py
@@ -1,0 +1,242 @@
+"""
+LINE 日次プッシュ通知のユニットテスト
+
+テスト対象:
+  - is_weekend_in_jst: 土日判定
+  - format_push_notification: 通知メッセージフォーマット
+  - send_daily_push_notification: BQ取得 + 送信（モック）
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.automation.api.line_webhook import (
+    format_push_notification,
+    is_weekend_in_jst,
+    send_daily_push_notification,
+)
+
+
+# ---------------------------------------------------------------------------
+# is_weekend_in_jst
+# ---------------------------------------------------------------------------
+
+class TestIsWeekendInJst:
+    def test_saturday_is_weekend(self):
+        # 2026-03-07 は土曜
+        assert is_weekend_in_jst(date(2026, 3, 7)) is True
+
+    def test_sunday_is_weekend(self):
+        # 2026-03-08 は日曜
+        assert is_weekend_in_jst(date(2026, 3, 8)) is True
+
+    def test_monday_is_weekday(self):
+        assert is_weekend_in_jst(date(2026, 3, 9)) is False
+
+    def test_friday_is_weekday(self):
+        assert is_weekend_in_jst(date(2026, 3, 13)) is False
+
+    def test_all_weekdays(self):
+        # 2026-03-09(月) 〜 2026-03-13(金)
+        for day in range(9, 14):
+            assert is_weekend_in_jst(date(2026, 3, day)) is False
+
+
+# ---------------------------------------------------------------------------
+# format_push_notification
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def sample_decisions():
+    return [
+        {
+            "venue_code": "09",
+            "race_number": 12,
+            "race_pattern": "standard",
+            "horse_number": 12,
+            "horse_name": "ニューオーリンズ",
+            "bet_type": "place",
+            "bet_amount": 2000.0,
+            "win_place_prob": 0.52,
+            "place_odds": 2.5,
+            "expected_return": 1.30,
+        },
+        {
+            "venue_code": "09",
+            "race_number": 12,
+            "race_pattern": "standard",
+            "horse_number": 13,
+            "horse_name": "チュウワチーフ",
+            "bet_type": "place",
+            "bet_amount": 1500.0,
+            "win_place_prob": 0.51,
+            "place_odds": 3.0,
+            "expected_return": 1.53,
+        },
+        {
+            "venue_code": "05",
+            "race_number": 11,
+            "race_pattern": "one_dominant",
+            "horse_number": 5,
+            "horse_name": "トーキョーホース",
+            "bet_type": "win",
+            "bet_amount": 1000.0,
+            "win_place_prob": 0.60,
+            "place_odds": 2.0,
+            "expected_return": 1.20,
+        },
+    ]
+
+
+class TestFormatPushNotification:
+    def test_returns_list_of_messages(self, sample_decisions):
+        messages = format_push_notification(date(2026, 3, 8), sample_decisions)
+        assert isinstance(messages, list)
+        assert len(messages) >= 1
+        for msg in messages:
+            assert msg["type"] == "text"
+
+    def test_header_contains_date(self, sample_decisions):
+        messages = format_push_notification(date(2026, 3, 8), sample_decisions)
+        header = messages[0]["text"]
+        assert "2026-03-08" in header
+
+    def test_header_contains_total_bet(self, sample_decisions):
+        messages = format_push_notification(date(2026, 3, 8), sample_decisions)
+        header = messages[0]["text"]
+        assert "4,500" in header  # 2000 + 1500 + 1000
+
+    def test_venue_name_in_body(self, sample_decisions):
+        messages = format_push_notification(date(2026, 3, 8), sample_decisions)
+        body = " ".join(m["text"] for m in messages)
+        assert "阪神" in body
+        assert "東京" in body
+
+    def test_bet_type_label_in_body(self, sample_decisions):
+        messages = format_push_notification(date(2026, 3, 8), sample_decisions)
+        body = " ".join(m["text"] for m in messages)
+        assert "複勝" in body
+        assert "単勝" in body
+
+    def test_horse_name_in_body(self, sample_decisions):
+        messages = format_push_notification(date(2026, 3, 8), sample_decisions)
+        body = " ".join(m["text"] for m in messages)
+        assert "ニューオーリンズ" in body
+
+    def test_pattern_label_in_body(self, sample_decisions):
+        messages = format_push_notification(date(2026, 3, 8), sample_decisions)
+        body = " ".join(m["text"] for m in messages)
+        assert "標準型" in body
+        assert "突出型" in body
+
+    def test_empty_decisions_returns_no_data_message(self):
+        messages = format_push_notification(date(2026, 3, 8), [])
+        assert len(messages) == 1
+        assert "ありません" in messages[0]["text"]
+
+    def test_max_5_messages(self):
+        # 大量レースでも5件以下に収まること
+        decisions = [
+            {
+                "venue_code": "05",
+                "race_number": i,
+                "race_pattern": "standard",
+                "horse_number": 1,
+                "horse_name": f"ウマ{i}",
+                "bet_type": "place",
+                "bet_amount": 1000.0,
+                "win_place_prob": 0.5,
+                "place_odds": 2.0,
+                "expected_return": 1.0,
+            }
+            for i in range(1, 20)
+        ]
+        messages = format_push_notification(date(2026, 3, 8), decisions)
+        assert len(messages) <= 5
+
+
+# ---------------------------------------------------------------------------
+# send_daily_push_notification
+# ---------------------------------------------------------------------------
+
+class TestSendDailyPushNotification:
+    @patch("src.automation.api.line_webhook._fetch_investment_decisions")
+    @patch("src.utils.line_notify.requests.post")
+    def test_weekend_sends_notification(self, mock_post, mock_fetch):
+        mock_fetch.return_value = [
+            {
+                "venue_code": "09", "race_number": 12, "race_pattern": "standard",
+                "horse_number": 1, "horse_name": "テスト馬", "bet_type": "place",
+                "bet_amount": 1000.0, "win_place_prob": 0.5,
+                "place_odds": 2.0, "expected_return": 1.0,
+            }
+        ]
+        mock_post.return_value = MagicMock(status_code=200)
+
+        result = send_daily_push_notification(
+            project_id="test_project",
+            channel_access_token="test_token",
+            user_id="test_user",
+            target_date=date(2026, 3, 7),  # 土曜
+        )
+
+        assert result["status"] == "sent"
+        assert result["messages_sent"] >= 1
+        mock_post.assert_called_once()
+
+    @patch("src.utils.line_notify.requests.post")
+    def test_weekday_skips(self, mock_post):
+        result = send_daily_push_notification(
+            project_id="test_project",
+            channel_access_token="test_token",
+            user_id="test_user",
+            target_date=date(2026, 3, 9),  # 月曜
+        )
+
+        assert result["status"] == "skipped"
+        assert result["messages_sent"] == 0
+        mock_post.assert_not_called()
+
+    @patch("src.automation.api.line_webhook._fetch_investment_decisions")
+    @patch("src.utils.line_notify.requests.post")
+    def test_no_decisions_returns_no_decisions(self, mock_post, mock_fetch):
+        mock_fetch.return_value = []
+        mock_post.return_value = MagicMock(status_code=200)
+
+        result = send_daily_push_notification(
+            project_id="test_project",
+            channel_access_token="test_token",
+            user_id="test_user",
+            target_date=date(2026, 3, 8),  # 日曜
+        )
+
+        assert result["status"] == "no_decisions"
+        assert result["messages_sent"] == 0
+        mock_post.assert_not_called()
+
+    @patch("src.automation.api.line_webhook._fetch_investment_decisions")
+    @patch("src.utils.line_notify.requests.post")
+    def test_sunday_sends_notification(self, mock_post, mock_fetch):
+        mock_fetch.return_value = [
+            {
+                "venue_code": "05", "race_number": 11, "race_pattern": "one_dominant",
+                "horse_number": 3, "horse_name": "日曜馬", "bet_type": "place",
+                "bet_amount": 2000.0, "win_place_prob": 0.6,
+                "place_odds": 2.5, "expected_return": 1.5,
+            }
+        ]
+        mock_post.return_value = MagicMock(status_code=200)
+
+        result = send_daily_push_notification(
+            project_id="test_project",
+            channel_access_token="test_token",
+            user_id="test_user",
+            target_date=date(2026, 3, 8),  # 日曜
+        )
+
+        assert result["status"] == "sent"
+        mock_post.assert_called_once()


### PR DESCRIPTION
## Summary

- `POST /api/v1/line/notify/daily` エンドポイントを新規追加
- **土曜・日曜のみ** `predictions.investment_decisions` を参照してLINEプッシュ通知を送信
- 平日に呼び出された場合は `status=skipped` を返す（二重安全: エンドポイント側でも判定）
- Cloud Scheduler `race-day-notify` ジョブを `setup_scheduler.sh` に追加（`0 9 * * 0,6`）

## 通知メッセージ例

```
🏇 本日の推奨馬券 (2026-03-08)
レース数: 2  総投資額: ¥4,500

【阪神 12R】標準型
  [複勝] 馬番12 ニューオーリンズ
    複勝率:52.0% / オッズ:2.5倍 / 期待値:1.30
    推奨: ¥2,000
  [複勝] 馬番13 チュウワチーフ
    ...
```

## Test plan

- [x] `tests/test_line_notify_daily.py` 18件 全件PASS
- [x] 既存テスト 618件 全件PASS
- [x] 土曜・日曜 → `status=sent`
- [x] 平日 → `status=skipped`（LINE API未呼び出しを確認）
- [x] 投資判断なし → `status=no_decisions`
- [x] LINEメッセージが最大5件に収まること

🤖 Generated with [Claude Code](https://claude.com/claude-code)