### PR TITLE
fix: 日曜日に predict_daily が来週土日を対象にするバグを修正

### DIFF
--- a/src/automation/api/app.py
+++ b/src/automation/api/app.py
@@ -767,10 +767,10 @@ def _run_predict(
 @app.post("/api/v1/predict/daily", response_model=PredictResponse)
 async def predict_daily(request: PredictDailyRequest):
     """
-    翌日レースの予測を実行してBigQueryに保存する
+    当日（および同週の土日）レースの予測を実行してBigQueryに保存する
 
-    実行日の翌日（土日）のレースを予測対象とする。
-    Cloud Schedulerから前日PM 9:00に呼び出されることを想定。
+    実行日を基準に当週の土日を予測対象とする。
+    Cloud Schedulerから当日 AM 8:00 JST に呼び出されることを想定。
 
     Args:
         request: リクエストボディ
@@ -787,9 +787,12 @@ async def predict_daily(request: PredictDailyRequest):
     try:
         from src.models.train import compute_week_boundaries
 
-        # 翌日を基準に今週の土日を算出
-        tomorrow = _today_jst() + datetime.timedelta(days=1)
-        saturday, sunday = compute_week_boundaries(tomorrow)
+        # 実行日（JST）を基準に今週の土日を算出
+        # 注意: _today_jst() を使う。UTC ベースの date.today() では日 AM 8:00 JST が
+        # 土 23:00 UTC となり日付がズレるため、JST で正しい曜日を取得する必要がある。
+        # tomorrow 基準にすると日曜に実行した場合に翌月曜を起点として来週土日を返してしまう。
+        today = _today_jst()
+        saturday, sunday = compute_week_boundaries(today)
         target_dates = [saturday, sunday]
 
         result = _run_predict(

--- a/src/automation/api/app.py
+++ b/src/automation/api/app.py
@@ -1291,6 +1291,99 @@ def _run_purchase_pipeline(
     )
 
 
+def _predict_race_on_the_fly(
+    project_id: str,
+    race_id: str,
+    target_date: datetime.date,
+    client,
+) -> bool:
+    """
+    features.training_data からオンザフライで1レース分の予測を生成し daily_predictions に保存する。
+
+    daily_predictions に予測データが存在しないが features.training_data には存在する場合の
+    フォールバック手段として使用する。モデルは GCS から最新のものを自動取得する。
+
+    Args:
+        project_id: GCP プロジェクト ID
+        race_id: 対象レース ID
+        target_date: 対象日
+        client: BigQuery クライアント
+
+    Returns:
+        True: 予測生成・保存に成功, False: 失敗
+    """
+    import shutil
+    import numpy as _np
+
+    from src.models.lgbm_ranker import LGBMRanker
+    from src.models.predict import _scores_to_place_prob, save_predictions_to_bq
+    from src.models.train import build_feature_matrix, load_config
+
+    try:
+        # features.training_data から対象レースのデータを取得
+        query = f"""
+        SELECT *
+        FROM `{project_id}.features.training_data`
+        WHERE race_date = '{target_date.isoformat()}'
+          AND race_id = '{race_id}'
+        ORDER BY horse_number
+        """
+        import pandas as _pd
+        df = client.query(query).to_dataframe()
+        if df.empty:
+            logger.warning(
+                f"_predict_race: race_id={race_id} は features.training_data にも存在しない → スキップ"
+            )
+            return False
+
+        # 最新モデルをGCSからロード
+        local_model_path, tmpdir = _resolve_model_path(None, project_id)
+        try:
+            config = load_config()
+            data_config = config["data"]
+
+            ranker = LGBMRanker()
+            ranker.load(local_model_path)
+
+            X = build_feature_matrix(
+                df,
+                exclude_columns=data_config["exclude_columns"],
+                categorical_columns=data_config.get("categorical_columns", []),
+            )
+            scores = ranker.predict(X)
+
+            result_df = df[["race_id", "race_date", "horse_id", "horse_number", "horse_name"]].copy()
+            if "venue_code" in df.columns:
+                result_df["venue_code"] = df["venue_code"]
+            if "race_number" in df.columns:
+                result_df["race_number"] = df["race_number"]
+
+            result_df["pred_score"] = scores
+            result_df["win_place_prob"] = _scores_to_place_prob(scores, n_places=3)
+            result_df["pred_rank"] = (
+                result_df["pred_score"].rank(ascending=False, method="min").astype(int)
+            )
+            result_df["finish_position"] = _np.nan
+
+            rows_saved = save_predictions_to_bq(result_df, project_id)
+            logger.info(
+                f"_predict_race: race_id={race_id} のオンザフライ予測を生成・保存 "
+                f"({len(result_df)}頭, {rows_saved}行保存)"
+            )
+            return True
+
+        finally:
+            if tmpdir is not None:
+                shutil.rmtree(tmpdir, ignore_errors=True)
+
+    except Exception as e:
+        logger.warning(
+            f"_predict_race: race_id={race_id} のオンザフライ予測に失敗: {e}",
+            exc_info=True,
+        )
+        return False
+
+
 def _refresh_investment_decisions_for_race(
     project_id: str,
     race_id: str,
@@ -1303,7 +1396,10 @@ def _refresh_investment_decisions_for_race(
     select_bets_for_race() で推奨馬券を再計算して predictions.investment_decisions へ
     MERGE UPSERT する。
 
-    データが取得できない場合は既存の investment_decisions をそのまま使用（フォールバック）。
+    daily_predictions に予測データが存在しない場合:
+      1. features.training_data に当該レースが存在するか診断ログを出力する
+      2. 存在すれば _predict_race_on_the_fly() でオンザフライ予測を生成して再試行する
+      3. それでも取得できない場合は既存の investment_decisions をそのまま使用（フォールバック）。
 
     Args:
         project_id: GCP プロジェクト ID
@@ -1339,8 +1435,38 @@ def _refresh_investment_decisions_for_race(
         pred_df = client.query(pred_query).to_dataframe()
 
         if pred_df.empty:
-            logger.warning(f"_refresh: race_id={race_id} の予測データなし → フォールバック")
-            return False
+            # 予測データが daily_predictions にない理由を診断する
+            check_query = f"""
+            SELECT COUNT(*) AS cnt
+            FROM `{project_id}.features.training_data`
+            WHERE race_date = '{target_date.isoformat()}'
+              AND race_id = '{race_id}'
+            """
+            check_df = client.query(check_query).to_dataframe()
+            in_features = int(check_df["cnt"].iloc[0]) > 0
+
+            if in_features:
+                # features.training_data には存在 → オンザフライで予測を生成して再試行
+                logger.warning(
+                    f"_refresh: race_id={race_id} が daily_predictions にないが "
+                    f"features.training_data には存在 → オンザフライ予測を試みる"
+                )
+                success = _predict_race_on_the_fly(project_id, race_id, target_date, client)
+                if success:
+                    pred_df = client.query(pred_query).to_dataframe()
+                if not success or pred_df.empty:
+                    logger.warning(
+                        f"_refresh: race_id={race_id} オンザフライ予測後も取得失敗 → フォールバック"
+                    )
+                    return False
+            else:
+                # features.training_data にも存在しない → データパイプラインの問題
+                logger.warning(
+                    f"_refresh: race_id={race_id} の予測データなし "
+                    f"(daily_predictions: 空, features.training_data: 空) → フォールバック。"
+                    f"daily-data-pipeline の実行状況を確認してください。"
+                )
+                return False
 
         # 対象レースの単複オッズを取得
         odds_query = f"""

--- a/src/automation/api/app.py
+++ b/src/automation/api/app.py
@@ -1294,99 +1294,6 @@ def _run_purchase_pipeline(
     )
 
 
-def _predict_race_on_the_fly(
-    project_id: str,
-    race_id: str,
-    target_date: datetime.date,
-    client,
-) -> bool:
-    """
-    features.training_data からオンザフライで1レース分の予測を生成し daily_predictions に保存する。
-
-    daily_predictions に予測データが存在しないが features.training_data には存在する場合の
-    フォールバック手段として使用する。モデルは GCS から最新のものを自動取得する。
-
-    Args:
-        project_id: GCP プロジェクト ID
-        race_id: 対象レース ID
-        target_date: 対象日
-        client: BigQuery クライアント
-
-    Returns:
-        True: 予測生成・保存に成功, False: 失敗
-    """
-    import shutil
-    import numpy as _np
-
-    from src.models.lgbm_ranker import LGBMRanker
-    from src.models.predict import _scores_to_place_prob, save_predictions_to_bq
-    from src.models.train import build_feature_matrix, load_config
-
-    try:
-        # features.training_data から対象レースのデータを取得
-        query = f"""
-        SELECT *
-        FROM `{project_id}.features.training_data`
-        WHERE race_date = '{target_date.isoformat()}'
-          AND race_id = '{race_id}'
-        ORDER BY horse_number
-        """
-        import pandas as _pd
-        df = client.query(query).to_dataframe()
-        if df.empty:
-            logger.warning(
-                f"_predict_race: race_id={race_id} は features.training_data にも存在しない → スキップ"
-            )
-            return False
-
-        # 最新モデルをGCSからロード
-        local_model_path, tmpdir = _resolve_model_path(None, project_id)
-        try:
-            config = load_config()
-            data_config = config["data"]
-
-            ranker = LGBMRanker()
-            ranker.load(local_model_path)
-
-            X = build_feature_matrix(
-                df,
-                exclude_columns=data_config["exclude_columns"],
-                categorical_columns=data_config.get("categorical_columns", []),
-            )
-            scores = ranker.predict(X)
-
-            result_df = df[["race_id", "race_date", "horse_id", "horse_number", "horse_name"]].copy()
-            if "venue_code" in df.columns:
-                result_df["venue_code"] = df["venue_code"]
-            if "race_number" in df.columns:
-                result_df["race_number"] = df["race_number"]
-
-            result_df["pred_score"] = scores
-            result_df["win_place_prob"] = _scores_to_place_prob(scores, n_places=3)
-            result_df["pred_rank"] = (
-                result_df["pred_score"].rank(ascending=False, method="min").astype(int)
-            )
-            result_df["finish_position"] = _np.nan
-
-            rows_saved = save_predictions_to_bq(result_df, project_id)
-            logger.info(
-                f"_predict_race: race_id={race_id} のオンザフライ予測を生成・保存 "
-                f"({len(result_df)}頭, {rows_saved}行保存)"
-            )
-            return True
-
-        finally:
-            if tmpdir is not None:
-                shutil.rmtree(tmpdir, ignore_errors=True)
-
-    except Exception as e:
-        logger.warning(
-            f"_predict_race: race_id={race_id} のオンザフライ予測に失敗: {e}",
-            exc_info=True,
-        )
-        return False
-
-
 def _refresh_investment_decisions_for_race(
     project_id: str,
     race_id: str,
@@ -1399,10 +1306,7 @@ def _refresh_investment_decisions_for_race(
     select_bets_for_race() で推奨馬券を再計算して predictions.investment_decisions へ
     MERGE UPSERT する。
 
-    daily_predictions に予測データが存在しない場合:
-      1. features.training_data に当該レースが存在するか診断ログを出力する
-      2. 存在すれば _predict_race_on_the_fly() でオンザフライ予測を生成して再試行する
-      3. それでも取得できない場合は既存の investment_decisions をそのまま使用（フォールバック）。
+    データが取得できない場合は既存の investment_decisions をそのまま使用（フォールバック）。
 
     Args:
         project_id: GCP プロジェクト ID
@@ -1438,38 +1342,8 @@ def _refresh_investment_decisions_for_race(
         pred_df = client.query(pred_query).to_dataframe()
 
         if pred_df.empty:
-            # 予測データが daily_predictions にない理由を診断する
-            check_query = f"""
-            SELECT COUNT(*) AS cnt
-            FROM `{project_id}.features.training_data`
-            WHERE race_date = '{target_date.isoformat()}'
-              AND race_id = '{race_id}'
-            """
-            check_df = client.query(check_query).to_dataframe()
-            in_features = int(check_df["cnt"].iloc[0]) > 0
-
-            if in_features:
-                # features.training_data には存在 → オンザフライで予測を生成して再試行
-                logger.warning(
-                    f"_refresh: race_id={race_id} が daily_predictions にないが "
-                    f"features.training_data には存在 → オンザフライ予測を試みる"
-                )
-                success = _predict_race_on_the_fly(project_id, race_id, target_date, client)
-                if success:
-                    pred_df = client.query(pred_query).to_dataframe()
-                if not success or pred_df.empty:
-                    logger.warning(
-                        f"_refresh: race_id={race_id} オンザフライ予測後も取得失敗 → フォールバック"
-                    )
-                    return False
-            else:
-                # features.training_data にも存在しない → データパイプラインの問題
-                logger.warning(
-                    f"_refresh: race_id={race_id} の予測データなし "
-                    f"(daily_predictions: 空, features.training_data: 空) → フォールバック。"
-                    f"daily-data-pipeline の実行状況を確認してください。"
-                )
-                return False
+            logger.warning(f"_refresh: race_id={race_id} の予測データなし → フォールバック")
+            return False
 
         # 対象レースの単複オッズを取得
         odds_query = f"""

--- a/tests/test_predict_daily_endpoint.py
+++ b/tests/test_predict_daily_endpoint.py
@@ -1,0 +1,141 @@
+"""
+predict_daily エンドポイントの target_dates 算出ロジックのテスト
+
+Issue #243 修正: _today_jst() 導入後に日曜日実行で来週土日を参照してしまうバグの回帰テスト
+
+バグの経緯:
+  - 旧コード: tomorrow = _today_jst() + timedelta(1) を compute_week_boundaries に渡す
+  - 日曜 8:00 JST に実行すると tomorrow = 月曜 → 来週土日 (NG)
+  - 修正: today = _today_jst() を直接渡す (土/日/平日いずれでも今週土日が正しく返る)
+
+注意: Cloud Run は UTC で動作するが _today_jst() は ZoneInfo("Asia/Tokyo") で JST 日付を返す。
+      このため UTC/JST の日付差 (日曜 AM 8:00 JST = 土曜 PM 11:00 UTC) に依らず正しい曜日で動作する。
+"""
+
+from __future__ import annotations
+
+import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# compute_week_boundaries の単体テスト（基準関数の挙動保証）
+# ---------------------------------------------------------------------------
+
+class TestComputeWeekBoundaries:
+    """compute_week_boundaries の曜日別動作を確認する"""
+
+    def setup_method(self):
+        from src.models.train import compute_week_boundaries
+        self.fn = compute_week_boundaries
+
+    def test_saturday_returns_this_weekend(self):
+        """土曜基準 → 当週土日を返すこと"""
+        sat = datetime.date(2026, 4, 11)  # 土
+        s, e = self.fn(sat)
+        assert s == datetime.date(2026, 4, 11)
+        assert e == datetime.date(2026, 4, 12)
+
+    def test_sunday_returns_this_weekend(self):
+        """日曜基準 → 当週土日を返すこと（修正後の期待動作）"""
+        sun = datetime.date(2026, 4, 12)  # 日
+        s, e = self.fn(sun)
+        assert s == datetime.date(2026, 4, 11)
+        assert e == datetime.date(2026, 4, 12)
+
+    def test_monday_returns_next_weekend(self):
+        """月曜基準 → 翌週土日を返すこと（平日は来週を対象とする設計）"""
+        mon = datetime.date(2026, 4, 13)  # 月
+        s, e = self.fn(mon)
+        assert s == datetime.date(2026, 4, 18)
+        assert e == datetime.date(2026, 4, 19)
+
+    def test_friday_returns_next_weekend(self):
+        """金曜基準 → 翌週土日（=翌日から1日後）を返すこと"""
+        fri = datetime.date(2026, 4, 10)  # 金
+        s, e = self.fn(fri)
+        assert s == datetime.date(2026, 4, 11)
+        assert e == datetime.date(2026, 4, 12)
+
+
+# ---------------------------------------------------------------------------
+# predict_daily エンドポイントの target_dates 検証
+# ---------------------------------------------------------------------------
+
+class TestPredictDailyTargetDates:
+    """predict_daily が today_jst を基準に正しい土日を target_dates に設定すること"""
+
+    def _make_success_result(self, sat, sun):
+        return {
+            "num_races": 2,
+            "num_horses": 16,
+            "saved_to_bq": True,
+            "saved_to_gcs": False,
+            "gcs_uri": None,
+            "model_path": "gs://test/model.txt",
+        }
+
+    @patch("src.automation.api.app._run_predict")
+    @patch("src.automation.api.app._today_jst")
+    @patch.dict("os.environ", {"GCP_PROJECT_ID": "test_project"})
+    def test_saturday_targets_this_weekend(self, mock_today, mock_run_predict):
+        """土曜 AM 8:00 JST 実行 → [4/11, 4/12] を対象とすること"""
+        mock_today.return_value = datetime.date(2026, 4, 11)  # 土
+        sat = datetime.date(2026, 4, 11)
+        sun = datetime.date(2026, 4, 12)
+        mock_run_predict.return_value = self._make_success_result(sat, sun)
+
+        import asyncio
+        from src.automation.api.app import predict_daily, PredictDailyRequest
+
+        result = asyncio.run(predict_daily(PredictDailyRequest()))
+
+        assert result.target_dates == ["2026-04-11", "2026-04-12"]
+        call_kwargs = mock_run_predict.call_args[1]
+        assert call_kwargs["target_dates"] == [sat, sun]
+
+    @patch("src.automation.api.app._run_predict")
+    @patch("src.automation.api.app._today_jst")
+    @patch.dict("os.environ", {"GCP_PROJECT_ID": "test_project"})
+    def test_sunday_targets_this_weekend_not_next(self, mock_today, mock_run_predict):
+        """
+        日曜 AM 8:00 JST 実行 → [4/11, 4/12] を対象とすること（バグ回帰テスト）
+
+        修正前バグ: tomorrow(月曜)を基準にすると [4/18, 4/19] (来週) になっていた
+        """
+        mock_today.return_value = datetime.date(2026, 4, 12)  # 日
+        sat = datetime.date(2026, 4, 11)
+        sun = datetime.date(2026, 4, 12)
+        mock_run_predict.return_value = self._make_success_result(sat, sun)
+
+        import asyncio
+        from src.automation.api.app import predict_daily, PredictDailyRequest
+
+        result = asyncio.run(predict_daily(PredictDailyRequest()))
+
+        assert result.target_dates == ["2026-04-11", "2026-04-12"], (
+            "日曜実行時に来週土日 [4/18, 4/19] を返すバグが再発していないか確認"
+        )
+        call_kwargs = mock_run_predict.call_args[1]
+        assert call_kwargs["target_dates"] == [sat, sun]
+
+    @patch("src.automation.api.app._run_predict")
+    @patch("src.automation.api.app._today_jst")
+    @patch.dict("os.environ", {"GCP_PROJECT_ID": "test_project"})
+    def test_monday_targets_next_weekend(self, mock_today, mock_run_predict):
+        """月曜（平日）実行 → [4/18, 4/19] (来週土日) を対象とすること"""
+        mock_today.return_value = datetime.date(2026, 4, 13)  # 月
+        sat = datetime.date(2026, 4, 18)
+        sun = datetime.date(2026, 4, 19)
+        mock_run_predict.return_value = self._make_success_result(sat, sun)
+
+        import asyncio
+        from src.automation.api.app import predict_daily, PredictDailyRequest
+
+        result = asyncio.run(predict_daily(PredictDailyRequest()))
+
+        assert result.target_dates == ["2026-04-18", "2026-04-19"]
+        call_kwargs = mock_run_predict.call_args[1]
+        assert call_kwargs["target_dates"] == [sat, sun]

--- a/tests/test_refresh_investment_decisions.py
+++ b/tests/test_refresh_investment_decisions.py
@@ -1,12 +1,18 @@
 """
-_refresh_investment_decisions_for_race のユニットテスト
+_refresh_investment_decisions_for_race / _predict_race_on_the_fly のユニットテスト
 
 テスト対象:
   - _refresh_investment_decisions_for_race: 最新オッズで investment_decisions を上書き
     - 正常系: 予測・オッズあり → 計算・保存 → True を返す
-    - 異常系: 予測データなし → False（フォールバック）
+    - 異常系: daily_predictions 空 かつ features.training_data 空 → False（フォールバック）
+    - 異常系: daily_predictions 空 かつ features.training_data あり → オンザフライ予測を試みる
     - 異常系: オッズデータなし → False（フォールバック）
     - 異常系: BQ例外 → False（フォールバック）
+
+  - _predict_race_on_the_fly: features.training_data から予測を生成して daily_predictions に保存
+    - 正常系: features にデータあり → 予測生成・保存 → True
+    - 異常系: features にデータなし → False
+    - 異常系: モデルロード失敗 → False
 
 Issue #231: 発走5分前に最新オッズで investment_decisions を上書きしてから IPAT 購入する
 """
@@ -16,10 +22,14 @@ from __future__ import annotations
 import datetime
 from unittest.mock import MagicMock, patch
 
+import numpy as np
 import pandas as pd
 import pytest
 
-from src.automation.api.app import _refresh_investment_decisions_for_race
+from src.automation.api.app import (
+    _predict_race_on_the_fly,
+    _refresh_investment_decisions_for_race,
+)
 
 TARGET_DATE = datetime.date(2026, 4, 12)
 RACE_ID = "202609050112"
@@ -56,6 +66,25 @@ def _make_merged_df() -> pd.DataFrame:
     df["odds"] = df["horse_number"].apply(lambda i: max(1.1, 1.5 * i))
     df["win_odds"] = df["horse_number"].apply(lambda i: 3.0 * i)
     return df
+
+
+def _make_cnt_df(cnt: int) -> pd.DataFrame:
+    """features.training_data の COUNT クエリ結果"""
+    return pd.DataFrame([{"cnt": cnt}])
+
+
+def _make_features_df() -> pd.DataFrame:
+    """features.training_data から取得する DataFrame（カラムは最小限）"""
+    return pd.DataFrame([
+        {
+            "race_id": RACE_ID, "race_date": TARGET_DATE,
+            "horse_id": f"h{i:04d}", "horse_number": i,
+            "horse_name": f"ウマ{i}", "venue_code": "09",
+            "race_number": 12,
+            "dummy_feature": float(i),
+        }
+        for i in range(1, 9)
+    ])
 
 
 class TestRefreshInvestmentDecisions:
@@ -103,15 +132,46 @@ class TestRefreshInvestmentDecisions:
         mock_save.assert_called_once()
 
     @patch("google.cloud.bigquery.Client")
-    def test_empty_predictions_returns_false(self, mock_bq_cls):
-        """予測データが空の場合は False（フォールバック）を返すこと"""
+    def test_empty_predictions_and_empty_features_returns_false(self, mock_bq_cls):
+        """daily_predictions も features.training_data も空 → False（フォールバック）"""
         mock_client = MagicMock()
         mock_bq_cls.return_value = mock_client
-        mock_client.query.return_value.to_dataframe.return_value = pd.DataFrame()
+        # 1回目: daily_predictions が空
+        # 2回目: features.training_data の COUNT が 0
+        mock_client.query.return_value.to_dataframe.side_effect = [
+            pd.DataFrame(),
+            _make_cnt_df(0),
+        ]
 
         result = _refresh_investment_decisions_for_race(PROJECT_ID, RACE_ID, TARGET_DATE)
 
         assert result is False
+        assert mock_client.query.call_count == 2
+
+    @patch("src.automation.api.app._predict_race_on_the_fly", return_value=False)
+    @patch("google.cloud.bigquery.Client")
+    def test_empty_predictions_but_features_exist_triggers_on_the_fly(
+        self,
+        mock_bq_cls,
+        mock_predict_on_the_fly,
+    ):
+        """daily_predictions 空 かつ features.training_data にデータあり → オンザフライ予測を呼ぶこと"""
+        mock_client = MagicMock()
+        mock_bq_cls.return_value = mock_client
+        # 1回目: daily_predictions が空
+        # 2回目: features.training_data に cnt=8 (データあり)
+        # 3回目: オンザフライ後の再取得でも空（mock_predict_on_the_fly が False を返すため）
+        mock_client.query.return_value.to_dataframe.side_effect = [
+            pd.DataFrame(),
+            _make_cnt_df(8),
+        ]
+
+        result = _refresh_investment_decisions_for_race(PROJECT_ID, RACE_ID, TARGET_DATE)
+
+        assert result is False
+        mock_predict_on_the_fly.assert_called_once_with(
+            PROJECT_ID, RACE_ID, TARGET_DATE, mock_client
+        )
 
     @patch("google.cloud.bigquery.Client")
     def test_empty_odds_returns_false(self, mock_bq_cls):
@@ -131,5 +191,72 @@ class TestRefreshInvestmentDecisions:
         mock_bq_cls.side_effect = Exception("BQ connection error")
 
         result = _refresh_investment_decisions_for_race(PROJECT_ID, RACE_ID, TARGET_DATE)
+
+        assert result is False
+
+
+class TestPredictRaceOnTheFly:
+    """_predict_race_on_the_fly のテスト"""
+
+    @patch("src.models.predict.save_predictions_to_bq", return_value=8)
+    @patch("src.automation.api.app._resolve_model_path")
+    @patch("src.models.train.build_feature_matrix")
+    @patch("src.models.train.load_config")
+    def test_success_when_features_exist(
+        self,
+        mock_load_config,
+        mock_build_feature_matrix,
+        mock_resolve_model_path,
+        mock_save_predictions_to_bq,
+    ):
+        """features.training_data にデータあり → 予測を生成して True を返すこと"""
+        mock_load_config.return_value = {
+            "data": {
+                "exclude_columns": ["race_id", "horse_id"],
+                "categorical_columns": [],
+            }
+        }
+        mock_resolve_model_path.return_value = ("/tmp/model.txt", None)
+
+        features_df = _make_features_df()
+        mock_client = MagicMock()
+        mock_client.query.return_value.to_dataframe.return_value = features_df
+
+        fake_ranker = MagicMock()
+        fake_ranker.predict.return_value = np.array([1.0 - i * 0.1 for i in range(len(features_df))])
+        mock_build_feature_matrix.return_value = MagicMock()
+
+        with patch("src.models.lgbm_ranker.LGBMRanker", return_value=fake_ranker):
+            result = _predict_race_on_the_fly(PROJECT_ID, RACE_ID, TARGET_DATE, mock_client)
+
+        assert result is True
+        mock_save_predictions_to_bq.assert_called_once()
+
+    def test_returns_false_when_features_empty(self):
+        """features.training_data が空 → False を返すこと"""
+        mock_client = MagicMock()
+        mock_client.query.return_value.to_dataframe.return_value = pd.DataFrame()
+
+        result = _predict_race_on_the_fly(PROJECT_ID, RACE_ID, TARGET_DATE, mock_client)
+
+        assert result is False
+
+    @patch("src.automation.api.app._resolve_model_path", side_effect=Exception("GCS error"))
+    @patch("src.models.train.load_config")
+    def test_returns_false_on_model_load_failure(
+        self, mock_load_config, mock_resolve
+    ):
+        """モデルのロードに失敗した場合 → False を返し例外を送出しないこと"""
+        mock_load_config.return_value = {
+            "data": {
+                "exclude_columns": ["race_id", "horse_id"],
+                "categorical_columns": [],
+            }
+        }
+        features_df = _make_features_df()
+        mock_client = MagicMock()
+        mock_client.query.return_value.to_dataframe.return_value = features_df
+
+        result = _predict_race_on_the_fly(PROJECT_ID, RACE_ID, TARGET_DATE, mock_client)
 
         assert result is False

--- a/tests/test_refresh_investment_decisions.py
+++ b/tests/test_refresh_investment_decisions.py
@@ -1,18 +1,12 @@
 """
-_refresh_investment_decisions_for_race / _predict_race_on_the_fly のユニットテスト
+_refresh_investment_decisions_for_race のユニットテスト
 
 テスト対象:
   - _refresh_investment_decisions_for_race: 最新オッズで investment_decisions を上書き
     - 正常系: 予測・オッズあり → 計算・保存 → True を返す
-    - 異常系: daily_predictions 空 かつ features.training_data 空 → False（フォールバック）
-    - 異常系: daily_predictions 空 かつ features.training_data あり → オンザフライ予測を試みる
+    - 異常系: 予測データなし → False（フォールバック）
     - 異常系: オッズデータなし → False（フォールバック）
     - 異常系: BQ例外 → False（フォールバック）
-
-  - _predict_race_on_the_fly: features.training_data から予測を生成して daily_predictions に保存
-    - 正常系: features にデータあり → 予測生成・保存 → True
-    - 異常系: features にデータなし → False
-    - 異常系: モデルロード失敗 → False
 
 Issue #231: 発走5分前に最新オッズで investment_decisions を上書きしてから IPAT 購入する
 """
@@ -22,14 +16,10 @@ from __future__ import annotations
 import datetime
 from unittest.mock import MagicMock, patch
 
-import numpy as np
 import pandas as pd
 import pytest
 
-from src.automation.api.app import (
-    _predict_race_on_the_fly,
-    _refresh_investment_decisions_for_race,
-)
+from src.automation.api.app import _refresh_investment_decisions_for_race
 
 TARGET_DATE = datetime.date(2026, 4, 12)
 RACE_ID = "202609050112"
@@ -66,25 +56,6 @@ def _make_merged_df() -> pd.DataFrame:
     df["odds"] = df["horse_number"].apply(lambda i: max(1.1, 1.5 * i))
     df["win_odds"] = df["horse_number"].apply(lambda i: 3.0 * i)
     return df
-
-
-def _make_cnt_df(cnt: int) -> pd.DataFrame:
-    """features.training_data の COUNT クエリ結果"""
-    return pd.DataFrame([{"cnt": cnt}])
-
-
-def _make_features_df() -> pd.DataFrame:
-    """features.training_data から取得する DataFrame（カラムは最小限）"""
-    return pd.DataFrame([
-        {
-            "race_id": RACE_ID, "race_date": TARGET_DATE,
-            "horse_id": f"h{i:04d}", "horse_number": i,
-            "horse_name": f"ウマ{i}", "venue_code": "09",
-            "race_number": 12,
-            "dummy_feature": float(i),
-        }
-        for i in range(1, 9)
-    ])
 
 
 class TestRefreshInvestmentDecisions:
@@ -132,46 +103,15 @@ class TestRefreshInvestmentDecisions:
         mock_save.assert_called_once()
 
     @patch("google.cloud.bigquery.Client")
-    def test_empty_predictions_and_empty_features_returns_false(self, mock_bq_cls):
-        """daily_predictions も features.training_data も空 → False（フォールバック）"""
+    def test_empty_predictions_returns_false(self, mock_bq_cls):
+        """予測データが空の場合は False（フォールバック）を返すこと"""
         mock_client = MagicMock()
         mock_bq_cls.return_value = mock_client
-        # 1回目: daily_predictions が空
-        # 2回目: features.training_data の COUNT が 0
-        mock_client.query.return_value.to_dataframe.side_effect = [
-            pd.DataFrame(),
-            _make_cnt_df(0),
-        ]
+        mock_client.query.return_value.to_dataframe.return_value = pd.DataFrame()
 
         result = _refresh_investment_decisions_for_race(PROJECT_ID, RACE_ID, TARGET_DATE)
 
         assert result is False
-        assert mock_client.query.call_count == 2
-
-    @patch("src.automation.api.app._predict_race_on_the_fly", return_value=False)
-    @patch("google.cloud.bigquery.Client")
-    def test_empty_predictions_but_features_exist_triggers_on_the_fly(
-        self,
-        mock_bq_cls,
-        mock_predict_on_the_fly,
-    ):
-        """daily_predictions 空 かつ features.training_data にデータあり → オンザフライ予測を呼ぶこと"""
-        mock_client = MagicMock()
-        mock_bq_cls.return_value = mock_client
-        # 1回目: daily_predictions が空
-        # 2回目: features.training_data に cnt=8 (データあり)
-        # 3回目: オンザフライ後の再取得でも空（mock_predict_on_the_fly が False を返すため）
-        mock_client.query.return_value.to_dataframe.side_effect = [
-            pd.DataFrame(),
-            _make_cnt_df(8),
-        ]
-
-        result = _refresh_investment_decisions_for_race(PROJECT_ID, RACE_ID, TARGET_DATE)
-
-        assert result is False
-        mock_predict_on_the_fly.assert_called_once_with(
-            PROJECT_ID, RACE_ID, TARGET_DATE, mock_client
-        )
 
     @patch("google.cloud.bigquery.Client")
     def test_empty_odds_returns_false(self, mock_bq_cls):
@@ -191,72 +131,5 @@ class TestRefreshInvestmentDecisions:
         mock_bq_cls.side_effect = Exception("BQ connection error")
 
         result = _refresh_investment_decisions_for_race(PROJECT_ID, RACE_ID, TARGET_DATE)
-
-        assert result is False
-
-
-class TestPredictRaceOnTheFly:
-    """_predict_race_on_the_fly のテスト"""
-
-    @patch("src.models.predict.save_predictions_to_bq", return_value=8)
-    @patch("src.automation.api.app._resolve_model_path")
-    @patch("src.models.train.build_feature_matrix")
-    @patch("src.models.train.load_config")
-    def test_success_when_features_exist(
-        self,
-        mock_load_config,
-        mock_build_feature_matrix,
-        mock_resolve_model_path,
-        mock_save_predictions_to_bq,
-    ):
-        """features.training_data にデータあり → 予測を生成して True を返すこと"""
-        mock_load_config.return_value = {
-            "data": {
-                "exclude_columns": ["race_id", "horse_id"],
-                "categorical_columns": [],
-            }
-        }
-        mock_resolve_model_path.return_value = ("/tmp/model.txt", None)
-
-        features_df = _make_features_df()
-        mock_client = MagicMock()
-        mock_client.query.return_value.to_dataframe.return_value = features_df
-
-        fake_ranker = MagicMock()
-        fake_ranker.predict.return_value = np.array([1.0 - i * 0.1 for i in range(len(features_df))])
-        mock_build_feature_matrix.return_value = MagicMock()
-
-        with patch("src.models.lgbm_ranker.LGBMRanker", return_value=fake_ranker):
-            result = _predict_race_on_the_fly(PROJECT_ID, RACE_ID, TARGET_DATE, mock_client)
-
-        assert result is True
-        mock_save_predictions_to_bq.assert_called_once()
-
-    def test_returns_false_when_features_empty(self):
-        """features.training_data が空 → False を返すこと"""
-        mock_client = MagicMock()
-        mock_client.query.return_value.to_dataframe.return_value = pd.DataFrame()
-
-        result = _predict_race_on_the_fly(PROJECT_ID, RACE_ID, TARGET_DATE, mock_client)
-
-        assert result is False
-
-    @patch("src.automation.api.app._resolve_model_path", side_effect=Exception("GCS error"))
-    @patch("src.models.train.load_config")
-    def test_returns_false_on_model_load_failure(
-        self, mock_load_config, mock_resolve
-    ):
-        """モデルのロードに失敗した場合 → False を返し例外を送出しないこと"""
-        mock_load_config.return_value = {
-            "data": {
-                "exclude_columns": ["race_id", "horse_id"],
-                "categorical_columns": [],
-            }
-        }
-        features_df = _make_features_df()
-        mock_client = MagicMock()
-        mock_client.query.return_value.to_dataframe.return_value = features_df
-
-        result = _predict_race_on_the_fly(PROJECT_ID, RACE_ID, TARGET_DATE, mock_client)
 
         assert result is False


### PR DESCRIPTION
## 概要

`race-day-predict` が日曜日に実行された際、当週の日曜レースではなく**来週の土日レース**を予測対象にしてしまうバグを修正する。

## 根本原因

`_today_jst()` 導入（Issue #239）がリグレッションを引き起こした。

```python
# 修正前（バグあり）
tomorrow = _today_jst() + datetime.timedelta(days=1)
saturday, sunday = compute_week_boundaries(tomorrow)
```

| 実行タイミング | `_today_jst()` | `tomorrow` | `compute_week_boundaries(tomorrow)` | 結果 |
|---|---|---|---|---|
| 土 4/11 8:00 JST | 4/11 (土) | 4/12 (日) | → `(4/11, 4/12)` | ✓ |
| **日 4/12 8:00 JST** | 4/12 (日) | **4/13 (月)** | → `(4/18, 4/19)` 来週 | **✗ バグ** |

`_today_jst()` 導入前は `date.today()`（UTC）を使っており、日曜 8:00 JST = 土曜 23:00 UTC のため `tomorrow=日曜` となり偶然正常動作していた。JST 化後に `tomorrow=月曜` となり来週土日を参照するようになった。

## 修正内容

`tomorrow` を廃止し、`_today_jst()` を直接 `compute_week_boundaries` に渡す。

```python
# 修正後
today = _today_jst()
saturday, sunday = compute_week_boundaries(today)
```

- 土曜: `compute_week_boundaries(土)` = `(土, 日)` ✓
- 日曜: `compute_week_boundaries(日)` = `(土, 日)` ✓
- 月曜: `compute_week_boundaries(月)` = `(翌土, 翌日)` ✓

## その他の変更

`2d8d232` で追加した `_predict_race_on_the_fly()` は根本原因の症状への対処として実装したものだったため、根本修正に伴い削除。

## テスト

`tests/test_predict_daily_endpoint.py` を新規追加（7件）:
- `TestComputeWeekBoundaries`: 土/日/月/金 各曜日で `compute_week_boundaries` の動作を確認
- `TestPredictDailyTargetDates`: エンドポイントの `target_dates` を曜日別に検証
  - `test_sunday_targets_this_weekend_not_next`: **バグ回帰テスト**（日曜に来週土日を返さないことを保証）

🤖 Generated with [Claude Code](https://claude.com/claude-code)