### PR TITLE
fix: line_webhook.py の _run_strategy_for_race で strategy_config.yaml のパラメータを正しく渡す (Issue #188)

### DIFF
--- a/src/automation/api/line_webhook.py
+++ b/src/automation/api/line_webhook.py
@@ -363,27 +363,35 @@ def _run_strategy_for_race(
         with open(config_path) as f:
             cfg = yaml.safe_load(f)
         p1 = float(cfg.get("p1", 0.2))
-        threshold = float(cfg.get("expected_return_threshold", 1.2))
-        max_bet_ratio = float(cfg.get("max_bet_ratio", 0.05))
+        _legacy_threshold = float(cfg.get("expected_return_threshold", 1.2))
+        budget_per_race = float(cfg.get("budget_per_race", 3000.0))
         min_bet_amount = float(cfg.get("min_bet_amount", 100.0))
         min_prob_threshold = float(cfg.get("min_prob_threshold", 0.10))
         prob_weight_r = float(cfg.get("prob_weight_r", 1.0))
-        top_n = int(cfg.get("top_n", 5))
+        _legacy_top_n = int(cfg.get("top_n", 5))
+        threshold_dominant = float(cfg.get("threshold_dominant", _legacy_threshold))
+        threshold_standard = float(cfg.get("threshold_standard", _legacy_threshold))
+        top_n_dominant = int(cfg.get("top_n_dominant", _legacy_top_n))
+        top_n_standard = int(cfg.get("top_n_standard", _legacy_top_n))
     else:
-        p1, threshold, max_bet_ratio, min_bet_amount = 0.2, 1.2, 0.05, 100.0
-        min_prob_threshold, prob_weight_r, top_n = 0.10, 1.0, 5
+        p1, budget_per_race, min_bet_amount = 0.2, 3000.0, 100.0
+        min_prob_threshold, prob_weight_r = 0.10, 1.0
+        threshold_dominant, threshold_standard = 1.2, 1.2
+        top_n_dominant, top_n_standard = 5, 5
 
     try:
         bets, pattern = select_bets_for_race(
             race_df=race_df,
             combo_odds_df=combo_odds_df if not combo_odds_df.empty else None,
+            budget_per_race=budget_per_race,
             p1=p1,
-            expected_return_threshold=threshold,
-            max_bet_ratio=max_bet_ratio,
             min_bet_amount=min_bet_amount,
-            top_n=top_n,
             min_prob_threshold=min_prob_threshold,
             prob_weight_r=prob_weight_r,
+            threshold_dominant=threshold_dominant,
+            threshold_standard=threshold_standard,
+            top_n_dominant=top_n_dominant,
+            top_n_standard=top_n_standard,
         )
         return bets, pattern.pattern
     except ValueError as e:


### PR DESCRIPTION
## Summary
- `_run_strategy_for_race()` が `select_bets_for_race()` を呼ぶ際に `strategy_config.yaml` のパラメータが正しく渡されていなかった問題を修正
- 廃止済みの `max_bet_ratio` 読み込みを削除し、Issue #168 以降の設定キーに統一

## 変更内容

| 修正内容 | Before | After |
|---|---|---|
| `max_bet_ratio` | config から読み込み（存在しないキー・廃止済み） | 削除 |
| `budget_per_race` | デフォルト値 3000.0 のみ使用 | config から読み込む |
| `threshold_dominant/standard` | 渡さない（デフォルト None） | config から読み込んで渡す |
| `top_n_dominant/standard` | 渡さない（deフォルト None） | config から読み込んで渡す |

## 影響範囲
- `POST /api/v1/line/webhook`（ユーザーがLINEで直接問い合わせる経路）のみ
- `POST /api/v1/strategy/daily` および `POST /api/v1/line/notify/daily` は影響なし（`run_strategy.py` は正しく実装済み）

## Test plan
- [x] `tests/test_line_webhook.py` 全 50 件 PASSED

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)