### PR TITLE
feat: raw.race_infoにstart_timeカラムを追加（Issue #214）

### DIFF
--- a/scripts/add_start_time_to_race_info.py
+++ b/scripts/add_start_time_to_race_info.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""
+raw.race_info テーブルに start_time カラムを追加するスクリプト
+
+Issue #214: BAAパーサーで読み取った発走時刻をBQに保存するための前提として、
+raw.race_info テーブルに start_time (STRING, HHMM形式) カラムを追加する。
+
+既存データは NULL になる。以降の BAA ファイルロード時に自動的に値が入る。
+
+Usage:
+    python scripts/add_start_time_to_race_info.py
+    python scripts/add_start_time_to_race_info.py --project-id my-project-id
+"""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+load_dotenv(ROOT_DIR / ".env")
+
+
+def add_start_time_column(project_id: str) -> None:
+    from google.cloud import bigquery
+
+    client = bigquery.Client(project=project_id)
+    table_ref = f"{project_id}.raw.race_info"
+
+    # 既にカラムが存在するか確認
+    table = client.get_table(table_ref)
+    existing_columns = {field.name for field in table.schema}
+
+    if "start_time" in existing_columns:
+        print(f"[SKIP] start_time カラムはすでに存在します: {table_ref}")
+        return
+
+    # ALTER TABLE でカラム追加
+    sql = f"""
+    ALTER TABLE `{table_ref}`
+    ADD COLUMN IF NOT EXISTS start_time STRING
+    """
+    print(f"[INFO] start_time カラムを追加します: {table_ref}")
+    client.query(sql).result()
+    print(f"[OK] start_time カラムの追加が完了しました: {table_ref}")
+    print("[INFO] 既存データの start_time は NULL です。")
+    print("[INFO] 以降の BAA ファイルロード時に発走時刻 (HHMM形式) が自動的に保存されます。")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="raw.race_info テーブルに start_time カラムを追加する"
+    )
+    parser.add_argument(
+        "--project-id",
+        default=os.environ.get("GCP_PROJECT_ID"),
+        help="GCP プロジェクト ID (デフォルト: 環境変数 GCP_PROJECT_ID)",
+    )
+    args = parser.parse_args()
+
+    if not args.project_id:
+        print("[ERROR] --project-id を指定するか、環境変数 GCP_PROJECT_ID を設定してください。")
+        sys.exit(1)
+
+    add_start_time_column(args.project_id)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/automation/data/jrdb_parser.py
+++ b/src/automation/data/jrdb_parser.py
@@ -235,6 +235,7 @@ class JRDBParser:
                 'prize_1st': prize_1st,
                 'prize_2nd': prize_2nd,
                 'prize_3rd': prize_3rd,
+                'start_time': start_time if start_time else None,
                 'created_at': datetime.utcnow().isoformat(),
                 'updated_at': datetime.utcnow().isoformat()
             }

--- a/tests/test_jrdb_parser.py
+++ b/tests/test_jrdb_parser.py
@@ -1,0 +1,105 @@
+"""
+JRDBParser のユニットテスト
+
+Issue #214: parse_baa_line が start_time を正しく返すことを検証する。
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from src.automation.data.jrdb_parser import JRDBParser
+
+
+def _make_baa_line(start_time: str = "1015") -> str:
+    """
+    テスト用の BAA 固定長行を生成する。
+
+    BAAフォーマット（抜粋）:
+      [0:8]   レースキー (場コード2 + 年2 + 回1 + 日1 + R2)
+      [8:16]  日付 (YYYYMMDD)
+      [16:20] 発走時刻 (HHMM)
+      [20:24] 距離
+      [24:25] 芝ダ障害コード
+      [25:26] 右左
+      [26:27] 内外
+      [27:29] 種別コード
+      [29:31] 条件コード
+      [31:34] 記号
+      [34:35] 重量種別
+      [35:36] グレード
+      [36:86] レース名 (50バイト)
+      [86:]   残余（頭数など）
+    """
+    race_key = "05260101"        # 東京26年1回1日1R
+    race_date = "20260104"       # 2026-01-04
+    distance = "1600"
+    course_type = "1"            # 芝
+    direction = "2"              # 左
+    inner_outer = "1"
+    age_condition = "13"         # 3歳以上
+    race_condition = "OP"
+    symbol = "   "               # 3バイト
+    weight_type = "4"            # 定量
+    grade = " "
+    race_name = "TEST RACE" + " " * 41  # 50バイト
+
+    line = (
+        race_key        # 0:8
+        + race_date     # 8:16
+        + start_time    # 16:20
+        + distance      # 20:24
+        + course_type   # 24:25
+        + direction     # 25:26
+        + inner_outer   # 26:27
+        + age_condition # 27:29
+        + race_condition# 29:31
+        + symbol        # 31:34
+        + weight_type   # 34:35
+        + grade         # 35:36
+        + race_name     # 36:86
+        + " " * 10      # 86: 残余パディング（90バイト以上を確保）
+    )
+    return line
+
+
+class TestParseBaaLineStartTime:
+    """parse_baa_line の start_time フィールドに関するテスト"""
+
+    def test_start_time_present(self):
+        """発走時刻が存在する行で start_time が正しく取得できること"""
+        line = _make_baa_line(start_time="1015")
+        result = JRDBParser.parse_baa_line(line)
+        assert result is not None
+        assert result["start_time"] == "1015"
+
+    def test_start_time_empty_returns_none(self):
+        """発走時刻が空白の行で start_time が None になること"""
+        line = _make_baa_line(start_time="    ")
+        result = JRDBParser.parse_baa_line(line)
+        assert result is not None
+        assert result["start_time"] is None
+
+    def test_start_time_key_exists_in_return_dict(self):
+        """return dict に start_time キーが含まれること"""
+        line = _make_baa_line(start_time="1530")
+        result = JRDBParser.parse_baa_line(line)
+        assert result is not None
+        assert "start_time" in result
+
+    def test_start_time_various_values(self):
+        """様々な発走時刻が正しく取得できること"""
+        for hhmm in ["1000", "1200", "1530", "1645"]:
+            line = _make_baa_line(start_time=hhmm)
+            result = JRDBParser.parse_baa_line(line)
+            assert result is not None, f"start_time={hhmm} のパースに失敗"
+            assert result["start_time"] == hhmm, f"期待値: {hhmm}, 実際: {result['start_time']}"
+
+    def test_line_too_short_returns_none(self):
+        """90バイト未満の行は None を返すこと"""
+        result = JRDBParser.parse_baa_line("05260101" + "20260104" + "1015")
+        assert result is None


