### PR TITLE
feat: 自動投票のdry-run解除と1レースあたり投資上限を1000円に変更

### DIFF
--- a/config/strategy_config.yaml
+++ b/config/strategy_config.yaml
@@ -2,7 +2,7 @@ p1: 0.5
 expected_return_threshold: 1.35 ## 最適化の結果は1.5
 prob_weight_r_dominant: 1.5 ## 最適化の結果は1.0
 prob_weight_r_standard: 1.0 ## 最適化の結果は1.5
-budget_per_race: 3000
+budget_per_race: 1000
 min_bet_amount: 100
 min_prob_threshold: 0.1
 top_n_dominant: 6 ## 最適化の結果は5

--- a/src/automation/api/app.py
+++ b/src/automation/api/app.py
@@ -1226,8 +1226,8 @@ class PurchaseDailyRequest(BaseModel):
         description="対象日付（YYYY-MM-DD形式、省略時は当日）",
     )
     dry_run: bool = Field(
-        default=True,
-        description="Trueの場合、実際の購入をせず推奨馬券内容をLINE通知のみ行う（デフォルト: True）",
+        default=False,
+        description="Trueの場合、実際の購入をせず推奨馬券内容をLINE通知のみ行う（デフォルト: False）",
     )
 
 

--- a/tests/test_ipat_purchaser.py
+++ b/tests/test_ipat_purchaser.py
@@ -237,20 +237,20 @@ class TestIpatPurchaserPurchaseBet:
 class TestDryRunFlag:
     """PurchaseDailyRequest の dry_run フラグに関するテスト"""
 
-    def test_dry_run_default_is_true(self):
-        """dry_run のデフォルト値が True（安全側）であること"""
+    def test_dry_run_default_is_false(self):
+        """dry_run のデフォルト値が False（本番購入モード）であること"""
         import sys
         sys.path.insert(0, str(ROOT_DIR))
         # app.py の PurchaseDailyRequest を直接検査
         from pydantic import BaseModel
         from typing import Optional
 
-        # デフォルト値が True になっていることをフィールド定義で確認
+        # デフォルト値が False になっていることをフィールド定義で確認
         # （実際のリクエストオブジェクトを生成して確認）
         import importlib
         app_module = importlib.import_module("src.automation.api.app")
         req = app_module.PurchaseDailyRequest()
-        assert req.dry_run is True
+        assert req.dry_run is False
 
     def test_dry_run_can_be_set_false(self):
         """dry_run=False を明示的に指定できること"""


### PR DESCRIPTION
## Summary

- `PurchaseDailyRequest.dry_run` のデフォルト値を `True` → `False` に変更し、Cloud SchedulerからのリクエストでIPAT本番購入が有効になるようにする
- `config/strategy_config.yaml` の `budget_per_race` を `3000` → `1000` 円に変更
- テスト `test_dry_run_default_is_true` → `test_dry_run_default_is_false` に更新（アサーションも対応）

## Test plan

- [ ] `TestDryRunFlag::test_dry_run_default_is_false` がパスすること
- [ ] `PurchaseDailyRequest()` のデフォルトで `dry_run=False` になること
- [ ] `strategy_config.yaml` の `budget_per_race` が `1000` になっていること
- [ ] dry_run=True を明示指定した場合は従来通りLINE通知のみ動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)