### PR TITLE
feat: IPAT自動購入にdry_runモードを追加（Issue #213）

### DIFF
--- a/src/automation/api/app.py
+++ b/src/automation/api/app.py
@@ -1174,6 +1174,10 @@ class PurchaseDailyRequest(BaseModel):
         default=None,
         description="対象日付（YYYY-MM-DD形式、省略時は当日）",
     )
+    dry_run: bool = Field(
+        default=True,
+        description="Trueの場合、実際の購入をせず推奨馬券内容をLINE通知のみ行う（デフォルト: True）",
+    )
 
 
 class PurchaseRaceResult(BaseModel):
@@ -1192,6 +1196,7 @@ class PurchaseDailyResponse(BaseModel):
 
     status: str = Field(description="処理ステータス (success/skipped/error)")
     execution_date: str = Field(description="対象日付")
+    dry_run: bool = Field(default=True, description="ドライランモードか")
     purchased_races: int = Field(default=0, description="購入処理を行ったレース数")
     total_amount: int = Field(default=0, description="当日累計購入金額（円）")
     results: list[PurchaseRaceResult] = Field(default_factory=list)
@@ -1226,7 +1231,8 @@ async def purchase_daily(request: PurchaseDailyRequest):
         else datetime.date.today()
     )
     execution_date_str = target_date.isoformat()
-    logger.info(f"IPAT日次購入リクエスト受信: execution_date={execution_date_str}")
+    dry_run = request.dry_run
+    logger.info(f"IPAT日次購入リクエスト受信: execution_date={execution_date_str}, dry_run={dry_run}")
 
     project_id = os.environ.get("GCP_PROJECT_ID")
     member_id = os.environ.get("IPAT_MEMBER_ID", "")
@@ -1237,7 +1243,8 @@ async def purchase_daily(request: PurchaseDailyRequest):
 
     if not project_id:
         raise HTTPException(status_code=500, detail="GCP_PROJECT_IDが未設定です")
