### PR TITLE
fix: SECパーサーの着順フィールド位置ズレを修正

### DIFF
--- a/src/automation/data/jrdb_parser.py
+++ b/src/automation/data/jrdb_parser.py
@@ -617,71 +617,75 @@ class JRDBParser:
             num_horses = JRDBParser.safe_int(line[87:89])
 
             # === 馬成績 ===
-            finish_position = JRDBParser.safe_int(line[93:95])
-            abnormal_code = JRDBParser.safe_int(line[95:96])
+            # SEC仕様: 頭数(131-132) + 馬番(133-134) + 着順(135-136) + 異常コード(137) + ...
+            # UTF-8位置: 87-88    + 89-90       + 91-92    + 93         + ...
+            # ※ 馬番(89-90)はスキップ（頭数の直後に再掲されるがパースでは不使用）
+            finish_position = JRDBParser.safe_int(line[91:93])
+            abnormal_code = JRDBParser.safe_int(line[93:94])
 
             # タイム (0.1秒単位) → 秒に変換
-            time_raw = JRDBParser.safe_int(line[96:100])
+            time_raw = JRDBParser.safe_int(line[94:98])
             finish_time = time_raw / 10.0 if time_raw else None
 
             # 斤量 (0.1kg単位) → kgに変換
-            weight_raw = JRDBParser.safe_int(line[100:103])
+            weight_raw = JRDBParser.safe_int(line[98:101])
             weight_carried = weight_raw / 10.0 if weight_raw else None
 
             # === 騎手名・調教師名 (全角6文字ずつ) ===
-            jockey_name = line[103:109].strip().replace('　', '')
-            trainer_name = line[109:115].strip().replace('　', '')
+            jockey_name = line[101:107].strip().replace('　', '')
+            trainer_name = line[107:113].strip().replace('　', '')
 
             # === オッズ・人気 ===
-            win_odds = JRDBParser.safe_float(line[115:121])
-            win_popularity = JRDBParser.safe_int(line[121:123])
+            win_odds = JRDBParser.safe_float(line[113:119])
+            win_popularity = JRDBParser.safe_int(line[119:121])
 
             # === JRDB指数 ===
-            idm = JRDBParser.safe_float(line[123:126])
-            raw_score = JRDBParser.safe_float(line[126:129])
-            track_bias = JRDBParser.safe_float(line[129:132])
-            pace = JRDBParser.safe_float(line[132:135])
-            late_start = JRDBParser.safe_float(line[135:138])
-            position_fault = JRDBParser.safe_float(line[138:141])
-            disadvantage = JRDBParser.safe_float(line[141:144])
-            front_disadvantage = JRDBParser.safe_float(line[144:147])
-            mid_disadvantage = JRDBParser.safe_float(line[147:150])
-            back_disadvantage = JRDBParser.safe_float(line[150:153])
-            race_score = JRDBParser.safe_float(line[153:156])
+            idm = JRDBParser.safe_float(line[121:124])
+            raw_score = JRDBParser.safe_float(line[124:127])
+            track_bias = JRDBParser.safe_float(line[127:130])
+            pace = JRDBParser.safe_float(line[130:133])
+            late_start = JRDBParser.safe_float(line[133:136])
+            position_fault = JRDBParser.safe_float(line[136:139])
+            disadvantage = JRDBParser.safe_float(line[139:142])
+            front_disadvantage = JRDBParser.safe_float(line[142:145])
+            mid_disadvantage = JRDBParser.safe_float(line[145:148])
+            back_disadvantage = JRDBParser.safe_float(line[148:151])
+            race_score = JRDBParser.safe_float(line[151:154])
 
             # === コース取り・上昇度・クラス ===
-            course_position = JRDBParser.safe_int(line[156:157])
-            improvement_code = JRDBParser.safe_int(line[157:158])
-            class_code = JRDBParser.safe_int(line[158:160])
-            body_code = JRDBParser.safe_int(line[160:161])
-            condition_code = JRDBParser.safe_int(line[161:162])
+            course_position = JRDBParser.safe_int(line[154:155])
+            improvement_code = JRDBParser.safe_int(line[155:156])
+            class_code = JRDBParser.safe_int(line[156:158])
+            body_code = JRDBParser.safe_int(line[158:159])
+            condition_code = JRDBParser.safe_int(line[159:160])
 
             # === ペース ===
