### PR TITLE
feat: SHAP説明画面をStreamlitダッシュボードに追加

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,6 +35,7 @@ lxml==5.3.0
 # Dashboard (Streamlit)
 streamlit==1.32.0
 plotly==5.19.0
+shap==0.49.1
 
 # Testing
 pytest==7.4.3

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -28,10 +28,10 @@ st.set_page_config(
     initial_sidebar_state="expanded",
 )
 
-from src.dashboard.components import backtest, home, model_info, race_detail, race_list
+from src.dashboard.components import backtest, home, model_info, race_detail, race_list, shap_explain
 from src.dashboard.data import get_available_dates
 
-MENU_ITEMS = ["ホーム", "レース一覧", "レース詳細", "バックテスト", "モデル情報"]
+MENU_ITEMS = ["ホーム", "レース一覧", "レース詳細", "SHAP説明", "バックテスト", "モデル情報"]
 
 
 def main() -> None:
@@ -45,8 +45,8 @@ def main() -> None:
 
         st.divider()
 
-        # 日付選択（ホーム・レース一覧・レース詳細で共通）
-        if menu in ("ホーム", "レース一覧", "レース詳細"):
+        # 日付選択（ホーム・レース一覧・レース詳細・SHAP説明で共通）
+        if menu in ("ホーム", "レース一覧", "レース詳細", "SHAP説明"):
             available_dates = get_available_dates(days_back=30)
             today_str = date.today().isoformat()
 
@@ -74,6 +74,8 @@ def main() -> None:
         race_list.render(selected_date)
     elif menu == "レース詳細":
         race_detail.render(selected_date)
+    elif menu == "SHAP説明":
+        shap_explain.render(selected_date)
     elif menu == "バックテスト":
         backtest.render()
     elif menu == "モデル情報":

