### PR TITLE
fix: _allocate_bets で除外後の残りbetに予算を再配分する (Issue #190)

### DIFF
--- a/src/backtest/strategy.py
+++ b/src/backtest/strategy.py
@@ -141,6 +141,8 @@ def _allocate_bets(
 
     総予算 = budget_per_race を各betのオッズ逆数の比率で割り当てる。
     100円単位に切り捨て後、min_bet_amount 未満のbetは除外する。
+    除外が発生した場合は残ったbetに対して予算を再配分し、
+    追加の除外が発生しなくなるまで繰り返す（収束まで反復）。
 
     Args:
         selected_bets: betの候補リスト。各要素は少なくとも 'odds' キーを持つ dict
@@ -153,31 +155,47 @@ def _allocate_bets(
     if not selected_bets:
         return []
 
-    total_budget = budget_per_race
+    # 除外後の残りbetに予算を再配分するため、収束するまでループ
+    active_bets = list(selected_bets)
 
-    # オッズ逆数を計算
-    inv_odds = []
-    for bet in selected_bets:
-        odds = float(bet.get("odds", 1.0))
-        inv_odds.append(1.0 / max(odds, 0.01))
+    while active_bets:
+        # オッズ逆数を計算
+        inv_odds = [1.0 / max(float(bet.get("odds", 1.0)), 0.01) for bet in active_bets]
+        total_inv = sum(inv_odds)
+        if total_inv <= 0:
+            return []
 
-    total_inv = sum(inv_odds)
-    if total_inv <= 0:
-        return []
+        # 各betの賭け金を計算（100円単位切り捨て）
+        amounts = []
+        for inv in inv_odds:
+            ratio = inv / total_inv
+            raw_amount = budget_per_race * ratio
+            amounts.append(float(np.floor(raw_amount / 100.0) * 100.0))
 
-    result = []
-    for bet, inv in zip(selected_bets, inv_odds):
-        ratio = inv / total_inv
-        raw_amount = total_budget * ratio
-        # 100円単位切り捨て
-        bet_amount = float(np.floor(raw_amount / 100.0) * 100.0)
-        if bet_amount < min_bet_amount:
-            continue
-        bet_copy = dict(bet)
-        bet_copy["bet_amount"] = bet_amount
-        result.append(bet_copy)
+        # min_bet_amount 以上のbetのみ残す
+        kept = [
+            (bet, amt)
+            for bet, amt in zip(active_bets, amounts)
+            if amt >= min_bet_amount
+        ]
 
-    return result
+        if len(kept) == len(active_bets):
+            # 除外されたbetなし → 収束
+            result = []
+            for bet, amt in kept:
+                bet_copy = dict(bet)
+                bet_copy["bet_amount"] = amt
+                result.append(bet_copy)
+            return result
+
+        if not kept:
+            # 全bet除外
+            return []
+
+        # 除外されたbetがある → 残ったbetで予算を再配分
+        active_bets = [bet for bet, _ in kept]
+
+    return []
 
 
 def select_base_bets(

--- a/tests/test_backtest_strategy.py
+++ b/tests/test_backtest_strategy.py
@@ -229,6 +229,44 @@ class TestAllocateBets:
         result = _allocate_bets([], 3000.0, min_bet_amount=100.0)
         assert result == []
 
+    def test_redistribution_after_exclusion(self):
+        """高オッズbet除外後に残ったbetへ予算が再配分される"""
+        # odds=4.6 と odds=765.4 の2点。
+        # 高オッズ側は逆数が極めて小さいため最初の計算では < 100円 → 除外。
+        # 除外後に残った odds=4.6 だけで予算3000を再配分すると 3000円 になる。
+        bets = [
+            {"bet_type": "wide", "horse_numbers": [5, 14], "horse_id": None, "odds": 4.6},
+            {"bet_type": "wide", "horse_numbers": [12, 15], "horse_id": None, "odds": 765.4},
+        ]
+        result = _allocate_bets(bets, budget_per_race=3000.0, min_bet_amount=100.0)
+        # 高オッズ側は除外され、1件のみ残る
+        assert len(result) == 1
+        assert result[0]["horse_numbers"] == [5, 14]
+        # 残ったbetが予算全額 (3000円) を受け取る
+        assert result[0]["bet_amount"] == 3000.0
+
+    def test_redistribution_total_within_budget(self):
+        """除外後再配分しても合計が budget_per_race 以内"""
+        bets = [
+            {"bet_type": "wide", "horse_numbers": [1, 2], "horse_id": None, "odds": 5.0},
+            {"bet_type": "wide", "horse_numbers": [1, 3], "horse_id": None, "odds": 8.0},
+            {"bet_type": "wide", "horse_numbers": [1, 4], "horse_id": None, "odds": 1000.0},
+        ]
+        result = _allocate_bets(bets, budget_per_race=3000.0, min_bet_amount=100.0)
+        total = sum(b["bet_amount"] for b in result)
+        assert total <= 3000.0
+        # 高オッズ(1000倍)は除外され2件のみ残る
+        assert len(result) == 2
+
+    def test_single_high_odds_excluded_when_below_min(self):
+        """単独bet でも計算額が min_bet_amount 未満なら除外される"""
+        bets = [
+            {"bet_type": "wide", "horse_numbers": [1, 2], "horse_id": None, "odds": 5.0},
+        ]
+        # 予算30円 → 計算額=30円 < 100円 → 除外
+        result = _allocate_bets(bets, budget_per_race=30.0, min_bet_amount=100.0)
+        assert len(result) == 0
+
 
 # ---------------------------------------------------------------------------
 # select_base_bets のテスト


### PR DESCRIPTION
## Summary
- `_allocate_bets()` において、高オッズbet（min_bet_amount未満になるbet）を除外した後、残ったbetで予算を再配分するよう修正
- 除外後も追加除外が発生しなくなるまで反復（収束型アルゴリズム）

## 問題
除外前: `[odds=4.6, odds=765.4]` → 配分後 `[¥2,985→¥2,900, ¥4→¥0(除外)]`  
除外後: `[odds=4.6 のみ ¥2,900]` ← **¥100分の予算が無駄に**

## 修正後
除外後: 残ったbetで予算3000を再計算 → `[odds=4.6: ¥3,000]`

## Test plan
- [x] `test_redistribution_after_exclusion`: 高オッズbet除外後に残betが全額受け取ることを検証
- [x] `test_redistribution_total_within_budget`: 再配分後も合計がbudget_per_race以内であることを検証
- [x] `test_single_high_odds_excluded_when_below_min`: 単独betでも予算<min_bet_amountなら除外
- [x] 既存43テスト全て通過

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)