### PR DESCRIPTION
## 概要

Issue #214 の実装。JRDBのBAAファイルに含まれる発走時刻（HHMM形式）を `raw.race_info` テーブルに保存できるようにする。

Issue #213（発走5分前IPAT自動購入）の前提条件。

## 変更内容

### `src/automation/data/jrdb_parser.py`
- `parse_baa_line()` の return dict に `start_time` を追加
- 値は HHMM形式の文字列（例: `"1015"` = 10時15分）
- 空文字列の場合は `None` を格納

### `scripts/add_start_time_to_race_info.py`（新規）
- `ALTER TABLE raw.race_info ADD COLUMN IF NOT EXISTS start_time STRING` を実行するスクリプト
- カラムが既存の場合はスキップ
- 使い方: `python scripts/add_start_time_to_race_info.py --project-id <PROJECT_ID>`

### `tests/test_jrdb_parser.py`（新規）
- `parse_baa_line` の `start_time` 取得を検証するテスト5件

## テスト結果

```
tests/test_jrdb_parser.py: 5 passed
tests/test_load_to_bq.py: 76 passed（既存テスト影響なし）
```

## デプロイ手順

1. このPRをマージ
2. 以下を実行してBQテーブルにカラムを追加:
   ```
   python scripts/add_start_time_to_race_info.py --project-id keiba-prediction-1768734113
   ```
3. 以降の BAA ファイルロード時に `start_time` が自動的に保存される

## 注意事項

- 既存データの `start_time` は `NULL` になる
- Issue #213 の自動購入実装側で `start_time IS NULL` のレースをスキップする実装が必要

Closes #214