--- a/src/dashboard/components/shap_explain.py
+++ b/src/dashboard/components/shap_explain.py
@@ -1,0 +1,239 @@
+"""
+SHAP説明画面コンポーネント
+
+特定の馬がなぜ複勝率が高い（低い）のかを SHAP ウォーターフォールで可視化する。
+
+SHAPの解釈:
+  - 予測スコア = base_value（全馬平均）+ 各特徴量のSHAP値の合計
+  - SHAP値 > 0: その特徴量がスコアを押し上げている（複勝率UPに寄与）
+  - SHAP値 < 0: その特徴量がスコアを押し下げている（複勝率DOWNに寄与）
+"""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+import pandas as pd
+import streamlit as st
+
+from src.dashboard.data import (
+    VENUE_CODE_TO_NAME,
+    fetch_horse_features,
+    fetch_race_detail,
+    fetch_race_list,
+    load_lgbm_ranker_for_shap,
+)
+
+logger = logging.getLogger(__name__)
+
+# model_config から除外カラムを読み込む（学習時と同じ除外リスト）
+_EXCLUDE_COLUMNS = [
+    "race_id", "horse_id", "race_date", "target_place",
+    "finish_position", "venue_code", "jockey_id", "trainer_id",
+    "created_at", "race_number", "horse_number", "horse_name",
+]
+_CATEGORICAL_COLUMNS = ["course_type", "track_condition"]
+
+
+def render(race_date: str) -> None:
+    """SHAP説明画面を描画する"""
+    st.header("SHAP説明 — 予測スコアの要因分析")
+    st.caption(
+        "各馬の予測スコア（複勝率ランキングの根拠）を特徴量ごとに分解します。"
+        " 棒が右（赤）=スコアを押し上げる要因 / 左（青）=押し下げる要因。"
+    )
+
+    # ── 1. レース・馬の選択 ────────────────────────────────────────────────
+    race_list_df = fetch_race_list(race_date)
+    if race_list_df.empty:
+        st.info(f"{race_date} の予測データがありません。")
+        return
+
+    col1, col2, col3 = st.columns(3)
+
+    venue_codes = sorted(race_list_df["venue_code"].unique())
+    venue_options = {VENUE_CODE_TO_NAME.get(vc, vc): vc for vc in venue_codes}
+    selected_venue_name = col1.selectbox("競馬場", list(venue_options.keys()), key="shap_venue")
+    selected_venue_code = venue_options[selected_venue_name]
+
+    race_numbers = sorted(
+        race_list_df[race_list_df["venue_code"] == selected_venue_code]["race_number"].unique()
+    )
+    selected_race = col2.selectbox(
+        "レース番号", race_numbers, format_func=lambda r: f"{r}R", key="shap_race"
+    )
+
+    detail_df = fetch_race_detail(race_date, selected_venue_code, int(selected_race))
+    if detail_df.empty:
+        st.warning("詳細データを取得できませんでした。")
+        return
+
+    horse_options = {
+        f"{int(row['horse_number'])}番 {row['horse_name']} (複勝率 {row['win_place_prob']*100:.1f}%)": int(row["horse_number"])
+        for _, row in detail_df.sort_values("rank_in_race").iterrows()
+    }
+    selected_horse_label = col3.selectbox("馬", list(horse_options.keys()), key="shap_horse")
+    selected_horse_number = horse_options[selected_horse_label]
+
+    selected_horse_row = detail_df[detail_df["horse_number"] == selected_horse_number].iloc[0]
+
+    st.divider()
+
+    # ── 2. SHAP計算 ──────────────────────────────────────────────────────
+    with st.spinner("モデルを読み込み中...（初回のみ時間がかかります）"):
+        ranker, feature_names = load_lgbm_ranker_for_shap()
+
+    if ranker is None or not feature_names:
+        st.error("モデルの読み込みに失敗しました。GCS 上のモデルファイルを確認してください。")
+        return
+
+    with st.spinner("特徴量を取得し SHAP 値を計算中..."):
+        horse_df = fetch_horse_features(
+            race_date, selected_venue_code, int(selected_race), selected_horse_number
+        )
+
+    if horse_df.empty:
+        st.warning(
+            "features.training_data に該当馬のデータが見つかりませんでした。"
+            " 特徴量生成バッチが完了しているか確認してください。"
+        )
+        return
+
+    shap_df = _compute_shap(ranker, horse_df, feature_names)
+    if shap_df is None:
+        st.error("SHAP 値の計算に失敗しました。")
+        return
+
+    # ── 3. 結果表示 ─────────────────────────────────────────────────────
+    _render_horse_header(selected_horse_row, selected_venue_name, int(selected_race))
+    _render_waterfall(shap_df, top_n=20)
+    _render_shap_table(shap_df)
+
+
+# ---------------------------------------------------------------------------
+# 内部関数
+# ---------------------------------------------------------------------------
+
+def _compute_shap(ranker, horse_df: pd.DataFrame, feature_names: list[str]):
+    """
+    SHAP TreeExplainer で指定馬のSHAP値を計算する。
+
+    Returns:
+        DataFrame[feature, shap_value, feature_value] (|shap_value|降順)
+        失敗時は None
+    """
+    try:
+        import shap
+
+        # 学習時と同じ除外カラムを除去して特徴量行列を作る
+        available_features = [f for f in feature_names if f in horse_df.columns]
+        missing = set(feature_names) - set(available_features)
+        if missing:
+            logger.warning(f"特徴量 {len(missing)} 件が training_data に存在しない: {list(missing)[:5]}...")
+
+        X = horse_df[available_features].copy()
+
+        # カテゴリカル変換
+        for col in _CATEGORICAL_COLUMNS:
+            if col in X.columns:
+                X[col] = X[col].astype("category")
+
+        explainer = shap.TreeExplainer(ranker.model)
+        shap_values = explainer.shap_values(X)  # shape: (1, n_features)
+
+        values = shap_values[0] if shap_values.ndim == 2 else shap_values
+        feature_vals = X.iloc[0].values
+
+        df = pd.DataFrame({
+            "feature": available_features,
+            "shap_value": values,
+            "feature_value": feature_vals,
+        })
+        df["abs_shap"] = df["shap_value"].abs()
+        return df.sort_values("abs_shap", ascending=False).reset_index(drop=True)
+
+    except Exception as e:
+        logger.error(f"SHAP 計算失敗: {e}", exc_info=True)
+        return None
+
+
+def _render_horse_header(row: pd.Series, venue_name: str, race_number: int) -> None:
+    """馬の予測情報ヘッダーを表示する"""
+    st.subheader(
+        f"{venue_name} {race_number}R — "
+        f"{int(row['horse_number'])}番 **{row['horse_name']}**"
+    )
+    col1, col2, col3, col4 = st.columns(4)
+    col1.metric("予測順位", f"{int(row['rank_in_race'])}位")
+    col2.metric("複勝率", f"{row['win_place_prob']*100:.1f}%")
+    col3.metric("複勝オッズ", f"{row['place_odds']:.1f}" if pd.notna(row.get("place_odds")) else "—")
+    col4.metric(
+        "期待回収率",
+        f"{row['expected_return']:.3f}" if pd.notna(row.get("expected_return")) else "—",
+    )
+
+
+def _render_waterfall(shap_df: pd.DataFrame, top_n: int = 20) -> None:
+    """SHAP ウォーターフォール（横棒グラフ）を表示する"""
+    try:
+        import plotly.graph_objects as go
+
+        top = shap_df.head(top_n).copy()
+        top = top.sort_values("shap_value")  # 昇順でプロット（下が最大）
+
+        colors = ["#d62728" if v > 0 else "#1f77b4" for v in top["shap_value"]]
+        text_labels = [
+            f"{v:+.4f}  ({fv:.3g})"
+            for v, fv in zip(top["shap_value"], top["feature_value"])
+        ]
+
+        fig = go.Figure(go.Bar(
+            x=top["shap_value"],
+            y=top["feature"],
+            orientation="h",
+            marker_color=colors,
+            text=text_labels,
+            textposition="outside",
+            hovertemplate=(
+                "<b>%{y}</b><br>"
+                "SHAP値: %{x:.4f}<br>"
+                "特徴量値: %{customdata:.4g}<extra></extra>"
+            ),
+            customdata=top["feature_value"],
+        ))
+
+        fig.add_vline(x=0, line_width=1, line_color="black")
+        fig.update_layout(
+            title=f"SHAP ウォーターフォール（上位 {top_n} 特徴量）",
+            xaxis_title="SHAP値（予測スコアへの寄与）",
+            yaxis_title="特徴量",
+            height=max(400, top_n * 28),
+            margin=dict(l=200, r=120, t=60, b=40),
+        )
+        st.plotly_chart(fig, use_container_width=True)
+
+    except ImportError:
+        st.info("plotly がインストールされていないためグラフを表示できません。")
+
+
+def _render_shap_table(shap_df: pd.DataFrame) -> None:
+    """SHAP値テーブルを折りたたみ表示する"""
+    with st.expander("全特徴量のSHAP値テーブル"):
+        display = shap_df[["feature", "shap_value", "feature_value"]].copy()
+        display.columns = ["特徴量", "SHAP値", "特徴量値"]
+        display["SHAP値"] = display["SHAP値"].round(6)
+        display["特徴量値"] = display["特徴量値"].round(4)
+
+        def color_shap(val):
+            if val > 0:
+                return "color: #d62728"
+            elif val < 0:
+                return "color: #1f77b4"
+            return ""
+
+        st.dataframe(
+            display.style.applymap(color_shap, subset=["SHAP値"]),
+            hide_index=True,
+            use_container_width=True,
+        )