-            race_pace = line[162:163].strip() if len(line) > 163 else ''
-            horse_pace = line[163:164].strip() if len(line) > 164 else ''
+            race_pace = line[160:161].strip() if len(line) > 161 else ''
+            horse_pace = line[161:162].strip() if len(line) > 162 else ''
 
             # === 指数群 ===
-            ten_index = JRDBParser.safe_float(line[164:169]) if len(line) > 169 else None
-            agari_index = JRDBParser.safe_float(line[169:174]) if len(line) > 174 else None
-            pace_index = JRDBParser.safe_float(line[174:179]) if len(line) > 179 else None
-            race_pace_index = JRDBParser.safe_float(line[179:184]) if len(line) > 184 else None
+            ten_index = JRDBParser.safe_float(line[162:167]) if len(line) > 167 else None
+            agari_index = JRDBParser.safe_float(line[167:172]) if len(line) > 172 else None
+            pace_index = JRDBParser.safe_float(line[172:177]) if len(line) > 177 else None
+            race_pace_index = JRDBParser.safe_float(line[177:182]) if len(line) > 182 else None
 
             # === 1(2)着馬名 (全角6文字) ===
-            winner_name = line[184:190].strip().replace('　', '') if len(line) > 190 else ''
+            winner_name = line[182:188].strip().replace('　', '') if len(line) > 188 else ''
 
             # 1着タイム差 (0.1秒単位)
-            winner_diff_raw = JRDBParser.safe_int(line[190:193]) if len(line) > 193 else None
+            winner_diff_raw = JRDBParser.safe_int(line[188:191]) if len(line) > 191 else None
             winner_time_diff = winner_diff_raw / 10.0 if winner_diff_raw else None
 
             # 前3F/後3Fタイム (0.1秒単位)
-            front_3f_raw = JRDBParser.safe_int(line[193:196]) if len(line) > 196 else None
+            front_3f_raw = JRDBParser.safe_int(line[191:194]) if len(line) > 194 else None
             front_3f_time = front_3f_raw / 10.0 if front_3f_raw else None
 
-            last_3f_raw = JRDBParser.safe_int(line[196:199]) if len(line) > 199 else None
+            last_3f_raw = JRDBParser.safe_int(line[194:197]) if len(line) > 197 else None
             last_3f_time = last_3f_raw / 10.0 if last_3f_raw else None
 
-            # === 備考 (全角12文字 = 位置199-211) ===
-            remarks = line[199:211].strip().replace('　', '').strip() if len(line) > 211 else ''
+            # === 備考 (全角10文字 = 位置197-207) ===
+            # SEC仕様: 備考(259-278) = 20バイト = 10全角 → UTF-8位置 197-207
+            remarks = line[197:207].strip().replace('　', '').strip() if len(line) > 207 else ''
 
             # === 馬体重関連フィールド (絶対位置で取得) ===
             # SEC仕様: 馬体重(333-335), 増減(336-338), 天候(339), コース(340), 脚質(341)

