### PR TITLE
fix: Cloud Run UTC/JST日付ズレ修正 & LINE通知5000文字制限対応

### DIFF
--- a/src/automation/api/app.py
+++ b/src/automation/api/app.py
@@ -36,6 +36,12 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+
+def _today_jst() -> datetime.date:
+    """JSTの今日の日付を返す（Cloud RunはUTCで動くため date.today() では日付がズレる）"""
+    return datetime.datetime.now(ZoneInfo("Asia/Tokyo")).date()
+
+
 # FastAPIアプリケーション
 app = FastAPI(
     title="JRDB Pipeline API",
@@ -366,7 +372,7 @@ async def load_daily_async(
     Returns:
         受付結果
     """
-    target_date = request.target_date or date.today().strftime("%Y-%m-%d")
+    target_date = request.target_date or _today_jst().strftime("%Y-%m-%d")
     logger.info(f"非同期日次ロードリクエスト受付: target_date={target_date}")
 
     def run_pipeline():
@@ -715,7 +721,7 @@ def _run_predict(
         config = load_config()
         result_df = predict_pipeline(
             project_id=project_id,
-            execution_date=datetime.date.today(),
+            execution_date=_today_jst(),
             config=config,
             model_path=local_model_path,
             target_dates=target_dates,
@@ -782,7 +788,7 @@ async def predict_daily(request: PredictDailyRequest):
         from src.models.train import compute_week_boundaries
 
         # 翌日を基準に今週の土日を算出
-        tomorrow = datetime.date.today() + datetime.timedelta(days=1)
+        tomorrow = _today_jst() + datetime.timedelta(days=1)
         saturday, sunday = compute_week_boundaries(tomorrow)
         target_dates = [saturday, sunday]
 
@@ -960,7 +966,7 @@ async def scrape_odds(request: OddsScrapeRequest, background_tasks: BackgroundTa
     Returns:
         スクレイプ結果（組み合わせオッズはバックグラウンドで処理継続）
     """
-    execution_date_str = request.execution_date or date.today().isoformat()
+    execution_date_str = request.execution_date or _today_jst().isoformat()
     execution_date = datetime.date.fromisoformat(execution_date_str)
 
     logger.info(f"オッズスクレイプリクエスト受信: execution_date={execution_date_str}")
@@ -1043,7 +1049,7 @@ async def run_strategy_daily(request: StrategyDailyRequest):
     Returns:
         投資判断結果
     """
-    execution_date_str = request.execution_date or date.today().isoformat()
+    execution_date_str = request.execution_date or _today_jst().isoformat()
     execution_date = datetime.date.fromisoformat(execution_date_str)
 
     logger.info(
@@ -1115,7 +1121,7 @@ async def line_notify_daily(
     target_date = (
         datetime.date.fromisoformat(execution_date)
         if execution_date
-        else datetime.date.today()
+        else _today_jst()
     )
     execution_date_str = target_date.isoformat()
 
@@ -1273,7 +1279,7 @@ async def purchase_daily(request: PurchaseDailyRequest):
     target_date = (
         datetime.date.fromisoformat(request.target_date)
         if request.target_date
-        else datetime.date.today()
+        else _today_jst()
     )
     execution_date_str = target_date.isoformat()
     dry_run = request.dry_run
@@ -1611,7 +1617,7 @@ async def retrain_model(request: RetrainRequest):
     execution_date = (
         datetime.date.fromisoformat(request.execution_date)
         if request.execution_date
-        else datetime.date.today()
+        else _today_jst()
     )
     logger.info(
         f"モデル再学習リクエスト受信: execution_date={execution_date}, "
@@ -1657,7 +1663,7 @@ async def retrain_model_async(request: RetrainRequest, background_tasks: Backgro
     execution_date = (
         datetime.date.fromisoformat(request.execution_date)
         if request.execution_date
-        else datetime.date.today()
+        else _today_jst()
     )
     logger.info(
         f"非同期モデル再学習リクエスト受付: execution_date={execution_date}"

--- a/src/automation/api/line_webhook.py
+++ b/src/automation/api/line_webhook.py
@@ -660,10 +660,21 @@ def format_push_notification(
             lines.append(_format_single_bet_line(bet))
         race_blocks.append("\n".join(lines))
 
-    # 10レースごとに1メッセージに分割
-    for i in range(0, len(race_blocks), _RACES_PER_MESSAGE):
-        chunk = race_blocks[i:i + _RACES_PER_MESSAGE]
-        messages.append({"type": "text", "text": "\n\n".join(chunk)})
+    # 5000文字制限を超えないようにレースブロックを分割してメッセージ化
+    _MAX_TEXT_LENGTH = 4800  # LINEの5000文字制限に余裕を持たせる
+    current_chunks: list[str] = []
+    current_len = 0
+    for block in race_blocks:
+        block_len = len(block) + (2 if current_chunks else 0)  # "\n\n" の分
+        if current_chunks and current_len + block_len > _MAX_TEXT_LENGTH:
+            messages.append({"type": "text", "text": "\n\n".join(current_chunks)})
+            current_chunks = [block]
+            current_len = len(block)
+        else:
+            current_chunks.append(block)
+            current_len += block_len
+    if current_chunks:
+        messages.append({"type": "text", "text": "\n\n".join(current_chunks)})
 
     return messages
 


### PR DESCRIPTION
## Summary

- **`_today_jst()` ヘルパーを追加し全エンドポイントの `date.today()` をJST日付に統一**
  - Cloud RunはUTC動作のため `date.today()` が8:00〜8:30 JSTに実行されると前日（UTC）日付を返す
  - 影響エンドポイント: `predict/daily`, `odds/scrape`, `strategy/daily`, `line/notify/daily`, `purchase/daily`, `retrain`
  - 4/11(土)実測: `strategy/daily` が `2026-04-10` で実行 → 予測データ（`2026-04-11`付け）を見つけられず投資判断0件 → LINE通知なし
- **LINE通知メッセージの5000文字制限超えを修正 (`line_webhook.py`)**
  - 投資判断317件の日は10レース固定分割で1メッセージが5000文字超 → LINE API 400エラー
  - 文字数ベースの動的分割に変更（4800文字に達したら新メッセージ開始）

## Test plan

- [x] 4/11(土) 本番で動作確認済み
  - 手動トリガーで `odds/scrape` → 524行BQ保存
  - 手動トリガーで `strategy/daily` → `execution_date=2026-04-11` で正常実行、317件・92,600円
  - 手動トリガーで `line/notify/daily` → 7メッセージ送信成功
- [ ] 翌週以降の自動実行で継続確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)