### PR TITLE
fix: IPAT SP版ログインボタン・成功確認ロジックを修正

### DIFF
--- a/src/automation/data/ipat_purchaser.py
+++ b/src/automation/data/ipat_purchaser.py
@@ -108,6 +108,10 @@ class IpatPurchaser:
 
         try:
             logger.info("JRA IPAT ログイン開始")
+
+            # バリデーション失敗時に出る alert を自動 dismiss
+            self._page.on("dialog", lambda d: d.dismiss())
+
             await self._page.goto(IPAT_BASE_URL, timeout=PURCHASE_TIMEOUT_MS, wait_until="domcontentloaded")
 
             # ログインフォームへの入力（SP版: id属性で識別）
@@ -116,16 +120,37 @@ class IpatPurchaser:
             await self._page.fill('#pars', self.pat_number, timeout=PURCHASE_TIMEOUT_MS)
 
             # ログインボタンをクリック
-            await self._page.click('input[type="submit"]', timeout=PURCHASE_TIMEOUT_MS)
+            # SP版のログインボタンは input[type="submit"] ではなく
+            # ToSPMenu() を呼び出す <a> タグ（li.btnColor a）
+            await self._page.click('li.btnColor a', timeout=PURCHASE_TIMEOUT_MS)
             await self._page.wait_for_load_state("domcontentloaded", timeout=PURCHASE_TIMEOUT_MS)
 
-            # ログイン成功の確認（ログアウトリンクの存在確認）
-            logout_link = await self._page.query_selector('a[href*="logout"]')
-            if logout_link is None:
-                logger.warning("IPAT ログイン失敗: ログアウトリンクが見つかりません")
+            # ログイン成功の確認
+            # SP版にはログアウトリンクがないため、URLの遷移とエラーメッセージで判断する
+            current_url = self._page.url
+            page_text = await self._page.text_content("body") or ""
+
+            # ログイン失敗を示すエラーキーワード
+            error_keywords = [
+                "加入者番号または暗証番号",
+                "認証エラー",
+                "ログインに失敗",
+                "入力内容をご確認",
+                "暗証番号が違います",
+                "PAT番号が違います",
+                "加入者番号が違います",
+            ]
+            has_error = any(kw in page_text for kw in error_keywords)
+            if has_error:
+                logger.warning(f"IPAT ログイン失敗: エラーメッセージ検出 URL={current_url}")
                 return False
 
-            logger.info("JRA IPAT ログイン成功")
+            # ログインページのままなら失敗（ToSPMenu のバリデーションで弾かれた等）
+            if current_url == IPAT_BASE_URL:
+                logger.warning(f"IPAT ログイン失敗: ページが遷移していません URL={current_url}")
+                return False
+
+            logger.info(f"JRA IPAT ログイン成功 URL={current_url}")
             return True
 
         except Exception as e:

--- a/tests/test_ipat_purchaser.py
+++ b/tests/test_ipat_purchaser.py
@@ -124,26 +124,55 @@ class TestFetchTargetRaces:
 class TestIpatPurchaserLogin:
     """IpatPurchaser.login() の成功・失敗ケースのテスト"""
 
+    IPAT_BASE_URL = "https://www.ipat.jra.go.jp/sp/index.cgi"
+    IPAT_MENU_URL = "https://www.ipat.jra.go.jp/sp/pw_732_i.cgi"
+
     def _make_purchaser(self) -> IpatPurchaser:
-        p = IpatPurchaser("12345678", "1234", "87654321")
+        p = IpatPurchaser("12345678", "1234", "8765")
         p._page = AsyncMock()
+        # dialog イベントリスナー登録のモック
+        p._page.on = MagicMock()
         return p
 
     def test_login_success(self):
-        """ログインボタンクリック後にログアウトリンクが見つかれば True を返すこと"""
+        """ページが IPAT_BASE_URL 以外に遷移し、エラーなければ True を返すこと"""
         purchaser = self._make_purchaser()
-        purchaser._page.query_selector = AsyncMock(return_value=MagicMock())  # ログアウトリンク found
+        purchaser._page.url = self.IPAT_MENU_URL  # ログイン後に遷移
+        purchaser._page.text_content = AsyncMock(return_value="馬券購入メニュー")
 
         result = run_async(purchaser.login())
 
         assert result is True
         purchaser._page.goto.assert_called_once()
         purchaser._page.fill.assert_called()
+        # SP版ログインボタン（li.btnColor a）がクリックされること
+        purchaser._page.click.assert_called_once_with('li.btnColor a', timeout=30_000)
 
