### PR TITLE
fix: 単勝の期待値表示と計算に複勝率を使っている問題を修正 (Issue #194)

### DIFF
--- a/scripts/run_strategy.py
+++ b/scripts/run_strategy.py
@@ -360,6 +360,7 @@ def _build_decision_row(
     horse_names_str = ",".join(horse_names_list)
 
     # 単複（単一馬番）のみ win_place_prob / expected_return を設定
+    # 単勝（win）は win_prob がないため expected_return を計算しない（複勝率ベースの計算は誤り）
     win_place_prob = None
     expected_return = None
     if len(horse_numbers) == 1:
@@ -367,7 +368,8 @@ def _build_decision_row(
         if not rows.empty:
             prob = float(rows.iloc[0]["win_place_prob"])
             win_place_prob = prob
-            expected_return = round(prob * odds, 4)
+            if bet_type != "win":
+                expected_return = round(prob * odds, 4)
 
     return {
         "race_id": str(race_id),

--- a/src/automation/api/line_webhook.py
+++ b/src/automation/api/line_webhook.py
@@ -606,14 +606,22 @@ def _format_single_bet_line(bet: dict[str, Any]) -> str:
     horse_str = " / ".join(horse_parts)
 
     if len(horse_numbers) == 1:
-        # 単複: 複勝率・期待値を表示
         prob = float(bet.get("win_place_prob", 0) or 0) * 100
-        ev = float(bet.get("expected_return", 0) or 0)
-        return (
-            f"  [{bet_label}] {horse_str}\n"
-            f"    複勝率:{prob:.1f}% / オッズ:{odds:.1f}倍 / 期待値:{ev:.2f}\n"
-            f"    推奨: ¥{amount:,.0f}"
-        )
+        if bet_type == "win":
+            # 単勝: win_prob がないため複勝率を参考表示。期待値は表示しない
+            return (
+                f"  [{bet_label}] {horse_str}\n"
+                f"    複勝率(参考):{prob:.1f}% / オッズ:{odds:.1f}倍\n"
+                f"    推奨: ¥{amount:,.0f}"
+            )
+        else:
+            # 複勝: 複勝率・期待値を表示
+            ev = float(bet.get("expected_return", 0) or 0)
+            return (
+                f"  [{bet_label}] {horse_str}\n"
+                f"    複勝率:{prob:.1f}% / オッズ:{odds:.1f}倍 / 期待値:{ev:.2f}\n"
+                f"    推奨: ¥{amount:,.0f}"
+            )
     else:
         # マルチ馬券: 馬番・馬名・オッズのみ
         return (

--- a/tests/test_line_webhook.py
+++ b/tests/test_line_webhook.py
@@ -404,6 +404,17 @@ class TestFormatSingleBetLine:
             "bet_amount": 1000.0,
         }
 
+    def _make_win_bet(self) -> dict:
+        return {
+            "bet_type": "win",
+            "horse_numbers": "6",
+            "horse_names": "オールザワールド",
+            "win_place_prob": 0.733,
+            "place_odds": 5.8,
+            "expected_return": None,  # 単勝は expected_return なし
+            "bet_amount": 1000.0,
+        }
+
     def _make_wide_bet(self) -> dict:
         return {
             "bet_type": "wide",
@@ -463,6 +474,30 @@ class TestFormatSingleBetLine:
     def test_wide_shows_bet_amount(self):
         result = _format_single_bet_line(self._make_wide_bet())
         assert "500" in result
+
+    def test_win_shows_place_prob_as_reference(self):
+        """単勝は「複勝率(参考)」ラベルで確率を表示する"""
+        result = _format_single_bet_line(self._make_win_bet())
+        assert "複勝率(参考)" in result
+        assert "73.3%" in result
+
+    def test_win_does_not_show_expected_return(self):
+        """単勝は期待値を表示しない（win_probがないため計算不可）"""
+        result = _format_single_bet_line(self._make_win_bet())
+        assert "期待値" not in result
+
+    def test_win_shows_odds_and_amount(self):
+        """単勝はオッズと推奨額を表示する"""
+        result = _format_single_bet_line(self._make_win_bet())
+        assert "5.8倍" in result
+        assert "1,000" in result
+
+    def test_place_still_shows_expected_return(self):
+        """複勝は引き続き期待値を表示する（回帰テスト）"""
+        result = _format_single_bet_line(self._make_place_bet())
+        assert "期待値" in result
+        assert "複勝率(参考)" not in result  # 複勝は "(参考)" なし
+        assert "複勝率:" in result
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_run_strategy.py
+++ b/tests/test_run_strategy.py
@@ -1,15 +1,17 @@
 """
-run_strategy.py の build_race_df のユニットテスト
+run_strategy.py の build_race_df と _build_decision_row のユニットテスト
 
 Issue #166: win_odds が race_df に渡されないため単勝が常に0件になるバグの修正検証。
+Issue #194: 単勝の expected_return に複勝率を使っているため誤った値になる問題の修正検証。
 """
 
 from __future__ import annotations
 
+import datetime
 import pandas as pd
 import pytest
 
-from scripts.run_strategy import build_race_df
+from scripts.run_strategy import build_race_df, _build_decision_row
 
 
 # ---------------------------------------------------------------------------
@@ -108,3 +110,72 @@ class TestBuildRaceDf:
 
         for col in ["horse_id", "horse_number", "win_place_prob", "odds"]:
             assert col in result.columns, f"{col} カラムが必要"
+
+
+# ---------------------------------------------------------------------------
+# _build_decision_row のテスト（Issue #194）
+# ---------------------------------------------------------------------------
+
+
+def _make_race_group(horse_number: int = 1, win_place_prob: float = 0.5) -> pd.DataFrame:
+    return pd.DataFrame([{
+        "race_id": "race_001",
+        "horse_id": "horse_001",
+        "horse_number": horse_number,
+        "horse_name": "テストホース",
+        "win_place_prob": win_place_prob,
+    }])
+
+
+def _make_meta_row() -> pd.Series:
+    return pd.Series({"venue_code": "09", "race_number": 5})
+
+
+class TestBuildDecisionRow:
+    """_build_decision_row の単勝/複勝 expected_return 計算テスト（Issue #194）"""
+
+    def test_place_bet_has_expected_return(self):
+        """複勝は expected_return が計算される"""
+        race_group = _make_race_group(horse_number=1, win_place_prob=0.4)
+        bet = {"bet_type": "place", "horse_numbers": [1], "horse_id": "horse_001", "odds": 3.0, "bet_amount": 1000.0}
+        row = _build_decision_row(
+            race_id="race_001",
+            target_date=datetime.date(2026, 3, 29),
+            meta_row=_make_meta_row(),
+            race_group=race_group,
+            bet=bet,
+            race_pattern_str="standard",
+            created_at=datetime.datetime(2026, 3, 29, 9, 0, 0),
+        )
+        assert row["expected_return"] is not None
+        assert abs(row["expected_return"] - 0.4 * 3.0) < 1e-6
+
+    def test_win_bet_expected_return_is_none(self):
+        """単勝は expected_return が None（win_prob がないため計算しない）"""
+        race_group = _make_race_group(horse_number=1, win_place_prob=0.733)
+        bet = {"bet_type": "win", "horse_numbers": [1], "horse_id": "horse_001", "odds": 5.8, "bet_amount": 1000.0}
+        row = _build_decision_row(
+            race_id="race_001",
+            target_date=datetime.date(2026, 3, 29),
+            meta_row=_make_meta_row(),
+            race_group=race_group,
+            bet=bet,
+            race_pattern_str="one_dominant",
+            created_at=datetime.datetime(2026, 3, 29, 9, 0, 0),
+        )
+        assert row["expected_return"] is None, "単勝の expected_return は None であるべき"
+
+    def test_win_bet_still_has_win_place_prob(self):
+        """単勝でも win_place_prob は保存される（参考表示用）"""
+        race_group = _make_race_group(horse_number=1, win_place_prob=0.733)
+        bet = {"bet_type": "win", "horse_numbers": [1], "horse_id": "horse_001", "odds": 5.8, "bet_amount": 1000.0}
+        row = _build_decision_row(
+            race_id="race_001",
+            target_date=datetime.date(2026, 3, 29),
+            meta_row=_make_meta_row(),
+            race_group=race_group,
+            bet=bet,
+            race_pattern_str="one_dominant",
+            created_at=datetime.datetime(2026, 3, 29, 9, 0, 0),
+        )
+        assert abs(row["win_place_prob"] - 0.733) < 1e-6


### PR DESCRIPTION
## Summary
- 単勝（win）推奨表示で「複勝率:XX% / 期待値:X.XX」と表示していたが、モデルが複勝率しか持たないため期待値が誤っていた
- `run_strategy.py`: 単勝の `expected_return` を None に設定（`win_place_prob × win_odds` は単勝の期待値として不正確）
- `line_webhook.py`: 単勝は「複勝率(参考)」ラベルで確率を表示し、期待値行を非表示に変更
- 複勝（place）は従来通りの表示を維持（回帰なし）

## Test plan
- [ ] `test_win_shows_place_prob_as_reference`: 単勝で「複勝率(参考)」ラベルが表示される
- [ ] `test_win_does_not_show_expected_return`: 単勝で「期待値」が表示されない
- [ ] `test_win_bet_expected_return_is_none`: DBに保存される単勝の expected_return が None
- [ ] `test_place_still_shows_expected_return`: 複勝は引き続き期待値を表示（回帰テスト）
- [ ] 全テスト通過確認

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)