--- a/tests/test_jrdb_parser_sec.py
+++ b/tests/test_jrdb_parser_sec.py
@@ -1,0 +1,385 @@
+"""
+JRDBParser の parse_sec_line ユニットテスト
+
+着順などのフィールド位置が正しく解析されることを検証する。
+
+SEC レコード構造 (CP932 デコード後の Python 文字列位置):
+  0- 7: レースキー (8 ASCII)
+  8- 9: 馬番 (2 ASCII)
+ 10-17: 血統登録番号 (8 ASCII)
+ 18-25: 年月日 (8 ASCII, YYYYMMDD)
+ 26-43: 馬名 (18 全角 = 18 Python chars)
+ 44-47: 距離 (4 ASCII)
+ 48   : 芝ダ障害コード (1)
+ 49   : 右左コード (1)
+ 50   : 内外コード (1)
+ 51-52: 馬場状態コード (2)
+ 53-54: 種別コード (2)
+ 55-56: 条件コード (2)
+ 57-60: 記号コード (4)
+ 61   : グレードコード (1)
+ 62-86: レース名 (25 全角 = 25 Python chars)
+ 87-88: 頭数 (2 ASCII)
+ 89-90: 馬番 再掲 (2 ASCII, スキップ)
+ 91-92: 着順 (2 ASCII)  ← finish_position
+ 93   : 異常コード (1 ASCII)
+ 94-97: 走破タイム 0.1秒単位 (4 ASCII)
+ 98-100: 斤量 0.1kg単位 (3 ASCII)
+101-106: 騎手名 (6 全角 = 6 Python chars)
+107-112: 調教師名 (6 全角 = 6 Python chars)
+113-118: 単勝オッズ (6 ASCII)
+119-120: 単勝人気 (2 ASCII)
+121-123: IDM (3 ASCII)
+...
+182-187: 1着馬名 (6 全角 = 6 Python chars)
+188-190: 1着タイム差 (3 ASCII)
+191-193: 前3F (3 ASCII)
+194-196: 後3F (3 ASCII)
+197-206: 備考 (10 全角 = 10 Python chars)
+207-218: コーナー順位等 (12 ASCII, 非抽出)
+219-224: 確定複勝オッズ下 (6 ASCII)  ← 仕様書 相対291, 検証済み
+225-230: 10時単勝オッズ (6 ASCII)
+231-236: 10時複勝オッズ (6 ASCII)
+...
+261-263: 馬体重 (3 ASCII)  ← 仕様書 byte 333-335, 検証済み
+264-266: 馬体重増減 (3 ASCII)
+267   : 天候コード (1)
+268   : コース (1)
+269   : レース脚質 (1)
+"""
+
+import pytest
+from src.automation.data.jrdb_parser import JRDBParser
+
+
+def _build_sec_line(
+    race_key: str = "08261712",
+    horse_number: str = "03",
+    horse_id: str = "23045678",
+    race_date: str = "20260118",
+    horse_name_full: str = "サク",          # 全角で指定、18文字にパディング
+    distance: str = "1600",
+    course_type: str = "1",
+    direction: str = "2",
+    inner_outer: str = " ",
+    track_condition: str = "11",
+    race_type: str = "11",
+    race_condition: str = "05",
+    mark_code: str = "    ",
+    grade_code: str = " ",
+    race_name_full: str = "4歳以上1勝クラス",  # 25文字にパディング
+    num_horses: str = "12",
+    horse_number_2: str = "03",
+    finish_pos: str = " 1",
+    abnormal_code: str = "0",
+    time_val: str = "0961",
+    weight_carried: str = "560",
+    jockey_name_full: str = "川田将雅",       # 6全角にパディング
+    trainer_name_full: str = "友道康夫",      # 6全角にパディング
+    win_odds: str = " 43.5",
+    win_popularity: str = " 5",
+    idm: str = "   ",
+    raw_score: str = "   ",
+    track_bias: str = "   ",
+    pace_val: str = "   ",
+    late_start: str = "   ",
+    position_fault: str = "   ",
+    disadvantage: str = "   ",
+    front_disadvantage: str = "   ",
+    mid_disadvantage: str = "   ",
+    back_disadvantage: str = "   ",
+    race_score: str = "   ",
+    course_position: str = " ",
+    improvement_code: str = " ",
+    class_code: str = "  ",
+    body_code: str = " ",
+    condition_code: str = " ",
+    race_pace: str = " ",
+    horse_pace: str = " ",
+    ten_index: str = "     ",
+    agari_index: str = "     ",
+    pace_index: str = "     ",
+    race_pace_index: str = "     ",
+    winner_name_full: str = "サク",          # 6全角にパディング
+    winner_diff: str = "  0",
+    front_3f: str = "347",
+    last_3f: str = "345",
+    remarks_full: str = "",                 # 10全角にパディング
+    corner_data: str = "            ",      # 12 ASCII (コーナー順位等)
+    place_odds: str = "  12.0",
+    odds_10am_win: str = "  43.5",
+    odds_10am_place: str = "  12.0",
+    # 219-260: 残りフィールド (42 ASCII)
+    intermediate: str = " " * 24,
+    horse_weight: str = "470",
+    weight_diff: str = "+10",
+    weather_code: str = "1",
+    course_code: str = "1",
+    race_running_style: str = "3",
+) -> str:
+    """テスト用 SEC 行を構築するヘルパー関数。"""
+
+    def _pad_full(text: str, width: int) -> str:
+        """全角文字列を指定文字数にパディング (全角スペースで埋める)。"""
+        padded = text.ljust(width, '　')
+        return padded[:width]
+
+    def _pad_ascii(text: str, width: int) -> str:
+        """ASCII文字列を指定文字数にパディング (半角スペースで埋める)。"""
+        padded = text.ljust(width, ' ')
+        return padded[:width]
+
+    # 各セクションを組み立てる
+    # 0- 7: レースキー
+    sec = _pad_ascii(race_key, 8)
+    # 8- 9: 馬番
+    sec += _pad_ascii(horse_number, 2)
+    # 10-17: 血統登録番号
+    sec += _pad_ascii(horse_id, 8)
+    # 18-25: 年月日
+    sec += _pad_ascii(race_date, 8)
+    # 26-43: 馬名 (18全角)
+    sec += _pad_full(horse_name_full, 18)
+    # 44-47: 距離
+    sec += _pad_ascii(distance, 4)
+    # 48: 芝ダ障害コード
+    sec += course_type
+    # 49: 右左コード
+    sec += direction
+    # 50: 内外コード
+    sec += inner_outer
+    # 51-52: 馬場状態コード
+    sec += _pad_ascii(track_condition, 2)
+    # 53-54: 種別コード
+    sec += _pad_ascii(race_type, 2)
+    # 55-56: 条件コード
+    sec += _pad_ascii(race_condition, 2)
+    # 57-60: 記号コード
+    sec += _pad_ascii(mark_code, 4)
+    # 61: グレードコード
+    sec += grade_code
+    # 62-86: レース名 (25全角)
+    sec += _pad_full(race_name_full, 25)
+    # 87-88: 頭数
+    sec += _pad_ascii(num_horses, 2)
+    # 89-90: 馬番 再掲 (スキップ)
+    sec += _pad_ascii(horse_number_2, 2)
+    # 91-92: 着順
+    assert len(sec) == 91, f"Expected 91 chars before finish_pos, got {len(sec)}"
+    sec += _pad_ascii(finish_pos, 2)
+    # 93: 異常コード
+    sec += abnormal_code
+    # 94-97: 走破タイム
+    sec += _pad_ascii(time_val, 4)
+    # 98-100: 斤量
+    sec += _pad_ascii(weight_carried, 3)
+    # 101-106: 騎手名 (6全角)
+    sec += _pad_full(jockey_name_full, 6)
+    # 107-112: 調教師名 (6全角)
+    sec += _pad_full(trainer_name_full, 6)
+    # 113-118: 単勝オッズ (6桁)
+    sec += _pad_ascii(win_odds, 6)
+    # 119-120: 単勝人気
+    sec += _pad_ascii(win_popularity, 2)
+    # 121-123: IDM (3桁)
+    sec += _pad_ascii(idm, 3)
+    # 124-126: 素点
+    sec += _pad_ascii(raw_score, 3)
+    # 127-129: 馬場差
+    sec += _pad_ascii(track_bias, 3)
+    # 130-132: ペース
+    sec += _pad_ascii(pace_val, 3)
+    # 133-135: 出遅
+    sec += _pad_ascii(late_start, 3)
+    # 136-138: 位置取
+    sec += _pad_ascii(position_fault, 3)
+    # 139-141: 不利
+    sec += _pad_ascii(disadvantage, 3)
+    # 142-144: 前不利
+    sec += _pad_ascii(front_disadvantage, 3)
+    # 145-147: 中不利
+    sec += _pad_ascii(mid_disadvantage, 3)
+    # 148-150: 後不利
+    sec += _pad_ascii(back_disadvantage, 3)
+    # 151-153: レース指数
+    sec += _pad_ascii(race_score, 3)
+    # 154: コース取
+    sec += course_position
+    # 155: 上昇度コード
+    sec += improvement_code
+    # 156-157: クラスコード
+    sec += _pad_ascii(class_code, 2)
+    # 158: 馬体コード
+    sec += body_code
+    # 159: 気配コード
+    sec += condition_code
+    # 160: レースペース
+    sec += race_pace
+    # 161: 馬ペース
+    sec += horse_pace
+    # 162-166: テン指数 (5桁)
+    sec += _pad_ascii(ten_index, 5)
+    # 167-171: 上がり指数
+    sec += _pad_ascii(agari_index, 5)
+    # 172-176: ペース指数
+    sec += _pad_ascii(pace_index, 5)
+    # 177-181: レースP指数
+    sec += _pad_ascii(race_pace_index, 5)
+    # 182-187: 1着馬名 (6全角)
+    sec += _pad_full(winner_name_full, 6)
+    # 188-190: 1着タイム差 (3桁)
+    sec += _pad_ascii(winner_diff, 3)
+    # 191-193: 前3F
+    sec += _pad_ascii(front_3f, 3)
+    # 194-196: 後3F
+    sec += _pad_ascii(last_3f, 3)
+    # 197-206: 備考 (10全角)
+    sec += _pad_full(remarks_full, 10)
+    # 207-218: コーナー順位等 (12 ASCII)
+    assert len(sec) == 207, f"Expected 207 chars before corner_data, got {len(sec)}"
+    sec += _pad_ascii(corner_data, 12)
+    # 219-224: 確定複勝オッズ下 (6桁) ← 検証済み位置
+    assert len(sec) == 219, f"Expected 219 chars before place_odds, got {len(sec)}"
+    sec += _pad_ascii(place_odds, 6)
+    # 225-230: 10時単勝オッズ
+    sec += _pad_ascii(odds_10am_win, 6)
+    # 231-236: 10時複勝オッズ
+    sec += _pad_ascii(odds_10am_place, 6)
+    # 237-260: 中間フィールド (24 ASCII)
+    sec += _pad_ascii(intermediate, 24)
+    # 261-263: 馬体重 (3桁) ← 検証済み位置 (仕様書 byte 333-335)
+    assert len(sec) == 261, f"Expected 261 chars before horse_weight, got {len(sec)}"
+    sec += _pad_ascii(horse_weight, 3)
+    # 264-266: 馬体重増減
+    sec += _pad_ascii(weight_diff, 3)
+    # 267: 天候コード
+    sec += weather_code
+    # 268: コース
+    sec += course_code
+    # 269: レース脚質
+    sec += race_running_style
+
+    return sec
+
+
+class TestSecParserFinishPosition:
+    """着順フィールドの正しい解析を検証する。"""
+
+    def test_finish_position_first(self):
+        """1着の着順が正しく取得できること。"""
+        line = _build_sec_line(
+            horse_name_full="サク",
+            finish_pos=" 1",
+            abnormal_code="0",
+            time_val="0961",
+        )
+        result = JRDBParser.parse_sec_line(line)
+        assert result is not None
+        assert result["finish_position"] == 1
+
+    def test_finish_position_second(self):
+        """2着の着順が正しく取得できること。"""
+        line = _build_sec_line(
+            horse_name_full="レッドフェルメール",
+            horse_number="11",
+            horse_number_2="11",
+            finish_pos=" 2",
+            time_val="0961",
+        )
+        result = JRDBParser.parse_sec_line(line)
+        assert result is not None
+        assert result["finish_position"] == 2
+
+    def test_finish_position_third(self):
+        """3着の着順が正しく取得できること。"""
+        line = _build_sec_line(
+            horse_name_full="パスコード",
+            horse_number="01",
+            horse_number_2="01",
+            finish_pos=" 3",
+        )
+        result = JRDBParser.parse_sec_line(line)
+        assert result is not None
+        assert result["finish_position"] == 3
+
+    def test_finish_position_not_zero(self):
+        """着順が 0 にならないこと（バグ回帰テスト）。"""
+        for pos in range(1, 13):
+            line = _build_sec_line(finish_pos=f"{pos:2d}", abnormal_code="0")
+            result = JRDBParser.parse_sec_line(line)
+            assert result is not None
+            assert result["finish_position"] == pos, (
+                f"finish_position should be {pos}, got {result['finish_position']}"
+            )
+
+    def test_abnormal_code_normal(self):
+        """正常完走時の異常コードが 0 であること。"""
+        line = _build_sec_line(finish_pos=" 1", abnormal_code="0")
+        result = JRDBParser.parse_sec_line(line)
+        assert result is not None
+        assert result["abnormal_code"] == 0
+
+    def test_finish_time_parsed_correctly(self):
+        """走破タイムが正しく解析されること (0.1秒単位)。"""
+        # 96.1秒 = 0961
+        line = _build_sec_line(finish_pos=" 1", time_val="0961")
+        result = JRDBParser.parse_sec_line(line)
+        assert result is not None
+        assert result["finish_time"] == pytest.approx(96.1)
+
+    def test_weight_carried_parsed(self):
+        """斤量が正しく解析されること (0.1kg単位 → kg)。"""
+        line = _build_sec_line(weight_carried="560")  # 56.0kg
+        result = JRDBParser.parse_sec_line(line)
+        assert result is not None
+        assert result["weight_carried"] == pytest.approx(56.0)
+
+    def test_jockey_name_parsed(self):
+        """騎手名が正しく解析されること。"""
+        line = _build_sec_line(jockey_name_full="川田将雅")
+        result = JRDBParser.parse_sec_line(line)
+        assert result is not None
+        assert result["jockey_name"] == "川田将雅"
+
+    def test_horse_name_parsed(self):
+        """馬名が正しく解析されること。"""
+        line = _build_sec_line(horse_name_full="サク")
+        result = JRDBParser.parse_sec_line(line)
+        assert result is not None
+        assert result["horse_name"] == "サク"
+
+    def test_horse_weight_at_correct_position(self):
+        """馬体重が正しい位置 (Python 261-263) で解析されること。"""
+        line = _build_sec_line(horse_weight="470")
+        result = JRDBParser.parse_sec_line(line)
+        assert result is not None
+        assert result["horse_weight"] == 470
+
+    def test_place_odds_at_correct_position(self):
+        """確定複勝オッズが正しい位置 (Python 219-224) で解析されること。"""
+        line = _build_sec_line(place_odds="  12.0")
+        result = JRDBParser.parse_sec_line(line)
+        assert result is not None
+        # 12.0 として解析される
+        assert result["place_odds"] == pytest.approx(12.0)
+
+    def test_race_id_parsed(self):
+        """レースキーが正しく解析されること。"""
+        line = _build_sec_line(race_key="08261712")
+        result = JRDBParser.parse_sec_line(line)
+        assert result is not None
+        assert result["race_id"] == "08261712"
+
+    def test_num_horses_parsed(self):
+        """頭数が正しく解析されること。"""
+        line = _build_sec_line(num_horses="12")
+        result = JRDBParser.parse_sec_line(line)
+        assert result is not None
+        assert result["num_horses"] == 12
+
+    def test_win_odds_parsed(self):
+        """単勝オッズが正しく解析されること。"""
+        line = _build_sec_line(win_odds=" 43.5")
+        result = JRDBParser.parse_sec_line(line)
+        assert result is not None
+        assert result["win_odds"] == pytest.approx(43.5)


