### PR TITLE
feat: race-day-purchase 実行時に対象レースのオッズをリアルタイムスクレイピングする

### DIFF
--- a/src/automation/api/app.py
+++ b/src/automation/api/app.py
@@ -1469,6 +1469,7 @@ async def _purchase_pipeline_async(
         save_purchase_record,
         DAILY_BUDGET_LIMIT,
     )
+    from src.automation.data.netkeiba_scraper import scrape_odds_for_race
     from src.utils.line_notify import push_messages, text_message
 
     def _send_line(msg: str) -> None:
@@ -1497,6 +1498,27 @@ async def _purchase_pipeline_async(
         f"対象レース {len(target_races)}件: {[r['race_id'] for r in target_races]}"
         f" [{'ドライラン' if dry_run else '本番購入'}]"
     )
+
+    # 3. 対象レースのオッズをリアルタイムスクレイピング
+    for race in target_races:
+        race_id = race["race_id"]
+        try:
+            success = await asyncio.to_thread(
+                scrape_odds_for_race,
+                race_id,
+                target_date,
+                project_id,
+            )
+            if success:
+                logger.info(f"race_id={race_id}: リアルタイムオッズ取得完了")
+            else:
+                logger.warning(
+                    f"race_id={race_id}: リアルタイムオッズ取得失敗（既存データを使用）"
+                )
+        except Exception as e:
+            logger.warning(
+                f"race_id={race_id}: リアルタイムオッズ取得中に例外発生（フォールバック）: {e}"
+            )
 
     race_results = []
 

