### PR TITLE
fix: 標準型レースで単勝が推奨される問題を修正 (Issue #191)

### DIFF
--- a/scripts/run_strategy.py
+++ b/scripts/run_strategy.py
@@ -306,7 +306,10 @@ def save_decisions_to_bq(
         place_odds = source.place_odds,
         expected_return = source.expected_return,
         created_at = source.created_at
-    WHEN NOT MATCHED THEN INSERT ROW
+    WHEN NOT MATCHED BY TARGET THEN INSERT ROW
+    WHEN NOT MATCHED BY SOURCE
+      AND target.race_id IN (SELECT DISTINCT race_id FROM `{temp_table}`)
+      THEN DELETE
     """
     client.query(merge_query).result()
     client.delete_table(temp_table, not_found_ok=True)

--- a/tests/test_backtest_strategy.py
+++ b/tests/test_backtest_strategy.py
@@ -536,6 +536,28 @@ class TestSelectBetsForRace:
         with pytest.raises(ValueError):
             select_bets_for_race(race_df)
 
+    def test_standard_pattern_no_win_or_umaren(self):
+        """標準型レースでは単勝・馬連（パターンA）が推奨されない"""
+        # [0.25, 0.25, 0.2, 0.2, 0.1] のジニ係数は低い → standard
+        race_df = _make_race_df(
+            n_horses=5,
+            probs=[0.25, 0.25, 0.2, 0.2, 0.1],
+            odds=[4.0, 4.0, 5.0, 5.0, 10.0],
+            win_odds=[8.0, 8.0, 10.0, 10.0, 20.0],
+        )
+        combo_df = _make_combo_odds_df([
+            {"bet_type": "umaren", "horse_number_1": 1, "horse_number_2": 2, "odds_value": 10.0},
+            {"bet_type": "wide", "horse_number_1": 1, "horse_number_2": 2, "odds_value": 3.0},
+        ])
+        bets, pattern = select_bets_for_race(
+            race_df, combo_odds_df=combo_df, p1=0.3,
+            expected_return_threshold=1.0,
+        )
+        assert pattern.pattern == "standard"
+        bet_types = {b["bet_type"] for b in bets}
+        assert "win" not in bet_types, "標準型レースで単勝が選定されてはならない"
+        assert "umaren" not in bet_types, "標準型レースで馬連が選定されてはならない"
+
     def test_bet_amount_not_exceeds_budget(self):
         """総賭け金が budget_per_race 以内"""
         race_df = _make_race_df(


### PR DESCRIPTION
## Summary
- **根本原因**: `save_decisions_to_bq()` の MERGE が `(race_id, bet_type, horse_numbers)` をキーとするため、レースパターンが `one_dominant → standard` に変わった際に旧 win/umaren ベットが `investment_decisions` テーブルに残存していた
- **修正**: MERGE に `WHEN NOT MATCHED BY SOURCE AND target.race_id IN (...) THEN DELETE` を追加し、当該実行で処理した race_id の旧ベットを自動削除
- **テスト追加**: 標準型レースで win/umaren が選定されないことを明示的に保証

## 変更ファイル
| ファイル | 変更内容 |
|---------|---------|
| `scripts/run_strategy.py` | MERGE クエリに `WHEN NOT MATCHED BY SOURCE ... THEN DELETE` を追加 |
| `tests/test_backtest_strategy.py` | `test_standard_pattern_no_win_or_umaren` テスト追加 |

## Test plan
- [x] `test_standard_pattern_no_win_or_umaren`: 標準型レースで win/umaren が出ないことを検証
- [x] `test_one_dominant_triggers_pattern_a`: 突出型レースで単勝が正しく追加されることを検証
- [x] 全44テスト通過

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)