--- a/src/dashboard/data.py
+++ b/src/dashboard/data.py
@@ -328,6 +328,85 @@ def fetch_feature_importance(model_path: Optional[str] = None) -> pd.DataFrame:
         return pd.DataFrame()
 
 
+# ---------------------------------------------------------------------------
+# SHAP説明
+# ---------------------------------------------------------------------------
+
+@st.cache_resource
+def load_lgbm_ranker_for_shap(model_path: Optional[str] = None):
+    """
+    GCS から最新 LGBMRanker を読み込み、モデルオブジェクトを返す。
+    @st.cache_resource でプロセスライフタイム中キャッシュする。
+
+    Returns:
+        (LGBMRanker, list[str]) — ranker インスタンスと特徴量名リスト
+        失敗時は (None, [])
+    """
+    import sys
+    import tempfile
+    from pathlib import Path
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+    try:
+        from src.models.lgbm_ranker import LGBMRanker
+
+        ranker = LGBMRanker()
+        if model_path:
+            ranker.load(model_path)
+        else:
+            project_id = get_project_id()
+            if not project_id:
+                return None, []
+            from google.cloud import storage
+            gcs_client = storage.Client(project=project_id)
+            bucket = gcs_client.bucket(f"{project_id}-keiba-models")
+            blobs = list(bucket.list_blobs(prefix="lgbm_ranker/"))
+            model_blobs = [b for b in blobs if b.name.endswith(".txt")]
+            if not model_blobs:
+                return None, []
+            model_blobs.sort(key=lambda b: b.name.split("/")[-2], reverse=True)
+            latest = model_blobs[0]
+            with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
+                latest.download_to_filename(f.name)
+                ranker.load(f.name)
+
+        feature_names = ranker.model.feature_name() if ranker.model else []
+        return ranker, feature_names
+    except Exception as e:
+        logger.warning(f"LGBMRanker 読み込み失敗: {e}")
+        return None, []
+
+
+@st.cache_data(ttl=3600)
+def fetch_horse_features(
+    race_date: str,
+    venue_code: str,
+    race_number: int,
+    horse_number: int,
+) -> pd.DataFrame:
+    """
+    features.training_data から指定馬の特徴量行を取得する。
+    """
+    project_id = get_project_id()
+    if not project_id:
+        return pd.DataFrame()
+    try:
+        client = _get_bq_client()
+        query = f"""
+        SELECT *
+        FROM `{project_id}.features.training_data`
+        WHERE race_date = '{race_date}'
+          AND venue_code = '{venue_code}'
+          AND race_number = {race_number}
+          AND horse_number = {horse_number}
+        LIMIT 1
+        """
+        return client.query(query).to_dataframe()
+    except Exception as e:
+        logger.warning(f"horse_features 取得失敗: {e}")
+        return pd.DataFrame()
+
+
 def get_available_dates(days_back: int = 30) -> list[str]:
     """
     過去 N 日間で予測データが存在する日付リストを返す

--- a/tests/test_shap_explain.py
+++ b/tests/test_shap_explain.py
@@ -1,0 +1,161 @@
+"""
+SHAP説明コンポーネントのユニットテスト
+
+_compute_shap の計算ロジックを中心に検証する。
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+os.environ.setdefault("GCP_PROJECT_ID", "test-project")
+
+
+def _make_mock_ranker(n_features: int = 5):
+    """テスト用 LGBMRanker モックを作る"""
+    mock_ranker = MagicMock()
+    mock_ranker.model.feature_name.return_value = [f"feat_{i}" for i in range(n_features)]
+    return mock_ranker
+
+
+class TestComputeShap:
+    """_compute_shap のテスト"""
+
+    def test_returns_dataframe_with_required_columns(self):
+        from src.dashboard.components.shap_explain import _compute_shap
+
+        n = 5
+        feature_names = [f"feat_{i}" for i in range(n)]
+        horse_df = pd.DataFrame(
+            {f: [float(i)] for i, f in enumerate(feature_names)}
+        )
+
+        ranker = _make_mock_ranker(n)
+
+        # shap.TreeExplainer をモック
+        mock_shap_values = np.array([[0.1, -0.2, 0.3, -0.05, 0.15]])
+        with patch("shap.TreeExplainer") as mock_explainer_cls:
+            mock_explainer = MagicMock()
+            mock_explainer.shap_values.return_value = mock_shap_values
+            mock_explainer_cls.return_value = mock_explainer
+
+            result = _compute_shap(ranker, horse_df, feature_names)
+
+        assert result is not None
+        assert set(["feature", "shap_value", "feature_value", "abs_shap"]).issubset(result.columns)
+        assert len(result) == n
+
+    def test_sorted_by_abs_shap_descending(self):
+        from src.dashboard.components.shap_explain import _compute_shap
+
+        feature_names = ["a", "b", "c"]
+        horse_df = pd.DataFrame({"a": [1.0], "b": [2.0], "c": [3.0]})
+        ranker = _make_mock_ranker(3)
+
+        # |shap| が b > c > a となるよう設定
+        mock_shap_values = np.array([[0.05, -0.8, 0.3]])
+        with patch("shap.TreeExplainer") as mock_explainer_cls:
+            mock_explainer = MagicMock()
+            mock_explainer.shap_values.return_value = mock_shap_values
+            mock_explainer_cls.return_value = mock_explainer
+
+            result = _compute_shap(ranker, horse_df, feature_names)
+
+        assert result is not None
+        assert result.iloc[0]["feature"] == "b"   # |shap|=0.8 が最大
+        assert result.iloc[1]["feature"] == "c"   # |shap|=0.3
+        assert result.iloc[2]["feature"] == "a"   # |shap|=0.05
+
+    def test_handles_1d_shap_values(self):
+        """shap_values が 1D 配列で返ってくる場合も正常処理する"""
+        from src.dashboard.components.shap_explain import _compute_shap
+
+        feature_names = ["x", "y"]
+        horse_df = pd.DataFrame({"x": [1.0], "y": [2.0]})
+        ranker = _make_mock_ranker(2)
+
+        mock_shap_values = np.array([0.5, -0.3])  # 1D
+        with patch("shap.TreeExplainer") as mock_explainer_cls:
+            mock_explainer = MagicMock()
+            mock_explainer.shap_values.return_value = mock_shap_values
+            mock_explainer_cls.return_value = mock_explainer
+
+            result = _compute_shap(ranker, horse_df, feature_names)
+
+        assert result is not None
+        assert len(result) == 2
+
+    def test_returns_none_on_exception(self):
+        """SHAP 計算で例外が発生した場合は None を返す"""
+        from src.dashboard.components.shap_explain import _compute_shap
+
+        feature_names = ["x"]
+        horse_df = pd.DataFrame({"x": [1.0]})
+        ranker = _make_mock_ranker(1)
+
+        with patch("shap.TreeExplainer", side_effect=RuntimeError("SHAP error")):
+            result = _compute_shap(ranker, horse_df, feature_names)
+
+        assert result is None
+
+    def test_skips_missing_features_gracefully(self):
+        """training_data に存在しない特徴量はスキップして残りで計算する"""
+        from src.dashboard.components.shap_explain import _compute_shap
+
+        # モデルは feat_0, feat_1, feat_missing の3特徴量を想定
+        feature_names = ["feat_0", "feat_1", "feat_missing"]
+        # horse_df には feat_missing が存在しない
+        horse_df = pd.DataFrame({"feat_0": [1.0], "feat_1": [2.0]})
+        ranker = _make_mock_ranker(3)
+
+        mock_shap_values = np.array([[0.1, -0.2]])  # 2特徴量分
+        with patch("shap.TreeExplainer") as mock_explainer_cls:
+            mock_explainer = MagicMock()
+            mock_explainer.shap_values.return_value = mock_shap_values
+            mock_explainer_cls.return_value = mock_explainer
+
+            result = _compute_shap(ranker, horse_df, feature_names)
+
+        assert result is not None
+        assert len(result) == 2  # feat_missing は除外
+        assert "feat_missing" not in result["feature"].values
+
+
+class TestFetchHorseFeatures:
+    """fetch_horse_features のテスト"""
+
+    def test_returns_dataframe(self):
+        mock_df = pd.DataFrame({
+            "race_date": ["2026-03-15"],
+            "venue_code": ["09"],
+            "race_number": [5],
+            "horse_number": [3],
+            "feat_0": [1.5],
+        })
+
+        with patch("src.dashboard.data._get_bq_client") as mock_client_fn:
+            mock_client = MagicMock()
+            mock_client.query.return_value.to_dataframe.return_value = mock_df
+            mock_client_fn.return_value = mock_client
+
+            from src.dashboard import data as dash_data
+            dash_data.fetch_horse_features.clear()
+            result = dash_data.fetch_horse_features("2026-03-15", "09", 5, 3)
+
+        assert not result.empty
+        assert result.iloc[0]["horse_number"] == 3
+
+    def test_returns_empty_on_error(self):
+        with patch("src.dashboard.data._get_bq_client") as mock_client_fn:
+            mock_client_fn.side_effect = Exception("BQ error")
+
+            from src.dashboard import data as dash_data
+            dash_data.fetch_horse_features.clear()
+            result = dash_data.fetch_horse_features("2026-03-15", "09", 5, 3)
+
+        assert result.empty


