### PR TITLE
fix: LINEドライラン通知の馬番表示に不要な"-"が混入するバグを修正

### DIFF
--- a/src/automation/data/ipat_purchaser.py
+++ b/src/automation/data/ipat_purchaser.py
@@ -360,9 +360,11 @@ def fetch_recommended_bets(
     rows = list(client.query(query, job_config=job_config).result())
     result = []
     for row in rows:
+        hn_str = str(row["horse_numbers"] or "")
+        horse_numbers = [int(h.strip()) for h in hn_str.split(",") if h.strip()]
         result.append({
             "bet_type": row["bet_type"],
-            "horse_numbers": list(row["horse_numbers"]),
+            "horse_numbers": horse_numbers,
             "bet_amount": int(row["bet_amount"]),
         })
     logger.info(f"race_id={race_id}: 推奨馬券 {len(result)}件取得")


### PR DESCRIPTION
## Summary
- `fetch_recommended_bets()` で `horse_numbers`（BigQuery STRING型、カンマ区切り）を `list()` でイテレートしていたため、文字単位に分解されていた
- `list("6,12,16")` → `['6', ',', '1', '2', ',', '1', '6']` となり、`"-".join()` が `"6-,-1-2-,-1-6"` を生成していた
- `str.split(",")` で正しくパースするよう修正し、`[6, 12, 16]` → `"6-12-16"` に修正

## 修正前後
```
# 修正前
place 1-2 2,000円
sanrenpuku 6-,-1-2-,-1-6 400円

# 修正後
place 12 2,000円
sanrenpuku 6-12-16 400円
```

## Test plan
- [ ] Python で修正ロジックの動作確認済み（`split(",")` で正しく分解されることを検証）
- [ ] 単一馬番（place）・複数馬番（sanrenpuku）どちらも正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)