### PR TITLE
fix: 日次LINE通知を上位10レース（期待回収率順）に限定

### DIFF
--- a/src/automation/api/line_webhook.py
+++ b/src/automation/api/line_webhook.py
@@ -510,28 +510,50 @@ def process_webhook_events(
 def _fetch_investment_decisions(
     project_id: str,
     target_date: date,
+    max_races: int = 10,
 ) -> list[dict[str, Any]]:
     """
-    predictions.investment_decisions から当日の投資判断を取得する
+    predictions.investment_decisions から当日の投資判断を取得する。
+
+    レースごとに最大期待回収率の馬でレースをランク付けし、
+    上位 max_races レースのみを返す。
+
+    Args:
+        project_id: GCP プロジェクト ID
+        target_date: 対象日
+        max_races: 通知対象の最大レース数（デフォルト10）
     """
     from google.cloud import bigquery
 
     client = bigquery.Client(project=project_id)
     query = f"""
+    WITH race_rank AS (
+      -- レースごとの最大期待回収率を計算し、上位 {max_races} レースを選定
+      SELECT
+        race_id,
+        MAX(expected_return) AS max_expected_return
+      FROM `{project_id}.predictions.investment_decisions`
+      WHERE race_date = '{target_date.isoformat()}'
+      GROUP BY race_id
+      ORDER BY max_expected_return DESC
+      LIMIT {max_races}
+    )
     SELECT
-        venue_code,
-        race_number,
-        race_pattern,
-        horse_number,
-        horse_name,
-        bet_type,
-        bet_amount,
-        win_place_prob,
-        place_odds,
-        expected_return
-    FROM `{project_id}.predictions.investment_decisions`
-    WHERE race_date = '{target_date.isoformat()}'
-    ORDER BY venue_code, race_number, expected_return DESC
+      d.venue_code,
+      d.race_number,
+      d.race_pattern,
+      d.horse_number,
+      d.horse_name,
+      d.bet_type,
+      d.bet_amount,
+      d.win_place_prob,
+      d.place_odds,
+      d.expected_return,
+      r.max_expected_return
+    FROM `{project_id}.predictions.investment_decisions` d
+    JOIN race_rank r ON d.race_id = r.race_id
+    WHERE d.race_date = '{target_date.isoformat()}'
+    ORDER BY r.max_expected_return DESC, d.venue_code, d.race_number, d.expected_return DESC
     """
     rows = client.query(query).result()
     return [dict(row) for row in rows]
@@ -639,7 +661,7 @@ def send_daily_push_notification(
         logger.info(f"平日のためLINE通知をスキップ: {target_date} (weekday={target_date.weekday()})")
         return {"status": "skipped", "messages_sent": 0}
 
-    decisions = _fetch_investment_decisions(project_id, target_date)
+    decisions = _fetch_investment_decisions(project_id, target_date, max_races=10)
     if not decisions:
         logger.info(f"投資判断なし: {target_date}")
         return {"status": "no_decisions", "messages_sent": 0}

--- a/tests/test_line_notify_daily.py
+++ b/tests/test_line_notify_daily.py
@@ -139,7 +139,8 @@ class TestFormatPushNotification:
         assert "ありません" in messages[0]["text"]
 
     def test_max_5_messages(self):
-        # 大量レースでも5件以下に収まること
+        # 上位10レースに絞られた後も、LINEメッセージは5件以下に収まること
+        # （上位10レースの選定はSQL側で行うため、ここでは10レース分のデータを渡す）
         decisions = [
             {
                 "venue_code": "05",
@@ -152,8 +153,9 @@ class TestFormatPushNotification:
                 "win_place_prob": 0.5,
                 "place_odds": 2.0,
                 "expected_return": 1.0,
+                "max_expected_return": 1.0,
             }
-            for i in range(1, 20)
+            for i in range(1, 11)  # 上位10レース分
         ]
         messages = format_push_notification(date(2026, 3, 8), decisions)
         assert len(messages) <= 5
@@ -240,3 +242,19 @@ class TestSendDailyPushNotification:
 
         assert result["status"] == "sent"
         mock_post.assert_called_once()
+
+    @patch("src.automation.api.line_webhook._fetch_investment_decisions")
+    @patch("src.utils.line_notify.requests.post")
+    def test_fetch_called_with_max_races_10(self, mock_post, mock_fetch):
+        """_fetch_investment_decisions が max_races=10 で呼ばれることを確認"""
+        mock_fetch.return_value = []
+        mock_post.return_value = MagicMock(status_code=200)
+
+        send_daily_push_notification(
+            project_id="test_project",
+            channel_access_token="test_token",
+            user_id="test_user",
+            target_date=date(2026, 3, 7),  # 土曜
+        )
+
+        mock_fetch.assert_called_once_with("test_project", date(2026, 3, 7), max_races=10)


### PR DESCRIPTION
## Summary

- `_fetch_investment_decisions()` に `max_races` パラメータを追加し、CTEでレースごとの最大期待回収率を計算、上位レースのみを返すよう変更
- `send_daily_push_notification()` 内で `max_races=10` を明示的に指定
- テストに `test_fetch_called_with_max_races_10` を追加し、仕様を保証

## Test plan
- [x] `tests/test_line_notify_daily.py` 全19件 PASS
- [x] `test_fetch_called_with_max_races_10`: `_fetch_investment_decisions` が `max_races=10` で呼ばれることを確認
- [x] `test_max_5_messages`: 10レース分データでもLINEメッセージが5件以下に収まることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)