### PR TITLE
fix: ローカルテスト環境のPython 3.9問題を解消し、既存テスト失敗を修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -324,6 +324,13 @@ LINE Messaging APIを使った双方向Botを実装済み。
 - シェル設定: 改行コードは LF を使用 (CRLFは避ける)
 - プロジェクト概要: JRDB競馬データパイプライン (BigQuery, GCS, Cloud Run)
 
+### Python実行環境（重要）
+- システムのpython3は3.9のため、**必ず `.venv` の Python/pytest を使用**すること
+- テスト実行: `.venv/bin/pytest tests/`
+- Python実行: `.venv/bin/python`
+- スクリプト実行: `.venv/bin/python scripts/xxx.py`
+- `python3` や `pytest` を直接呼び出さない（システムの3.9が使われてしまう）
+
 ### 開発ワークフロー
 GitHub Issueの実装時は以下の手順を遵守してください:
 1. ブランチ作成 (feature/issue-XX)

--- a/src/automation/api/line_webhook.py
+++ b/src/automation/api/line_webhook.py
@@ -286,6 +286,114 @@ def _format_prediction_table(
     return header + "\n" + "\n".join(rows)
 
 
+def _format_single_bet_line(bet: dict[str, Any]) -> str:
+    """
+    単一馬券dictを1行テキストにフォーマットする。
+
+    bet キー:
+        bet_type       : "place" | "win" | "wide" | "sanrenpuku" など
+        horse_numbers  : カンマ区切り文字列 "3" or "1,3" or "1,3,7"
+        horse_names    : カンマ区切り文字列
+        win_place_prob : float | None  (複勝確率)
+        place_odds     : float | None  (オッズ)
+        expected_return: float | None  (期待値)
+        bet_amount     : float
+    """
+    bet_type = bet.get("bet_type", "")
+    horse_numbers_str = str(bet.get("horse_numbers", ""))
+    horse_names_str = str(bet.get("horse_names", ""))
+    win_place_prob: float | None = bet.get("win_place_prob")
+    place_odds: float | None = bet.get("place_odds")
+    expected_return: float | None = bet.get("expected_return")
+    bet_amount = float(bet.get("bet_amount", 0.0))
+
+    # 馬番・馬名の表示
+    numbers = [n.strip() for n in horse_numbers_str.split(",") if n.strip()]
+    names = [n.strip() for n in horse_names_str.split(",") if n.strip()]
+    horse_parts = []
+    for i, hn in enumerate(numbers):
+        hn_name = names[i] if i < len(names) else ""
+        horse_parts.append(f"馬番{hn} {hn_name}".strip())
+    horse_str = " / ".join(horse_parts)
+
+    parts = [horse_str]
+
+    # 確率表示（複勝・単勝のみ）
+    if win_place_prob is not None:
+        if bet_type == "win":
+            parts.append(f"複勝率(参考): {win_place_prob * 100:.1f}%")
+        else:
+            parts.append(f"複勝率: {win_place_prob * 100:.1f}%")
+
+    # オッズ表示
+    if place_odds is not None:
+        parts.append(f"{place_odds:.1f}倍")
+
+    # 期待値表示（複勝のみ、単勝は表示しない）
+    if expected_return is not None and bet_type != "win":
+        parts.append(f"期待値: {expected_return:.2f}")
+
+    # 推奨額
+    parts.append(f"¥{bet_amount:,.0f}")
+
+    return "  ".join(parts)
+
+
+def format_push_notification(
+    race_date: date,
+    decisions: list[dict[str, Any]],
+    races_per_message: int = 10,
+) -> list[dict[str, str]]:
+    """
+    投資決定リストをLINEプッシュ通知用メッセージリストに変換する。
+
+    Returns:
+        list of {"text": str} dicts.
+        - 先頭メッセージ: ヘッダー（日付・合計投資額・レース数）
+        - 以降のメッセージ: レースごとの馬券リスト（races_per_message件ずつ分割）
+        - decisionsが空の場合: 1件の "推奨馬券はありません" メッセージ
+    """
+    if not decisions:
+        return [{"text": f"🏇 {race_date.isoformat()}\n推奨馬券はありません"}]
+
+    # レース単位でグループ化（venue_code + race_number）
+    from collections import defaultdict
+    race_groups: dict[tuple[str, int], list[dict[str, Any]]] = defaultdict(list)
+    for d in decisions:
+        key = (str(d.get("venue_code", "")), int(d.get("race_number", 0)))
+        race_groups[key].append(d)
+
+    # venue_code → race_number 順でソート
+    sorted_keys = sorted(race_groups.keys(), key=lambda k: (k[0], k[1]))
+
+    # ヘッダーメッセージ
+    total_bet = sum(float(d.get("bet_amount", 0.0)) for d in decisions)
+    n_races = len(sorted_keys)
+    header_text = (
+        f"🏇 本日の推奨馬券 {race_date.isoformat()}\n"
+        f"レース数: {n_races}  合計投資額: ¥{total_bet:,.0f}"
+    )
+    messages: list[dict[str, str]] = [{"text": header_text}]
+
+    # レースをraces_per_message件ずつ分割してメッセージ化
+    for chunk_start in range(0, len(sorted_keys), races_per_message):
+        chunk_keys = sorted_keys[chunk_start : chunk_start + races_per_message]
+        lines: list[str] = []
+        for venue_code, race_number in chunk_keys:
+            venue_name = VENUE_CODE_TO_NAME.get(venue_code, venue_code)
+            bets = race_groups[(venue_code, race_number)]
+            race_pattern = bets[0].get("race_pattern", "")
+            pattern_label = PATTERN_LABELS.get(race_pattern, race_pattern)
+            lines.append(f"【{venue_name} {race_number}R】({pattern_label})")
+            for bet in bets:
+                bet_type_label = BET_TYPE_LABELS.get(bet.get("bet_type", ""), bet.get("bet_type", ""))
+                bet_line = _format_single_bet_line(bet)
+                lines.append(f"  [{bet_type_label}] {bet_line}")
+        messages.append({"text": "\n".join(lines)})
+
+    return messages
+
+
 def _format_bet_recommendations(
     race_date: date,
     venue_name: str,

--- a/tests/test_backtest_strategy_optimizer.py
+++ b/tests/test_backtest_strategy_optimizer.py
@@ -225,12 +225,12 @@ class TestStrategyOptimizerRunSimulation:
 
 
 class TestStrategyOptimizerRunGridSearch:
-    def test_grid_search_returns_100_results(self):
-        """デフォルトグリッドサーチが100通り（5×5×4）の結果を返す"""
+    def test_grid_search_returns_1296_results(self):
+        """デフォルトグリッドサーチが1296通り（p1(3)×threshold(3)×top_n_dominant(3)×top_n_standard(3)×r_dominant(4)×r_standard(4)）の結果を返す"""
         df = _make_predictions_df(n_races=2, n_horses=5, win_place_prob=0.5, odds=3.0)
         optimizer = StrategyOptimizer(df, None, combo_odds_df=None)
         results = optimizer.run_grid_search()
-        assert len(results) == 100  # p1(5) × threshold(5) × r(4)
+        assert len(results) == 1296  # 3×3×3×3×4×4
 
     def test_grid_search_results_have_params(self):
         """各結果に p1 と expected_return_threshold が含まれる"""
@@ -251,9 +251,10 @@ class TestStrategyOptimizerRunGridSearch:
         results = optimizer.run_grid_search(
             p1_range=[0.1, 0.2],
             threshold_range=[1.0, 1.2, 1.5],
-            r_range=[1.0],
+            r_dominant_range=[1.0],
+            r_standard_range=[1.0],
         )
-        assert len(results) == 6  # 2×3×1
+        assert len(results) == 54  # p1(2)×threshold(3)×top_n_dominant(3)×top_n_standard(3)×r_dominant(1)×r_standard(1)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_load_to_bq.py
+++ b/tests/test_load_to_bq.py
@@ -543,14 +543,13 @@ class TestBigQueryLoaderMerge:
         mock_client = MagicMock()
         mock_bq_client.return_value = mock_client
 
-        # テーブルスキーマ
-        mock_field_1 = MagicMock()
-        mock_field_1.name = "race_id"
-        mock_field_2 = MagicMock()
-        mock_field_2.name = "data"
-
+        # テーブルスキーマ（bigquery.SchemaFieldを使用しないとLoadJobConfigが拒否する）
+        from google.cloud import bigquery as bq_module
         mock_table = MagicMock()
-        mock_table.schema = [mock_field_1, mock_field_2]
+        mock_table.schema = [
+            bq_module.SchemaField("race_id", "STRING"),
+            bq_module.SchemaField("data", "STRING"),
+        ]
         mock_client.get_table.return_value = mock_table
 
         # load_table_from_json成功（Load Job）

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -277,18 +277,19 @@ class TestFormatPredictions:
 
     def test_format_position_zero_shows_dash(self):
         """finish_position=0の場合、'-'が表示されること（取消/除外/中止の馬）"""
+        # classify_race_pattern は最低3頭必要なのでダミー馬を追加
         df = pd.DataFrame({
-            "race_id": ["r1", "r1"],
-            "race_date": [datetime.date(2026, 2, 14)] * 2,
-            "horse_id": ["h1", "h2"],
-            "horse_name": ["テスト馬1", "テスト馬2"],
-            "horse_number": [1, 2],
-            "venue_code": ["05", "05"],
-            "race_number": [1, 1],
-            "pred_score": [0.8, 0.5],
-            "win_place_prob": [0.7, 0.5],
-            "pred_rank": [1, 2],
-            "finish_position": [1, 0],  # 2頭目は取消（finish_position=0）
+            "race_id": ["r1", "r1", "r1"],
+            "race_date": [datetime.date(2026, 2, 14)] * 3,
+            "horse_id": ["h1", "h2", "h3"],
+            "horse_name": ["テスト馬1", "テスト馬2", "ダミー馬3"],
+            "horse_number": [1, 2, 3],
+            "venue_code": ["05", "05", "05"],
+            "race_number": [1, 1, 1],
+            "pred_score": [0.8, 0.5, 0.2],
+            "win_place_prob": [0.7, 0.5, 0.2],
+            "pred_rank": [1, 2, 3],
+            "finish_position": [1, 0, 3],  # 2頭目は取消（finish_position=0）
         })
 
         result = format_predictions(df)
@@ -303,18 +304,19 @@ class TestFormatPredictions:
 
     def test_format_position_none_shows_dash(self):
         """finish_positionがNaNの場合（未来レース）、'-'が表示されること"""
+        # classify_race_pattern は最低3頭必要なのでダミー馬を追加
         df = pd.DataFrame({
-            "race_id": ["r1"],
-            "race_date": [datetime.date(2026, 2, 14)],
-            "horse_id": ["h1"],
-            "horse_name": ["テスト馬1"],
-            "horse_number": [1],
-            "venue_code": ["05"],
-            "race_number": [1],
-            "pred_score": [0.8],
-            "win_place_prob": [0.7],
-            "pred_rank": [1],
-            "finish_position": [float("nan")],  # 未来レースはNaN
+            "race_id": ["r1", "r1", "r1"],
+            "race_date": [datetime.date(2026, 2, 14)] * 3,
+            "horse_id": ["h1", "h2", "h3"],
+            "horse_name": ["テスト馬1", "ダミー馬2", "ダミー馬3"],
+            "horse_number": [1, 2, 3],
+            "venue_code": ["05", "05", "05"],
+            "race_number": [1, 1, 1],
+            "pred_score": [0.8, 0.5, 0.2],
+            "win_place_prob": [0.7, 0.5, 0.2],
+            "pred_rank": [1, 2, 3],
+            "finish_position": [float("nan"), float("nan"), float("nan")],  # 未来レースはNaN
         })
 
         result = format_predictions(df)

--- a/tests/test_run_backtest.py
+++ b/tests/test_run_backtest.py
@@ -408,13 +408,14 @@ class TestFetchPlaceOddsWinOdds:
 
 class TestWinOddsMergeEnablesWinBets:
     """
-    run_full_strategy_backtest_pipeline() で win_odds がマージされた結果、
-    one_dominant パターン時に単勝が購入されることを検証する（Issue #176）
+    one_dominant パターンの馬券選定動作を検証する。
+    ※ Issue #202 により単勝・複勝の自動追加は廃止済み。
     """
 
     def test_win_odds_merged_into_predictions_df(self):
         """
-        fetch_place_odds が win_odds を返した場合に predictions_df に win_odds カラムが付与される
+        Issue #202: one_dominant パターンで win_odds があっても単勝は自動追加されない。
+        代わりに馬連（umaren）のみが追加される。
         """
         from src.backtest.strategy import select_bets_for_race
 
@@ -434,12 +435,13 @@ class TestWinOddsMergeEnablesWinBets:
             combo_odds_df=pd.DataFrame(),
             budget_per_race=3000,
             p1=0.1,              # top1 - top2 = 0.35 > 0.1 → one_dominant
-            expected_return_threshold=1.0,  # 低めに設定して単勝が通るように
+            expected_return_threshold=1.0,  # 低めに設定して馬券が通るように
         )
 
         bet_types = [b["bet_type"] for b in bets]
         assert pattern.pattern == "one_dominant", f"パターン判定が one_dominant でない: {pattern}"
-        assert "win" in bet_types, (
-            f"one_dominant パターンで win_odds が存在するのに単勝が購入されない。"
+        # Issue #202: 単勝は自動追加されない（馬連のみ追加される）
+        assert "win" not in bet_types, (
+            f"Issue #202 で単勝自動追加は廃止済みだが、単勝が含まれている。"
             f"実際の馬券種: {bet_types}"
         )


### PR DESCRIPTION
## Summary

- **根本原因**: システムの `python3` がmacOS標準の3.9を指しており、Claude Codeがテスト実行時にこれを使用していた（プロジェクトには既に Python 3.13 の `.venv` が存在）
- **CLAUDE.md** に `.venv/bin/pytest` / `.venv/bin/python` を使用する旨を追記し、今後のテスト実行で3.9が使われないよう明記
- **既存テスト4件の失敗も同時修正**（Pythonバージョン問題の露見により発覚）

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `CLAUDE.md` | `.venv/bin/pytest` 使用を明記（Python 3.9回避） |
| `.venv` | `httpx` パッケージ追加（`starlette.testclient` の依存） |
| `src/automation/api/line_webhook.py` | `_format_single_bet_line` / `format_push_notification` 関数を追加（テストが期待していたが実装が欠けていた） |
| `tests/test_backtest_strategy_optimizer.py` | グリッドサーチ結果数を 100→1296 に修正・`r_range`→`r_dominant_range`/`r_standard_range` に引数名修正 |
| `tests/test_load_to_bq.py` | `MagicMock` SchemaField → `bigquery.SchemaField` に差し替え（`LoadJobConfig` がモックを拒否する問題） |
| `tests/test_predict.py` | `classify_race_pattern` の最低3頭制約に合わせてテストデータを修正 |
| `tests/test_run_backtest.py` | Issue #202 で廃止された単勝自動追加の期待値を更新 |

## Test plan

- [ ] `.venv/bin/pytest tests/` を実行し全30ファイル・743テストが通過することを確認
- [ ] `python3 --version` が3.9を返す環境でも `.venv/bin/pytest` で3.13が使われることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)