### PR DESCRIPTION
## Summary

- `parse_sec_line()` で `finish_position` が常に 0 になるバグを修正
- JRDBのSECフォーマットで着順(bytes 135-136)の前に馬番再掲(bytes 133-134)があることを見落とし、`line[93:95]` が異常コード+"0"="00"=0 を読んでいた
- `line[91:93]` に修正し、着順以降の全フィールドを -2 シフト

## 根本原因の分析

SEC レコード（CP932デコード後のPython文字位置）:

| フィールド | バイト位置(1-indexed) | Python文字位置 |
|---|---|---|
| 頭数 | 131-132 | 87-88 |
| 馬番（再掲、スキップ） | 133-134 | 89-90 |
| **着順** | **135-136** | **91-92** ← 修正後 |
| 異常コード | 137 | 93 |
| 走破タイム | 138-141 | 94-97 |

修正前 `line[93:95]` は 異常コード("0") + 走破タイム先頭文字("0") = "00" = **0** を返していた。

コード内に検証済みアンカーが存在（コメントより）:
- 馬体重: byte 333-335 → Python 261-263
- 確定複勝オッズ: byte 291 → Python 219

これら2点からの逆算で総シフト量=71が確定し、備考フィールドが10全角(20bytes)であることも確認。

## Test plan

- [ ] `tests/test_jrdb_parser_sec.py` 14件パスを確認
- [ ] 1着〜全頭数での `finish_position != 0` を検証（バグ回帰テスト）
- [ ] 走破タイム・斤量・騎手名・馬体重・確定複勝オッズの位置が正しいことを確認
- [ ] 既存テスト619件への影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)