-    if not member_id or not pin or not pat_number:
+    # dry_run=False の場合のみ IPAT 認証情報を必須チェック
+    if not dry_run and (not member_id or not pin or not pat_number):
         raise HTTPException(
             status_code=500,
             detail="IPAT認証情報が未設定です（IPAT_MEMBER_ID / IPAT_PIN / IPAT_PAT_NUMBER）",
@@ -1253,10 +1260,12 @@ async def purchase_daily(request: PurchaseDailyRequest):
             pat_number=pat_number,
             channel_access_token=channel_access_token,
             line_user_id=line_user_id,
+            dry_run=dry_run,
         )
         return PurchaseDailyResponse(
             status=result["status"],
             execution_date=execution_date_str,
+            dry_run=dry_run,
             purchased_races=result["purchased_races"],
             total_amount=result["total_amount"],
             results=[PurchaseRaceResult(**r) for r in result["results"]],
@@ -1274,6 +1283,7 @@ def _run_purchase_pipeline(
     pat_number: str,
     channel_access_token: str,
     line_user_id: str,
+    dry_run: bool = True,
 ) -> dict:
     """
     IPAT自動購入パイプラインの同期ラッパー（asyncio.to_thread で実行）。
@@ -1289,6 +1299,7 @@ def _run_purchase_pipeline(
             pat_number=pat_number,
             channel_access_token=channel_access_token,
             line_user_id=line_user_id,
+            dry_run=dry_run,
         )
     )
 
@@ -1301,20 +1312,27 @@ async def _purchase_pipeline_async(
     pat_number: str,
     channel_access_token: str,
     line_user_id: str,
+    dry_run: bool = True,
 ) -> dict:
     """
     IPAT自動購入パイプラインの非同期実装。
+
+    dry_run=True（デフォルト）:
+      - IPATへのログイン・購入を一切行わない
+      - 発走5分前レースの推奨馬券内容をLINEに通知するのみ
+
+    dry_run=False:
+      - 通常フロー（IPAT購入 + 履歴BQ保存）
 
     フロー:
       1. raw.race_info から当日の発走時刻を取得
       2. 現在時刻の5〜10分後に発走するレースを特定
       3. 対象レースが0件なら skipped を返す
-      4. IPAT ログイン
-      5. 各レースの推奨馬券を取得し購入
-         - 予算上限チェック → 超過なら以降のレースをスキップ & LINE通知
-         - 購入失敗なら LINE通知して当該レースをスキップ
-      6. ログアウト
-      7. 購入結果を返す
+      4. [dry_run=False] IPAT ログイン
+      5. 各レースの推奨馬券を取得
+         [dry_run=True]  LINE通知のみ
+         [dry_run=False] 予算チェック → 購入 → 履歴保存
+      6. [dry_run=False] ログアウト
     """
     from src.automation.data.ipat_purchaser import (
         IpatLoginError,
@@ -1349,10 +1367,58 @@ async def _purchase_pipeline_async(
         logger.info(f"{target_date}: 現在時刻 {now.strftime('%H:%M')} に対象レースなし")
         return {"status": "skipped", "purchased_races": 0, "total_amount": 0, "results": []}
 
-    logger.info(f"対象レース {len(target_races)}件: {[r['race_id'] for r in target_races]}")
+    logger.info(
+        f"対象レース {len(target_races)}件: {[r['race_id'] for r in target_races]}"
+        f" [{'ドライラン' if dry_run else '本番購入'}]"
+    )
 
     race_results = []
 
+    # --- ドライランモード ---
+    if dry_run:
+        for race in target_races:
+            race_id = race["race_id"]
+            venue_name = race.get("venue_name", "")
+            race_number = race.get("race_number", "")
+
+            bets = fetch_recommended_bets(project_id, race_id, target_date)
+            if not bets:
+                logger.info(f"[DRY RUN] race_id={race_id}: 推奨馬券なし → スキップ")
+                continue
+
+            # 推奨馬券をLINE通知
+            lines = [f"【ドライラン】{venue_name}{race_number}R 購入予定馬券"]
+            total_amount = 0
+            for bet in bets:
+                bet_type = bet["bet_type"]
+                horse_numbers = bet["horse_numbers"]
+                amount = int(bet["bet_amount"])
+                horse_str = "-".join(str(h) for h in horse_numbers)
+                lines.append(f"  {bet_type} {horse_str} {amount:,}円")
+                total_amount += amount
+            lines.append(f"  合計: {total_amount:,}円")
+            _send_line("\n".join(lines))
+            logger.info(f"[DRY RUN] race_id={race_id}: {len(bets)}件通知")
+
+            race_results.append({
+                "race_id": race_id,
+                "bets_purchased": 0,
+                "bets_failed": 0,
+                "bets_skipped_budget": 0,
+                "amount": 0,
+                "status": "dry_run",
+            })
+
+        notified_races = len(race_results)
+        logger.info(f"ドライラン完了: {notified_races}レース分をLINE通知")
+        return {
+            "status": "success",
+            "purchased_races": 0,
+            "total_amount": 0,
+            "results": race_results,
+        }
+
+    # --- 本番購入モード ---
     # 3. IPAT ログイン
     async with IpatPurchaser(member_id, pin, pat_number) as purchaser:
         try:

--- a/tests/test_ipat_purchaser.py
+++ b/tests/test_ipat_purchaser.py
@@ -231,6 +231,47 @@ class TestIpatPurchaserPurchaseBet:
 
 
 # ---------------------------------------------------------------------------
+# dry_run フラグのテスト
+# ---------------------------------------------------------------------------
+
+class TestDryRunFlag:
+    """PurchaseDailyRequest の dry_run フラグに関するテスト"""
+
+    def test_dry_run_default_is_true(self):
+        """dry_run のデフォルト値が True（安全側）であること"""
+        import sys
+        sys.path.insert(0, str(ROOT_DIR))
+        # app.py の PurchaseDailyRequest を直接検査
+        from pydantic import BaseModel
+        from typing import Optional
+
+        # デフォルト値が True になっていることをフィールド定義で確認
+        # （実際のリクエストオブジェクトを生成して確認）
+        import importlib
+        app_module = importlib.import_module("src.automation.api.app")
+        req = app_module.PurchaseDailyRequest()
+        assert req.dry_run is True
+
+    def test_dry_run_can_be_set_false(self):
+        """dry_run=False を明示的に指定できること"""
+        import importlib
+        app_module = importlib.import_module("src.automation.api.app")
+        req = app_module.PurchaseDailyRequest(dry_run=False)
+        assert req.dry_run is False
+
+    def test_dry_run_response_contains_flag(self):
+        """レスポンスに dry_run フラグが含まれること"""
+        import importlib
+        app_module = importlib.import_module("src.automation.api.app")
+        resp = app_module.PurchaseDailyResponse(
+            status="success",
+            execution_date="2026-04-05",
+            dry_run=True,
+        )
+        assert resp.dry_run is True
+
+
+# ---------------------------------------------------------------------------
 # 予算上限チェックロジックのテスト
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## 概要

しばらくは実際の購入を行わず、推奨馬券のLINE通知のみ行うための `dry_run` モードを追加。

## 変更内容

### `src/automation/api/app.py`
- `PurchaseDailyRequest` に `dry_run: bool = True` を追加（**デフォルトは安全側の `true`**）
- `PurchaseDailyResponse` に `dry_run: bool` を追加
- `dry_run=True` の挙動:
  - IPATへのログイン・購入を一切行わない
  - 発走5分前レースの推奨馬券内容（馬券種・馬番・金額）をLINEに通知
  - IPAT認証情報の必須チェックをスキップ（環境変数未設定でも動作）
- `dry_run=False` の挙動: 従来通りの本番購入フロー

### `tests/test_ipat_purchaser.py`
- `dry_run` デフォルト値が `True` であることを確認するテスト追加
- `dry_run=False` を明示指定できることを確認するテスト追加
- レスポンスに `dry_run` フィールドが含まれることを確認するテスト追加

### Cloud Scheduler（コード外）
- `race-day-purchase` ジョブのボディを `{"dry_run": true}` に更新済み

## 本番購入への切り替え方法

準備ができたら Cloud Scheduler のジョブボディを変更するだけで切り替え可能:
```bash
gcloud scheduler jobs update http race-day-purchase \
  --location=asia-northeast1 \
  --message-body='{"dry_run": false}' \
  --project=keiba-prediction-1768734113
```

## テスト結果
```
tests/test_ipat_purchaser.py: 25 passed（+3件追加）
```