--- a/src/automation/api/app.py
+++ b/src/automation/api/app.py
@@ -1450,14 +1450,16 @@ async def _purchase_pipeline_async(
       1. raw.race_info から当日の発走時刻を取得
       2. 現在時刻の5〜10分後に発走するレースを特定
       3. 対象レースが0件なら skipped を返す
-      4. [dry_run=False] IPAT ログイン
-      5. 各レースについて:
-         5a. 最新オッズで investment_decisions を上書き（_refresh_investment_decisions_for_race）
+      4. 対象レースのオッズをリアルタイムスクレイピング（netkeiba）
+         失敗時はフォールバック（既存の daily_odds を使用）
+      5. [dry_run=False] IPAT ログイン
+      6. 各レースについて:
+         6a. 最新オッズで investment_decisions を上書き（_refresh_investment_decisions_for_race）
              失敗時はフォールバック（既存の investment_decisions を使用）
-         5b. 推奨馬券を取得
+         6b. 推奨馬券を取得
              [dry_run=True]  LINE通知のみ
              [dry_run=False] 予算チェック → 購入 → 履歴保存
-      6. [dry_run=False] ログアウト
+      7. [dry_run=False] ログアウト
     """
     from src.automation.data.ipat_purchaser import (
         IpatLoginError,

--- a/src/automation/data/netkeiba_scraper.py
+++ b/src/automation/data/netkeiba_scraper.py
@@ -439,6 +439,124 @@ def netkeiba_to_jrdb_race_id(
         return None
 
 
+def jrdb_race_id_to_netkeiba(jrdb_race_id: str) -> str:
+    """
+    JRDB形式のrace_id（8文字）をnetkeiba形式（12桁）に変換する
+
+    JRDB形式: {PP}{YY}{K}{D}{RR}
+      - PP: 競馬場コード（2文字）
+      - YY: 年の下2桁（2文字）
+      - K : 回次（16進1文字）
+      - D : 日次（16進1文字）
+      - RR: レース番号（2文字）
+
+    netkeiba形式: {YYYY}{PP}{NN}{DD}{RR}
+      - YYYY: 4桁年
+      - PP  : 競馬場コード（2文字）
+      - NN  : 回次（2桁ゼロ埋め）
+      - DD  : 日次（2桁ゼロ埋め）
+      - RR  : レース番号（2文字）
+
+    Args:
+        jrdb_race_id: 8文字のJRDB race_id（例: "06261411"）
+
+    Returns:
+        12桁のnetkeiba race_id（例: "202606010411"）
+
+    Raises:
+        ValueError: 8文字でない、または形式が不正な場合
+    """
+    if len(jrdb_race_id) != 8:
+        raise ValueError(
+            f"JRDB race_id は8文字である必要があります: '{jrdb_race_id}'"
+        )
+    venue_code = jrdb_race_id[0:2]
+    year_short = jrdb_race_id[2:4]
+    kai = int(jrdb_race_id[4], 16)
+    day = int(jrdb_race_id[5], 16)
+    race_number = jrdb_race_id[6:8]
+    year = f"20{year_short}"
+    return f"{year}{venue_code}{kai:02d}{day:02d}{race_number}"
+
+
+def scrape_odds_for_race(
+    jrdb_race_id: str,
+    race_date: datetime.date,
+    project_id: str,
+    ticket_types: list[str] | None = None,
+    sleep_sec: float = 1.5,
+) -> bool:
+    """
+    指定レースの単複・組み合わせオッズをリアルタイムスクレイピングしてBQにUPSERTする
+
+    JRDB race_idをnetkeiba race_idに変換してnetkeibaからオッズを取得し、
+    predictions.daily_odds（単複）と predictions.daily_odds_combo（組み合わせ）に保存する。
+
+    Args:
+        jrdb_race_id: JRDB形式のレースID（8文字）
+        race_date: 開催日
+        project_id: GCPプロジェクトID
+        ticket_types: 組み合わせ馬券種リスト（例: ['b4', 'b5', 'b7']）
+                      None の場合は ['b4', 'b5', 'b7']（馬連・ワイド・三連複）を取得
+        sleep_sec: スクレイプ間隔（秒）
+
+    Returns:
+        単複オッズの取得・保存に成功した場合 True、失敗した場合 False
+        （組み合わせオッズの失敗はWARNINGログのみで全体の成否には影響しない）
+    """
+    if ticket_types is None:
+        ticket_types = ["b4", "b5", "b7"]
+
+    netkeiba_race_id = jrdb_race_id_to_netkeiba(jrdb_race_id)
+    scraped_at = datetime.datetime.now(datetime.timezone.utc)
+
+    # 単複オッズ取得
+    win_place_df = get_win_place_odds(netkeiba_race_id, sleep_sec=sleep_sec)
+    if win_place_df.empty:
+        logger.warning(f"race_id={jrdb_race_id}: 単複オッズが取得できませんでした")
+        return False
+
+    rows = []
+    for _, row in win_place_df.iterrows():
+        rows.append({
+            "race_id": jrdb_race_id,
+            "race_date": race_date,
+            "horse_number": int(row["horse_number"]),
+            "win_odds": row.get("win_odds"),
+            "place_odds_min": row.get("place_odds_min"),
+            "place_odds_max": row.get("place_odds_max"),
+            "scraped_at": scraped_at,
+        })
+
+    odds_df = pd.DataFrame(rows)
+    try:
+        saved = save_odds_to_bq(odds_df, project_id=project_id)
+        logger.info(f"race_id={jrdb_race_id}: 単複オッズ {saved}行をBQに保存")
+    except Exception as e:
+        logger.warning(f"race_id={jrdb_race_id}: 単複オッズのBQ保存失敗: {e}")
+        return False
+
+    # 組み合わせオッズ取得
+    try:
+        time.sleep(sleep_sec)
+        combo_df = get_combo_odds(netkeiba_race_id, ticket_types=ticket_types, sleep_sec=sleep_sec)
+        if combo_df.empty:
+            logger.warning(f"race_id={jrdb_race_id}: 組み合わせオッズが取得できませんでした（単複は保存済み）")
+        else:
+            save_combo_odds_to_bq(
+                df=combo_df,
+                race_id=jrdb_race_id,
+                race_date=race_date,
+                scraped_at=scraped_at,
+                project_id=project_id,
+            )
+            logger.info(f"race_id={jrdb_race_id}: 組み合わせオッズ {len(combo_df)}行をBQに保存")
+    except Exception as e:
+        logger.warning(f"race_id={jrdb_race_id}: 組み合わせオッズ取得・保存失敗（単複は保存済み）: {e}")
+
+    return True
+
+
 def scrape_today_odds(
     date: datetime.date,
     project_id: str,

--- a/tests/test_ipat_purchaser.py
+++ b/tests/test_ipat_purchaser.py
@@ -327,3 +327,131 @@ class TestBudgetCheck:
         """全馬券種が BET_TYPE_MAP に定義されていること"""
         expected_types = {"win", "place", "umaren", "wide", "umatan", "sanrenpuku"}
         assert set(BET_TYPE_MAP.keys()) == expected_types
+
+
+# ---------------------------------------------------------------------------
+# リアルタイムオッズスクレイピングのテスト
+# ---------------------------------------------------------------------------
+
+class TestRealtimeScraping:
+    """_purchase_pipeline_async() におけるリアルタイムオッズ取得の検証"""
+
+    TARGET_DATE = datetime.date(2026, 4, 12)
+    RACE_ID_1 = "06261411"
+    RACE_ID_2 = "05261208"
+
+    def _run_pipeline(self, target_races: list[dict], scrape_mock: MagicMock) -> dict:
+        """_purchase_pipeline_async() を dry_run=True で実行するヘルパー"""
+        import importlib
+        app_module = importlib.import_module("src.automation.api.app")
+
+        with (
+            patch(
+                "src.automation.data.ipat_purchaser.fetch_today_races_with_start_time",
+                return_value=[
+                    {
+                        "race_id": r["race_id"],
+                        "start_time": "1000",
+                        "venue_name": "東京",
+                        "race_number": 1,
+                    }
+                    for r in target_races
+                ],
+            ),
+            patch(
+                "src.automation.data.ipat_purchaser.fetch_target_races",
+                return_value=target_races,
+            ),
+            patch(
+                "src.automation.data.netkeiba_scraper.scrape_odds_for_race",
+                side_effect=scrape_mock,
+            ),
+            patch(
+                "src.automation.api.app._refresh_investment_decisions_for_race",
+                return_value=True,
+            ),
+            patch(
+                "src.automation.data.ipat_purchaser.fetch_recommended_bets",
+                return_value=[],
+            ),
+            patch("src.utils.line_notify.push_messages"),
+        ):
+            return run_async(
+                app_module._purchase_pipeline_async(
+                    project_id="test-project",
+                    target_date=self.TARGET_DATE,
+                    member_id="12345678",
+                    pin="1234",
+                    pat_number="87654321",
+                    channel_access_token="",
+                    line_user_id="",
+                    dry_run=True,
+                )
+            )
+
+    def test_scrape_called_for_each_target_race(self):
+        """target_races が1件以上ある場合、各レースに対して scrape_odds_for_race が呼ばれること"""
+        target_races = [
+            {"race_id": self.RACE_ID_1, "venue_name": "東京", "race_number": 11},
+            {"race_id": self.RACE_ID_2, "venue_name": "中山", "race_number": 8},
+        ]
+        call_log: list[str] = []
+
+        def scrape_side_effect(race_id, race_date, project_id, **kwargs):
+            call_log.append(race_id)
+            return True
+
+        self._run_pipeline(target_races, scrape_side_effect)
+
+        assert call_log == [self.RACE_ID_1, self.RACE_ID_2]
+
+    def test_no_scrape_when_no_target_races(self):
+        """target_races が0件の場合、scrape_odds_for_race は呼ばれないこと"""
+        import importlib
+        app_module = importlib.import_module("src.automation.api.app")
+
+        call_log: list[str] = []
+
+        def scrape_side_effect(race_id, race_date, project_id, **kwargs):
+            call_log.append(race_id)
+            return True
+
+        with (
+            patch(
+                "src.automation.data.ipat_purchaser.fetch_today_races_with_start_time",
+                return_value=[],
+            ),
+            patch(
+                "src.automation.data.netkeiba_scraper.scrape_odds_for_race",
+                side_effect=scrape_side_effect,
+            ),
+        ):
+            result = run_async(
+                app_module._purchase_pipeline_async(
+                    project_id="test-project",
+                    target_date=self.TARGET_DATE,
+                    member_id="12345678",
+                    pin="1234",
+                    pat_number="87654321",
+                    channel_access_token="",
+                    line_user_id="",
+                    dry_run=True,
+                )
+            )
+
+        assert result["status"] == "skipped"
+        assert call_log == []
+
+    def test_scrape_failure_does_not_abort_pipeline(self):
+        """scrape_odds_for_race が例外を投げてもパイプラインが止まらないこと"""
+        target_races = [
+            {"race_id": self.RACE_ID_1, "venue_name": "東京", "race_number": 11},
+        ]
+
+        def scrape_raises(race_id, race_date, project_id, **kwargs):
+            raise RuntimeError("ネットワークエラー")
+
+        result = self._run_pipeline(target_races, scrape_raises)
+
+        # スクレイプ失敗でもパイプライン全体は成功
+        assert result["status"] == "success"

--- a/tests/test_netkeiba_scraper.py
+++ b/tests/test_netkeiba_scraper.py
@@ -32,10 +32,12 @@ from src.automation.data.netkeiba_scraper import (
     get_combo_odds,
     get_today_race_list,
     get_win_place_odds,
+    jrdb_race_id_to_netkeiba,
     netkeiba_to_jrdb_race_id,
     parse_netkeiba_race_id,
     save_combo_odds_to_bq,
     save_odds_to_bq,
+    scrape_odds_for_race,
     scrape_today_odds,
 )
 
@@ -705,3 +707,187 @@ class TestPlaywrightDomcontentloaded:
         mock_page.goto.assert_called()
         _, kwargs = mock_page.goto.call_args
         assert kwargs.get("wait_until") == "domcontentloaded"
+
+
+# ---------------------------------------------------------------------------
+# jrdb_race_id_to_netkeiba
+# ---------------------------------------------------------------------------
+
+
+class TestJrdbRaceIdToNetkeiba:
+    """JRDB race_id → netkeiba race_id 変換の検証"""
+
+    def test_basic_conversion(self):
+        """東京1回4日11R（2026年）のJRDB race_idをnetkeiba形式に変換できること"""
+        # JRDB: venue=06, year=26, kai=1, day=4, race=11 → "06261411"
+        result = jrdb_race_id_to_netkeiba("06261411")
+        assert result == "202606010411"
+
+    def test_hex_kai_and_day(self):
+        """回次・日次が10以上（16進数）の場合も正しく変換できること"""
+        # venue=05, year=25→2025, kai='a'=10, day='b'=11, race=01
+        # 期待値: "2025" + "05" + "10" + "11" + "01" = "202505101101"
+        result = jrdb_race_id_to_netkeiba("0525ab01")
+        assert result == "202505101101"
+
+    def test_hex_conversion_correct(self):
+        """16進数の回次・日次が正しく10進数2桁ゼロ埋めになること"""
+        # kai=a=10, day=b=11
+        result = jrdb_race_id_to_netkeiba("0525ab01")
+        assert result[4:6] == "05"   # venue_code
+        assert result[6:8] == "10"   # kai=10
+        assert result[8:10] == "11"  # day=11
+        assert result[10:12] == "01" # race_number
+
+    def test_invalid_length_raises(self):
+        """8文字でないJRDB race_idはValueErrorを送出すること"""
+        with pytest.raises(ValueError):
+            jrdb_race_id_to_netkeiba("0626141")  # 7文字
+
+    def test_round_trip_components(self):
+        """変換後のnetkeiba race_idをparse_netkeiba_race_idで逆解析すると元の情報に一致すること"""
+        jrdb_id = "06261411"
+        netkeiba_id = jrdb_race_id_to_netkeiba(jrdb_id)
+        parsed = parse_netkeiba_race_id(netkeiba_id)
+
+        assert parsed["year"] == "2026"
+        assert parsed["venue_code"] == "06"
+        assert parsed["kai"] == "01"
+        assert parsed["nichi"] == "04"
+        assert parsed["race_number"] == 11
+
+    def test_output_is_12_digits(self):
+        """変換結果は必ず12桁の文字列であること"""
+        result = jrdb_race_id_to_netkeiba("06261411")
+        assert len(result) == 12
+        assert result.isdigit()
+
+
+# ---------------------------------------------------------------------------
+# scrape_odds_for_race
+# ---------------------------------------------------------------------------
+
+
+class TestScrapeOddsForRace:
+    """scrape_odds_for_race() の動作検証"""
+
+    RACE_DATE = datetime.date(2026, 4, 12)
+    JRDB_RACE_ID = "06261411"
+    PROJECT_ID = "test-project"
+
+    def _make_win_place_df(self) -> pd.DataFrame:
+        return pd.DataFrame([
+            {"horse_number": 1, "win_odds": 3.5, "place_odds_min": 1.5, "place_odds_max": 2.0},
+            {"horse_number": 2, "win_odds": 5.0, "place_odds_min": 2.0, "place_odds_max": 3.0},
+        ])
+
+    def _make_combo_df(self) -> pd.DataFrame:
+        return pd.DataFrame([
+            {"ticket_type": "umaren", "horse_number_1": 1, "horse_number_2": 2, "horse_number_3": None, "odds": 10.0},
+        ])
+
+    def test_returns_true_on_success(self):
+        """単複・組み合わせオッズの取得・保存が成功した場合 True を返すこと"""
+        with (
+            patch(
+                "src.automation.data.netkeiba_scraper.get_win_place_odds",
+                return_value=self._make_win_place_df(),
+            ),
+            patch(
+                "src.automation.data.netkeiba_scraper.save_odds_to_bq",
+                return_value=2,
+            ),
+            patch(
+                "src.automation.data.netkeiba_scraper.get_combo_odds",
+                return_value=self._make_combo_df(),
+            ),
+            patch(
+                "src.automation.data.netkeiba_scraper.save_combo_odds_to_bq",
+                return_value=1,
+            ),
+        ):
+            result = scrape_odds_for_race(
+                self.JRDB_RACE_ID, self.RACE_DATE, self.PROJECT_ID, sleep_sec=0
+            )
+
+        assert result is True
+
+    def test_returns_false_when_win_place_empty(self):
+        """単複オッズが空の場合 False を返すこと"""
+        with patch(
+            "src.automation.data.netkeiba_scraper.get_win_place_odds",
+            return_value=pd.DataFrame(),
+        ):
+            result = scrape_odds_for_race(
+                self.JRDB_RACE_ID, self.RACE_DATE, self.PROJECT_ID, sleep_sec=0
+            )
+
+        assert result is False
+
+    def test_returns_false_when_bq_save_fails(self):
+        """単複オッズのBQ保存が失敗した場合 False を返すこと"""
+        with (
+            patch(
+                "src.automation.data.netkeiba_scraper.get_win_place_odds",
+                return_value=self._make_win_place_df(),
+            ),
+            patch(
+                "src.automation.data.netkeiba_scraper.save_odds_to_bq",
+                side_effect=RuntimeError("BQ error"),
+            ),
+        ):
+            result = scrape_odds_for_race(
+                self.JRDB_RACE_ID, self.RACE_DATE, self.PROJECT_ID, sleep_sec=0
+            )
+
+        assert result is False
+
+    def test_combo_failure_does_not_affect_return(self):
+        """組み合わせオッズの取得失敗は True を返す（フォールバック）こと"""
+        with (
+            patch(
+                "src.automation.data.netkeiba_scraper.get_win_place_odds",
+                return_value=self._make_win_place_df(),
+            ),
+            patch(
+                "src.automation.data.netkeiba_scraper.save_odds_to_bq",
+                return_value=2,
+            ),
+            patch(
+                "src.automation.data.netkeiba_scraper.get_combo_odds",
+                side_effect=RuntimeError("combo error"),
+            ),
+        ):
+            result = scrape_odds_for_race(
+                self.JRDB_RACE_ID, self.RACE_DATE, self.PROJECT_ID, sleep_sec=0
+            )
+
+        assert result is True
+
+    def test_default_ticket_types_are_b4_b5_b7(self):
+        """ticket_types を省略した場合 b4/b5/b7 が使われること"""
+        called_with: list[list] = []
+
+        def fake_combo(netkeiba_race_id, ticket_types=None, sleep_sec=1.5):
+            called_with.append(ticket_types)
+            return pd.DataFrame()
+
+        with (
+            patch(
+                "src.automation.data.netkeiba_scraper.get_win_place_odds",
+                return_value=self._make_win_place_df(),
+            ),
+            patch(
+                "src.automation.data.netkeiba_scraper.save_odds_to_bq",
+                return_value=2,
+            ),
+            patch(
+                "src.automation.data.netkeiba_scraper.get_combo_odds",
+                side_effect=fake_combo,
+            ),
+        ):
+            scrape_odds_for_race(
+                self.JRDB_RACE_ID, self.RACE_DATE, self.PROJECT_ID, sleep_sec=0
+            )
+
+        assert called_with == [["b4", "b5", "b7"]]


### PR DESCRIPTION
## Summary

- `netkeiba_scraper.py` に `jrdb_race_id_to_netkeiba()` を追加（JRDB→netkeiba race_id 変換）
- `netkeiba_scraper.py` に `scrape_odds_for_race()` を追加（指定レースの単複・コンボオッズをスクレイプ→BQ UPSERT）
- `_purchase_pipeline_async()` の `target_races` 確定直後に各��ースのリアルタイムオッズ取得ステップを追加
- テスト 14 件追加（`jrdb_race_id_to_netkeiba` 6件・`scrape_odds_for_race` 5件・パイプライン統合 3件）

## Closes
#239

## Test plan
- [x] `TestJrdbRaceIdToNetkeiba`: 変換ロジックの正確性（通常・16進回次/日次・逆変換ラウンドトリップ）
- [x] `TestScrapeOddsForRace`: 成功/単複取得失敗/BQ保存失敗/コンボ失敗フォールバック/デフォルトticket_types
- [x] `TestRealtimeScraping`: 対象レース分だけスクレイプされること、0件時スキップ、失敗時パイプライン継続
- [x] 既存テスト 51 件 PASS を維持（18件は lxml/playwright 未インストールによる pre-existing failures）

🤖 Generated with [Claude Code](https://claude.com/claude-code)