### PR TITLE
feat: 突出型レースでtop1馬の複勝をthreshold無関係に必ず購入する (Issue #193)

### DIFF
--- a/src/backtest/strategy.py
+++ b/src/backtest/strategy.py
@@ -330,13 +330,19 @@ def select_pattern_a_extra_bets(
     extra_bets = []
 
     # ── 複勝: 軸馬（複勝率1位）を期待値フィルタなしで1点購入 ──
-    place_odds_val = float(top1_row["odds"])
-    extra_bets.append({
-        "bet_type": "place",
-        "horse_numbers": [top1_horse_number],
-        "horse_id": top1_horse_id,
-        "odds": place_odds_val,
-    })
+    # base_bets に既に top1 の複勝が含まれている場合は追加しない（重複防止）
+    top1_place_already_in_base = any(
+        bet["bet_type"] == "place" and bet["horse_numbers"] == [top1_horse_number]
+        for bet in base_bets
+    )
+    if not top1_place_already_in_base:
+        place_odds_val = float(top1_row["odds"])
+        extra_bets.append({
+            "bet_type": "place",
+            "horse_numbers": [top1_horse_number],
+            "horse_id": top1_horse_id,
+            "odds": place_odds_val,
+        })
 
     # ── 単勝: win_odds カラムがあれば軸馬（複勝率1位）を無条件で1点購入 ──
     if "win_odds" in race_df.columns:

--- a/tests/test_backtest_strategy.py
+++ b/tests/test_backtest_strategy.py
@@ -465,6 +465,22 @@ class TestSelectPatternAExtraBets:
         assert len(place_bets) == 1
         assert place_bets[0]["horse_numbers"] == [1]  # 複勝率1位（馬番1）
 
+    def test_place_not_duplicated_when_already_in_base_bets(self):
+        """base_betsに既にtop1の複勝があれば重複して追加しない"""
+        race_df = _make_race_df(
+            n_horses=5,
+            probs=[0.5, 0.2, 0.15, 0.1, 0.05],
+            odds=[3.0, 3.0, 4.0, 5.0, 6.0],
+        )
+        # base_betsに既にhorse_number=1の複勝が含まれている
+        base_bets = [
+            {"bet_type": "place", "horse_numbers": [1], "horse_id": "horse_001", "odds": 3.0},
+        ]
+        bets = select_pattern_a_extra_bets(race_df, None, base_bets=base_bets)
+        place_bets = [b for b in bets if b["bet_type"] == "place"]
+        # base_betsに既にあるので extra_bets には追加されない（重複なし）
+        assert len(place_bets) == 0
+
     def test_place_for_top1_even_below_threshold_in_select_bets_for_race(self):
         """select_bets_for_race経由でも突出型では複勝が必ず含まれる"""
         from src.backtest.strategy import select_bets_for_race


### PR DESCRIPTION
## Summary
- `select_pattern_a_extra_bets()` に top1 馬（複勝率1位）の複勝を `expected_return_threshold` チェックなしで自動追加する処理を実装
- 突出型（one_dominant）レースで単勝を推奨する際、同じ馬の複勝が必ず1点購入される
- 既存テスト1件（`test_pattern_specific_params_applied`）を新動作に合わせて更新、新テスト2件を追加

## Test plan
- [ ] `test_place_always_added_for_top1`: top1馬の複勝がthreshold無関係に追加されること
- [ ] `test_place_for_top1_even_below_threshold_in_select_bets_for_race`: select_bets_for_race経由でも突出型では複勝が含まれること
- [ ] 全48テストがパスすること（`python3 -m pytest tests/test_backtest_strategy.py`）

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)