### PR TITLE
feat: 発走直前に最新オッズで investment_decisions を上書き (Issue #231)

### DIFF
--- a/src/automation/api/app.py
+++ b/src/automation/api/app.py
@@ -1031,11 +1031,15 @@ async def scrape_odds(request: OddsScrapeRequest, background_tasks: BackgroundTa
 @app.post("/api/v1/strategy/daily", response_model=StrategyDailyResponse)
 async def run_strategy_daily(request: StrategyDailyRequest):
     """
-    日次投資戦略を策定してBigQueryに保存する
+    日次投資戦略を策定する（デフォルトはBQ保存なし）
 
     config/strategy_config.yaml のパラメータを読み込み、当日の予測結果と
     リアルタイムオッズを JOIN して投資判断を実行する。
-    Cloud Schedulerから毎朝AM 9:00に呼び出されることを想定。
+    Cloud Schedulerから毎朝AM 8:30に呼び出されることを想定。
+
+    デフォルト（dry_run=True）では BQ への保存を行わない。
+    BQ への保存は発走直前の _refresh_investment_decisions_for_race() が行う。
+    dry_run=False を明示した場合のみ investment_decisions テーブルへ保存する。
 
     前提条件:
       - predictions.daily_predictions に当日の予測データが存在すること
@@ -1447,9 +1451,12 @@ async def _purchase_pipeline_async(
       2. 現在時刻の5〜10分後に発走するレースを特定
       3. 対象レースが0件なら skipped を返す
       4. [dry_run=False] IPAT ログイン
-      5. 各レースの推奨馬券を取得
-         [dry_run=True]  LINE通知のみ
-         [dry_run=False] 予算チェック → 購入 → 履歴保存
+      5. 各レースについて:
+         5a. 最新オッズで investment_decisions を上書き（_refresh_investment_decisions_for_race）
+             失敗時はフォールバック（既存の investment_decisions を使用）
+         5b. 推奨馬券を取得
+             [dry_run=True]  LINE通知のみ
+             [dry_run=False] 予算チェック → 購入 → 履歴保存
       6. [dry_run=False] ログアウト
     """
     from src.automation.data.ipat_purchaser import (

--- a/src/automation/api/app.py
+++ b/src/automation/api/app.py
@@ -914,8 +914,8 @@ class StrategyDailyRequest(BaseModel):
         json_schema_extra={"example": "2026-03-07"},
     )
     dry_run: bool = Field(
-        default=False,
-        description="Trueの場合BQ保存をスキップして結果のみ返す",
+        default=True,
+        description="Trueの場合BQ保存をスキップして結果のみ返す（デフォルト: True。BQへの保存は発走直前の上書き処理で行う）",
     )
     initial_capital: float = Field(
         default=100_000.0,
@@ -1287,6 +1287,141 @@ def _run_purchase_pipeline(
     )
 
 
+def _refresh_investment_decisions_for_race(
+    project_id: str,
+    race_id: str,
+    target_date: datetime.date,
+) -> bool:
+    """
+    発走直前に最新オッズで investment_decisions を1レース分上書きする。
+
+    predictions.daily_odds / daily_odds_combo から最新オッズを取得し、
+    select_bets_for_race() で推奨馬券を再計算して predictions.investment_decisions へ
+    MERGE UPSERT する。
+
+    データが取得できない場合は既存の investment_decisions をそのまま使用（フォールバック）。
+
+    Args:
+        project_id: GCP プロジェクト ID
+        race_id: 対象レース ID
+        target_date: 対象日
+
+    Returns:
+        True: 上書き成功, False: フォールバック（既存データ使用）
+    """
+    from google.cloud import bigquery as _bq
+    from scripts.run_strategy import (
+        build_race_df,
+        fetch_combo_odds_for_date,
+        load_strategy_config,
+        save_decisions_to_bq,
+        _build_decision_row,
+    )
+    from src.backtest.strategy import select_bets_for_race
+
+    try:
+        client = _bq.Client(project=project_id)
+
+        # 対象レースの予測データを取得
+        pred_query = f"""
+        SELECT race_id, race_date, horse_id, horse_number, horse_name,
+               venue_code, race_number, win_place_prob, pred_score, rank_in_race
+        FROM `{project_id}.predictions.daily_predictions`
+        WHERE race_date = '{target_date.isoformat()}'
+          AND race_id = '{race_id}'
+        ORDER BY rank_in_race
+        """
+        import pandas as _pd
+        pred_df = client.query(pred_query).to_dataframe()
+
+        if pred_df.empty:
+            logger.warning(f"_refresh: race_id={race_id} の予測データなし → フォールバック")
+            return False
+
+        # 対象レースの単複オッズを取得
+        odds_query = f"""
+        SELECT race_id, horse_number, win_odds, place_odds_min, place_odds_max, scraped_at
+        FROM `{project_id}.predictions.daily_odds`
+        WHERE race_date = '{target_date.isoformat()}'
+          AND race_id = '{race_id}'
+        """
+        odds_df = client.query(odds_query).to_dataframe()
+
+        if odds_df.empty:
+            logger.warning(f"_refresh: race_id={race_id} のオッズデータなし → フォールバック")
+            return False
+
+        # race_df を構築（predictions + odds JOIN）
+        race_df = build_race_df(pred_df, odds_df)
+        race_df = race_df.dropna(subset=["win_place_prob", "odds"])
+        if len(race_df) < 3:
+            logger.warning(f"_refresh: race_id={race_id} の有効データ不足 → フォールバック")
+            return False
+
+        # 組み合わせオッズを取得
+        combo_df = fetch_combo_odds_for_date(client, project_id, [race_id])
+        race_combo_df = combo_df[combo_df["race_id"] == race_id] if not combo_df.empty else _pd.DataFrame()
+
+        # 戦略パラメータを読み込み
+        config = load_strategy_config()
+        p1 = float(config.get("p1", 0.3))
+        expected_return_threshold = float(config.get("expected_return_threshold", 1.2))
+        _legacy_top_n = int(config.get("top_n", 5))
+        top_n_dominant = int(config.get("top_n_dominant", _legacy_top_n))
+        top_n_standard = int(config.get("top_n_standard", _legacy_top_n))
+        budget_per_race = float(config.get("budget_per_race", 3000.0))
+        min_bet_amount = float(config.get("min_bet_amount", 100.0))
+        min_prob_threshold = float(config.get("min_prob_threshold", 0.10))
+        prob_weight_r_dominant = float(config.get("prob_weight_r_dominant", 1.0))
+        prob_weight_r_standard = float(config.get("prob_weight_r_standard", 1.0))
+
+        # 推奨馬券を再計算
+        bets, race_pattern = select_bets_for_race(
+            race_df=race_df,
+            combo_odds_df=race_combo_df if not race_combo_df.empty else None,
+            budget_per_race=budget_per_race,
+            p1=p1,
+            expected_return_threshold=expected_return_threshold,
+            min_bet_amount=min_bet_amount,
+            min_prob_threshold=min_prob_threshold,
+            prob_weight_r_dominant=prob_weight_r_dominant,
+            prob_weight_r_standard=prob_weight_r_standard,
+            top_n_dominant=top_n_dominant,
+            top_n_standard=top_n_standard,
+        )
+
+        # 投資判断 dict を構築して MERGE UPSERT 保存
+        meta_row = race_df.iloc[0]
+        created_at = datetime.datetime.now(datetime.timezone.utc)
+        decisions = [
+            _build_decision_row(
+                race_id=race_id,
+                target_date=target_date,
+                meta_row=meta_row,
+                race_group=race_df,
+                bet=bet,
+                race_pattern_str=race_pattern.pattern,
+                created_at=created_at,
+            )
+            for bet in bets
+            if bet.get("horse_numbers")
+        ]
+
+        save_decisions_to_bq(decisions, project_id)
+        logger.info(
+            f"_refresh: race_id={race_id} の investment_decisions を更新 "
+            f"({len(decisions)}件, パターン={race_pattern.pattern})"
+        )
+        return True
+
+    except Exception as e:
+        logger.warning(
+            f"_refresh: race_id={race_id} の更新失敗 → フォールバック: {e}",
+            exc_info=True,
+        )
+        return False
+
+
 async def _purchase_pipeline_async(
     project_id: str,
     target_date: datetime.date,
@@ -1365,6 +1500,13 @@ async def _purchase_pipeline_async(
             venue_name = race.get("venue_name", "")
             race_number = race.get("race_number", "")
 
+            # 最新オッズで investment_decisions を上書き
+            refreshed = _refresh_investment_decisions_for_race(project_id, race_id, target_date)
+            if refreshed:
+                logger.info(f"[DRY RUN] race_id={race_id}: 最新オッズで investment_decisions を更新済み")
+            else:
+                logger.info(f"[DRY RUN] race_id={race_id}: フォールバック（既存 investment_decisions を使用）")
+
             bets = fetch_recommended_bets(project_id, race_id, target_date)
             if not bets:
                 logger.info(f"[DRY RUN] race_id={race_id}: 推奨馬券なし → スキップ")
@@ -1424,6 +1566,13 @@ async def _purchase_pipeline_async(
             race_id = race["race_id"]
             venue_name = race.get("venue_name", "")
             race_number = race.get("race_number", "")
+
+            # 最新オッズで investment_decisions を上書き
+            refreshed = _refresh_investment_decisions_for_race(project_id, race_id, target_date)
+            if refreshed:
+                logger.info(f"race_id={race_id}: 最新オッズで investment_decisions を更新済み")
+            else:
+                logger.info(f"race_id={race_id}: フォールバック（既存 investment_decisions を使用）")
 
             # 推奨馬券取得
             bets = fetch_recommended_bets(project_id, race_id, target_date)

--- a/tests/test_refresh_investment_decisions.py
+++ b/tests/test_refresh_investment_decisions.py
@@ -1,0 +1,135 @@
+"""
+_refresh_investment_decisions_for_race のユニットテスト
+
+テスト対象:
+  - _refresh_investment_decisions_for_race: 最新オッズで investment_decisions を上書き
+    - 正常系: 予測・オッズあり → 計算・保存 → True を返す
+    - 異常系: 予測データなし → False（フォールバック）
+    - 異常系: オッズデータなし → False（フォールバック）
+    - 異常系: BQ例外 → False（フォールバック）
+
+Issue #231: 発走5分前に最新オッズで investment_decisions を上書きしてから IPAT 購入する
+"""
+
+from __future__ import annotations
+
+import datetime
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from src.automation.api.app import _refresh_investment_decisions_for_race
+
+TARGET_DATE = datetime.date(2026, 4, 12)
+RACE_ID = "202609050112"
+PROJECT_ID = "test_project"
+
+
+def _make_pred_df() -> pd.DataFrame:
+    return pd.DataFrame([
+        {
+            "race_id": RACE_ID, "race_date": TARGET_DATE,
+            "horse_id": f"h{i:04d}", "horse_number": i,
+            "horse_name": f"ウマ{i}", "venue_code": "09",
+            "race_number": 12, "win_place_prob": 0.3 if i == 1 else 0.12,
+            "pred_score": 1.0 - i * 0.1, "rank_in_race": i,
+        }
+        for i in range(1, 9)
+    ])
+
+
+def _make_odds_df() -> pd.DataFrame:
+    return pd.DataFrame([
+        {
+            "race_id": RACE_ID, "horse_number": i,
+            "win_odds": 3.0 * i, "place_odds_min": max(1.1, 1.5 * i),
+            "place_odds_max": 2.5 * i, "scraped_at": "2026-04-12 08:30:00",
+        }
+        for i in range(1, 9)
+    ])
+
+
+def _make_merged_df() -> pd.DataFrame:
+    """build_race_df が返す想定の DataFrame"""
+    df = _make_pred_df().copy()
+    df["odds"] = df["horse_number"].apply(lambda i: max(1.1, 1.5 * i))
+    df["win_odds"] = df["horse_number"].apply(lambda i: 3.0 * i)
+    return df
+
+
+class TestRefreshInvestmentDecisions:
+    """_refresh_investment_decisions_for_race のテスト"""
+
+    @patch("scripts.run_strategy.save_decisions_to_bq", return_value=1)
+    @patch("scripts.run_strategy.fetch_combo_odds_for_date", return_value=pd.DataFrame())
+    @patch("scripts.run_strategy.load_strategy_config", return_value={
+        "p1": 0.3, "expected_return_threshold": 1.2, "budget_per_race": 3000,
+        "top_n": 5, "min_bet_amount": 100, "min_prob_threshold": 0.10,
+        "prob_weight_r_dominant": 1.0, "prob_weight_r_standard": 1.0,
+    })
+    @patch("scripts.run_strategy.build_race_df")
+    @patch("src.backtest.strategy.select_bets_for_race")
+    @patch("google.cloud.bigquery.Client")
+    def test_success_returns_true(
+        self,
+        mock_bq_cls,
+        mock_select,
+        mock_build,
+        mock_config,
+        mock_combo,
+        mock_save,
+    ):
+        """予測・オッズが取得でき計算・保存に成功した場合は True を返すこと"""
+        pred_df = _make_pred_df()
+        odds_df = _make_odds_df()
+        merged_df = _make_merged_df()
+
+        mock_client = MagicMock()
+        mock_bq_cls.return_value = mock_client
+        mock_client.query.return_value.to_dataframe.side_effect = [pred_df, odds_df]
+        mock_build.return_value = merged_df
+
+        fake_pattern = MagicMock()
+        fake_pattern.pattern = "standard"
+        mock_select.return_value = (
+            [{"horse_numbers": [1], "bet_type": "place", "odds": 2.0, "bet_amount": 300.0}],
+            fake_pattern,
+        )
+
+        result = _refresh_investment_decisions_for_race(PROJECT_ID, RACE_ID, TARGET_DATE)
+
+        assert result is True
+        mock_save.assert_called_once()
+
+    @patch("google.cloud.bigquery.Client")
+    def test_empty_predictions_returns_false(self, mock_bq_cls):
+        """予測データが空の場合は False（フォールバック）を返すこと"""
+        mock_client = MagicMock()
+        mock_bq_cls.return_value = mock_client
+        mock_client.query.return_value.to_dataframe.return_value = pd.DataFrame()
+
+        result = _refresh_investment_decisions_for_race(PROJECT_ID, RACE_ID, TARGET_DATE)
+
+        assert result is False
+
+    @patch("google.cloud.bigquery.Client")
+    def test_empty_odds_returns_false(self, mock_bq_cls):
+        """オッズデータが空の場合は False（フォールバック）を返すこと"""
+        pred_df = _make_pred_df()
+        mock_client = MagicMock()
+        mock_bq_cls.return_value = mock_client
+        mock_client.query.return_value.to_dataframe.side_effect = [pred_df, pd.DataFrame()]
+
+        result = _refresh_investment_decisions_for_race(PROJECT_ID, RACE_ID, TARGET_DATE)
+
+        assert result is False
+
+    @patch("google.cloud.bigquery.Client")
+    def test_bq_exception_returns_false(self, mock_bq_cls):
+        """BigQuery例外時は False（フォールバック）を返し、例外を送出しないこと"""
+        mock_bq_cls.side_effect = Exception("BQ connection error")
+
+        result = _refresh_investment_decisions_for_race(PROJECT_ID, RACE_ID, TARGET_DATE)
+
+        assert result is False


### PR DESCRIPTION
## Summary

- `StrategyDailyRequest.dry_run` のデフォルトを `False` → `True` に変更
  - 朝の `POST /api/v1/strategy/daily` 実行では BQ への保存をスキップ（ドライラン化）
- `_refresh_investment_decisions_for_race(project_id, race_id, target_date)` を追加
  - 発走直前に `predictions.daily_odds` の最新オッズで `select_bets_for_race()` を再計算
  - 結果を `save_decisions_to_bq()`（`run_strategy.py` の既存実装）で MERGE UPSERT
  - オッズ・予測データ未取得時はフォールバック（既存 `investment_decisions` をそのまま使用）
  - 上書き成功・失敗（フォールバック）いずれもログに記録
- `_purchase_pipeline_async()` のドライラン・本番両モードで各レース処理前に
  `_refresh_investment_decisions_for_race()` を呼び出すよう変更

## 変更後のフロー（対象レース1件ごと）

```
1. predictions.daily_odds から最新オッズを取得
2. predictions.daily_predictions から予測スコアを取得
3. select_bets_for_race() で推奨馬券を再計算
4. predictions.investment_decisions に MERGE UPSERT
5. fetch_recommended_bets() で上書き後データを取得して IPAT 購入
```

## Test plan

- [x] `tests/test_refresh_investment_decisions.py` を新規追加（4件）
  - 正常系: 予測・オッズあり → 保存 → True
  - 異常系: 予測なし → False（フォールバック）
  - 異常系: オッズなし → False（フォールバック）
  - 異常系: BQ例外 → False（フォールバック）

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)