### PR TITLE
fix: 3/15日次バッチ タイムアウト・スケジュール競合の修正

### DIFF
--- a/src/automation/api/app.py
+++ b/src/automation/api/app.py
@@ -897,7 +897,7 @@ class StrategyDailyResponse(BaseModel):
 
 
 @app.post("/api/v1/odds/scrape", response_model=OddsScrapeResponse)
-async def scrape_odds(request: OddsScrapeRequest):
+async def scrape_odds(request: OddsScrapeRequest, background_tasks: BackgroundTasks):
     """
     netkeibaから当日レースの単勝・複勝オッズをスクレイピングしてBigQueryに保存する
 
@@ -906,12 +906,14 @@ async def scrape_odds(request: OddsScrapeRequest):
     2. 各レースの単複オッズを取得
     3. JRDB形式のrace_idに変換
     4. predictions.daily_odds テーブルにUPSERT保存
+    5. include_combo=True の場合、組み合わせオッズをバックグラウンドで取得・保存
 
     Args:
         request: リクエストボディ
+        background_tasks: FastAPI BackgroundTasks（組み合わせオッズの非同期保存に使用）
 
     Returns:
-        スクレイプ結果
+        スクレイプ結果（組み合わせオッズはバックグラウンドで処理継続）
     """
     execution_date_str = request.execution_date or date.today().isoformat()
     execution_date = datetime.date.fromisoformat(execution_date_str)
@@ -952,14 +954,14 @@ async def scrape_odds(request: OddsScrapeRequest):
         else:
             logger.warning(f"単複オッズを取得できませんでした: {execution_date_str}")
 
-        combo_rows_saved = 0
+        # 組み合わせオッズはバックグラウンドで処理（タイムアウト回避のため即座に200を返す）
         if request.include_combo:
-            combo_rows_saved = await asyncio.to_thread(
+            background_tasks.add_task(
                 scrape_today_combo_odds,
                 date=execution_date,
                 project_id=project_id,
             )
-            logger.info(f"組み合わせオッズ保存: {combo_rows_saved}行")
+            logger.info("組み合わせオッズスクレイプをバックグラウンドで開始")
 
         return OddsScrapeResponse(
             status="success",
@@ -967,7 +969,7 @@ async def scrape_odds(request: OddsScrapeRequest):
             races_scraped=races_scraped,
             horses_scraped=horses_scraped,
             saved_rows=saved_rows,
-            combo_rows_saved=combo_rows_saved,
+            combo_rows_saved=0,  # バックグラウンド処理のため結果は非同期
         )
 
     except Exception as e:

--- a/src/automation/data/netkeiba_scraper.py
+++ b/src/automation/data/netkeiba_scraper.py
@@ -677,39 +677,49 @@ def get_combo_odds(
 
     all_dfs: list[pd.DataFrame] = []
 
-    for i, ttype in enumerate(ticket_types):
-        if ttype not in COMBO_TICKET_TYPES:
-            logger.warning(f"未対応の馬券種をスキップ: {ttype}")
-            continue
-
-        url = (
-            f"{NETKEIBA_BASE_URL}/odds/index.html"
-            f"?race_id={netkeiba_race_id}&type={ttype}"
+    # ブラウザを1回だけ起動して全馬券種を取得（起動コストを削減）
+    with sync_playwright() as p:
+        browser = p.chromium.launch(
+            headless=True,
+            args=["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage", "--disable-gpu"],
         )
-        logger.debug(f"組み合わせオッズ取得: {url}")
+        try:
+            for i, ttype in enumerate(ticket_types):
+                if ttype not in COMBO_TICKET_TYPES:
+                    logger.warning(f"未対応の馬券種をスキップ: {ttype}")
+                    continue
 
-        if i > 0:
-            time.sleep(sleep_sec)
+                url = (
+                    f"{NETKEIBA_BASE_URL}/odds/index.html"
+                    f"?race_id={netkeiba_race_id}&type={ttype}"
+                )
+                logger.debug(f"組み合わせオッズ取得: {url}")
 
-        with sync_playwright() as p:
-            browser = p.chromium.launch(headless=True, args=["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage", "--disable-gpu"])
-            try:
-                page = browser.new_page()
-                page.goto(url, wait_until="load", timeout=30_000)
-                time.sleep(sleep_sec)
-                html = page.content()
-            except Exception as e:
-                logger.error(f"オッズページ取得失敗: {ttype} race_id={netkeiba_race_id}, {e}")
-                html = ""
-            finally:
-                browser.close()
+                if i > 0:
+                    time.sleep(sleep_sec)
 
-        df = _parse_combo_odds_html(html, ttype)
-        if not df.empty:
-            all_dfs.append(df)
-            logger.debug(
-                f"  {COMBO_TICKET_TYPES[ttype]}: {len(df)}件"
-            )
+                try:
+                    page = browser.new_page()
+                    page.goto(url, wait_until="load", timeout=15_000)
+                    time.sleep(sleep_sec)
+                    html = page.content()
+                    page.close()
+                except Exception as e:
+                    logger.error(f"オッズページ取得失敗: {ttype} race_id={netkeiba_race_id}, {e}")
+                    html = ""
+                    try:
+                        page.close()
+                    except Exception:
+                        pass
+
+                df = _parse_combo_odds_html(html, ttype)
+                if not df.empty:
+                    all_dfs.append(df)
+                    logger.debug(
+                        f"  {COMBO_TICKET_TYPES[ttype]}: {len(df)}件"
+                    )
+        finally:
+            browser.close()
 
     if not all_dfs:
         return pd.DataFrame(columns=_EMPTY_COMBO_COLUMNS)


### PR DESCRIPTION
## Summary
- **コンボオッズスクレイプをBackgroundTasksで非同期化**: `POST /api/v1/odds/scrape` が単複オッズ保存後すぐに200を返すよう変更。コンボオッズ（馬連/ワイド/三連複）はFastAPI `BackgroundTasks` でバックグラウンド処理継続。Cloud Schedulerの504タイムアウト・リトライ429を防止。
- **ブラウザ再利用による高速化**: `get_combo_odds()` で1レースにつき1ブラウザインスタンスを再利用（従来は馬券種ごとに起動）。起動コストを最大4分の1に削減。
- **ページロードタイムアウト短縮**: 30,000ms → 15,000ms

## 背景 (3/15 失敗ログ分析)
| 問題 | 原因 | 修正 |
|------|------|------|
| `odds/scrape` 504 | 36レース×4馬券種=144ブラウザ起動でCloud Run 900s超 | BackgroundTasks化 + ブラウザ再利用 + Cloud Run timeout 3600sへ延長 |
| `strategy/daily` 200だが投資判断0件 | 戦略実行(8:30)がオッズ取得完了前 | Cloud Scheduler: strategy 8:30→9:30, notify 9:00→10:00 |

## Test plan
- [ ] `POST /api/v1/odds/scrape` が単複オッズ保存後即座に200を返すことを確認
- [ ] コンボオッズがバックグラウンドで処理されBQに保存されることを確認（Cloud Runログ）
- [ ] `strategy/daily` が9:30に実行され投資判断が生成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)