### PR DESCRIPTION
## Summary

- `src/dashboard/components/shap_explain.py`: SHAP説明コンポーネント（新規）
  - 日付・競馬場・レース・馬をセレクトボックスで選択
  - `shap.TreeExplainer` で各特徴量の予測スコアへの寄与を計算
  - Plotlyウォーターフォール（赤＝スコアUP要因 / 青＝スコアDOWN要因）
  - 全特徴量SHAP値テーブル（折りたたみ）
- `src/dashboard/data.py`: SHAP用関数を追加
  - `load_lgbm_ranker_for_shap()`: `@st.cache_resource` でモデルをプロセス全体でキャッシュ
  - `fetch_horse_features()`: `features.training_data` から対象馬の特徴量1行を取得
- `src/dashboard/app.py`: メニューに「SHAP説明」を追加（レース詳細の次）
- `requirements.txt`: `shap==0.49.1` 追加
- `tests/test_shap_explain.py`: ユニットテスト7件

## SHAPの解釈

| 表示 | 意味 |
|------|------|
| 赤い棒（右） | その特徴量がスコアを押し上げている（複勝率UPに寄与） |
| 青い棒（左） | その特徴量がスコアを押し下げている（複勝率DOWNに寄与） |
| 棒の長さ | 寄与の大きさ |
| テキスト | `SHAP値 (特徴量の実際の値)` |

## Test plan

- [ ] `python3 -m pytest tests/test_shap_explain.py -v` — 7件全パス
- [ ] `python3 -m pytest -q` — 638件全パス
- [ ] ダッシュボード「SHAP説明」画面でレース・馬を選択して分析実行確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)