-    def test_login_failure_no_logout_link(self):
-        """ログアウトリンクが見つからない場合は False を返すこと"""
+    def test_login_failure_url_unchanged(self):
+        """ページが IPAT_BASE_URL のまま遷移しなかった場合は False を返すこと"""
         purchaser = self._make_purchaser()
-        purchaser._page.query_selector = AsyncMock(return_value=None)  # ログアウトリンク not found
+        purchaser._page.url = self.IPAT_BASE_URL  # ページ遷移なし
+        purchaser._page.text_content = AsyncMock(return_value="加入者番号を入力してください")
+
+        result = run_async(purchaser.login())
+
+        assert result is False
+
+    def test_login_failure_error_message_detected(self):
+        """ページにエラーキーワードがある場合は False を返すこと"""
+        purchaser = self._make_purchaser()
+        purchaser._page.url = self.IPAT_MENU_URL
+        purchaser._page.text_content = AsyncMock(return_value="暗証番号が違います。再度ご確認ください。")
+
+        result = run_async(purchaser.login())
+
+        assert result is False
+
+    def test_login_failure_member_id_error(self):
+        """加入者番号エラーのメッセージがある場合は False を返すこと"""
+        purchaser = self._make_purchaser()
+        purchaser._page.url = self.IPAT_MENU_URL
+        purchaser._page.text_content = AsyncMock(return_value="加入者番号または暗証番号が正しくありません")
 
         result = run_async(purchaser.login())
 
@@ -159,7 +188,7 @@ class TestIpatPurchaserLogin:
 
     def test_login_without_browser_raises(self):
         """_page が None の場合は IpatLoginError を送出すること"""
-        purchaser = IpatPurchaser("12345678", "1234", "87654321")
+        purchaser = IpatPurchaser("12345678", "1234", "8765")
         # _page を None のまま（コンテキストマネージャーを使わない）
 
         with pytest.raises(IpatLoginError):


### PR DESCRIPTION
## 問題

16:00・16:20のIPAT自動購入でログインが失敗し、LINE通知も届かなかった。

**ログから特定した2つのバグ:**

### バグ1（16:00発生）: ログインボタンのセレクタ誤り
```
Page.fill: Timeout 30000ms exceeded.
waiting for locator("input[name=\"umid\"]")
```
旧コードが `input[name="umid"]`（旧PC版セレクタ）を使用していた。Issue #230でSP版URLに変更済みだったが、新デプロイが16:06に完了したため購入ウィンドウを逃した。

### バグ2（16:20発生）: ログイン成功確認ロジック誤り
```
IPAT ログイン失敗: ログアウトリンクが見つかりません
```
修正済みコードが `a[href*="logout"]` でログイン成功を確認しようとしていたが、**IPAT SP版にこのリンクは存在しない**ため常に失敗していた。

## 根本原因

実際のIPAT SP版ページを Playwright で確認した結果:
- ログインボタン: `<a onclick="JavaScript:ToSPMenu();">ログイン</a>` → セレクタは `li.btnColor a`
- `input[type="submit"]` の実体は「**ガラケー型スマートフォン版サイトへ**」ボタン（全く別の機能）
- ログイン後のURLは `https://www.ipat.jra.go.jp/sp/pw_732_i.cgi` に遷移する
- ログアウトリンク（`a[href*="logout"]`）はSP版に存在しない

## 修正内容

### `src/automation/data/ipat_purchaser.py`

| 項目 | 修正前 | 修正後 |
|---|---|---|
| ログインボタン | `input[type="submit"]` | `li.btnColor a` |
| ログイン成功確認 | `a[href*="logout"]` の存在確認 | URLの遷移確認 + エラーキーワード検出 |
| alertハンドリング | なし | `page.on("dialog", dismiss)` を追加 |

### `tests/test_ipat_purchaser.py`

- ログイン成功確認のテストをURLベースの新ロジックに合わせて更新
- エラーキーワード検出のテストケースを追加（暗証番号エラー・加入者番号エラー）
- `li.btnColor a` クリックのアサーションを追加

## テスト結果

```
tests/test_ipat_purchaser.py::TestIpatPurchaserLogin::test_login_success PASSED
tests/test_ipat_purchaser.py::TestIpatPurchaserLogin::test_login_failure_url_unchanged PASSED
tests/test_ipat_purchaser.py::TestIpatPurchaserLogin::test_login_failure_error_message_detected PASSED
tests/test_ipat_purchaser.py::TestIpatPurchaserLogin::test_login_failure_member_id_error PASSED
tests/test_ipat_purchaser.py::TestIpatPurchaserLogin::test_login_raises_on_playwright_error PASSED
tests/test_ipat_purchaser.py::TestIpatPurchaserLogin::test_login_without_browser_raises PASSED
24 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)