### PR TITLE
fix: 月次モデル再学習が動作しない3つの根本原因を修正

### DIFF
--- a/infrastructure/scripts/deploy_cloud_run.sh
+++ b/infrastructure/scripts/deploy_cloud_run.sh
@@ -99,6 +99,7 @@ gcloud run deploy "${SERVICE_NAME}" \
     --timeout=900 \
     --concurrency=1 \
     --max-instances=1 \
+    --no-cpu-throttling \
     --no-allow-unauthenticated \
     --set-env-vars="GCP_PROJECT_ID=${GCP_PROJECT_ID},GCP_REGION=${GCP_REGION},GCS_BUCKET_RAW=${GCS_BUCKET_RAW:-keiba-raw-data},GCS_BUCKET_MODELS=${GCS_BUCKET_MODELS:-keiba-models},BQ_DATASET_RAW=raw,BQ_DATASET_FEATURES=features,BQ_DATASET_PREDICTIONS=predictions,LOG_LEVEL=INFO" \
     --set-secrets="JRDB_USER=jrdb-user:latest,JRDB_PASSWORD=jrdb-password:latest,LINE_CHANNEL_ACCESS_TOKEN=line-channel-access-token:latest,LINE_CHANNEL_SECRET=line-channel-secret:latest,LINE_USER_ID=line-user-id:latest,IPAT_MEMBER_ID=ipat-member-id:latest,IPAT_PIN=ipat-pin:latest,IPAT_PAT_NUMBER=ipat-pat-number:latest" \
@@ -115,9 +116,10 @@ gsutil iam ch \
     log_info "GCSバケット権限を設定しました: gs://${GCS_BUCKET_RAW_FULL}" || \
     log_warn "GCSバケット権限の設定をスキップしました（バケットが存在しない可能性があります）"
 
-# モデルバケットへのアクセス権限を付与（読み取りのみ）
+# モデルバケットへのアクセス権限を付与
+# objectAdmin: 月次再学習(POST /api/v1/model/retrain/async)でモデルをGCSに書き込むため書き込み権限が必要
 gsutil iam ch \
-    "serviceAccount:${PIPELINE_SA_EMAIL}:roles/storage.objectViewer" \
+    "serviceAccount:${PIPELINE_SA_EMAIL}:roles/storage.objectAdmin" \
     "gs://${GCS_BUCKET_MODELS_FULL}" 2>/dev/null && \
     log_info "モデルバケット権限を設定しました: gs://${GCS_BUCKET_MODELS_FULL}" || \
     log_warn "モデルバケット権限の設定をスキップしました（バケットが存在しない可能性があります）"
@@ -139,4 +141,15 @@ log_info "  2. 予測エンドポイントのテスト (任意日付指定):"
 log_info "     POST /api/v1/predict/on-demand"
 log_info "  3. 日次予測スケジューラーの設定:"
 log_info "     POST /api/v1/predict/daily (前日PM 9:00 に実行)"
+log_info ""
+log_warn "=========================================="
+log_warn "【重要】デプロイ後は必ず以下を実行してください"
+log_warn "=========================================="
+log_warn "Cloud Schedulerジョブを作成・更新するため setup_scheduler.sh を再実行してください:"
+log_warn "  ./infrastructure/scripts/setup_scheduler.sh"
+log_warn ""
+log_warn "これを実行しないと以下のジョブが本番環境に存在しません:"
+log_warn "  - monthly-model-retrain（毎月第1月曜 AM 8:00）"
+log_warn "  - race-day-predict、race-day-strategy 等の日次ジョブ"
+log_warn "=========================================="
 log_info ""

--- a/infrastructure/scripts/setup_scheduler.sh
+++ b/infrastructure/scripts/setup_scheduler.sh
@@ -6,10 +6,12 @@
 # Cloud Schedulerジョブを作成する。
 #
 # 作成されるジョブ:
-#   1. daily-data-pipeline   AM 6:00 JST  データロード
-#   2. race-day-predict      AM 8:00 JST  翌日レース予測
-#   3. race-day-odds-scrape  AM 8:15 JST  netkeibaオッズ取得（単複＋組み合わせ）
-#   4. race-day-strategy     AM 8:30 JST  投資戦略策定・investment_decisions保存
+#   1. daily-data-pipeline    AM 6:00 JST  データロード
+#   2. race-day-predict       AM 8:00 JST  翌日レース予測
+#   3. race-day-odds-scrape   AM 8:15 JST  netkeibaオッズ取得（単複＋組み合わせ）
+#   4. race-day-strategy      AM 8:30 JST  投資戦略策定・investment_decisions保存
+#   5. monthly-model-retrain  毎月第1月曜 AM 8:00 JST  LightGBMモデル月次再学習
+#   6. race-day-purchase      土日 8:00〜17:00 5分おき  IPAT自動馬券購入
 #
 # 使用方法:
 #   ./infrastructure/scripts/setup_scheduler.sh
@@ -19,6 +21,11 @@
 #   2. 適切な権限を持つユーザーでログイン済み (gcloud auth login)
 #   3. .envファイルにGCP_PROJECT_IDが設定済み
 #   4. Cloud Runサービス keiba-pipeline がデプロイ済み
+#
+# 【重要】deploy_cloud_run.sh 実行後は必ずこのスクリプトを再実行してください。
+# Cloud Runのサービスを新たにデプロイするとURLが変わる場合があり、
+# また新規ジョブ（monthly-model-retrain 等）はこのスクリプトを実行しないと
+# Cloud Scheduler上に作成されません。
 #
 
 set -e

--- a/scripts/fix_retrain_setup.sh
+++ b/scripts/fix_retrain_setup.sh
@@ -1,0 +1,163 @@
+#!/bin/bash
+#
+# 月次モデル再学習の環境修正スクリプト
+#
+# 以下の2つの問題を修正します:
+#   1. モデルバケットへの書き込み権限がない（objectViewer → objectAdmin）
+#   2. monthly-model-retrain Cloud Schedulerジョブが存在しない場合の作成
+#
+# 使用方法:
+#   ./scripts/fix_retrain_setup.sh
+#
+
+set -e
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+if [ -f "${PROJECT_ROOT}/.env" ]; then
+    set -a
+    source "${PROJECT_ROOT}/.env"
+    set +a
+else
+    log_error ".envファイルが見つかりません"
+    exit 1
+fi
+
+if [ -z "${GCP_PROJECT_ID}" ] || [ "${GCP_PROJECT_ID}" = "your-project-id" ]; then
+    log_error "GCP_PROJECT_IDが設定されていません"
+    exit 1
+fi
+
+GCP_REGION="${GCP_REGION:-asia-northeast1}"
+PIPELINE_SA_NAME="${PIPELINE_SA_NAME:-keiba-pipeline-sa}"
+PIPELINE_SA_EMAIL="${PIPELINE_SA_NAME}@${GCP_PROJECT_ID}.iam.gserviceaccount.com"
+GCS_BUCKET_MODELS_FULL="${GCP_PROJECT_ID}-${GCS_BUCKET_MODELS:-keiba-models}"
+SERVICE_NAME="keiba-pipeline"
+
+log_info "=========================================="
+log_info "月次モデル再学習の環境修正"
+log_info "=========================================="
+log_info "プロジェクトID : ${GCP_PROJECT_ID}"
+log_info "サービスアカウント: ${PIPELINE_SA_EMAIL}"
+log_info "モデルバケット  : gs://${GCS_BUCKET_MODELS_FULL}"
+log_info "=========================================="
+
+# ----------------------------------------
+# 修正1: モデルバケットへの書き込み権限付与
+# ----------------------------------------
+log_info "【修正1】モデルバケットに objectAdmin 権限を付与します..."
+log_info "  月次再学習(POST /api/v1/model/retrain/async)でGCSにモデルを書き込むために必要です"
+
+gsutil iam ch \
+    "serviceAccount:${PIPELINE_SA_EMAIL}:roles/storage.objectAdmin" \
+    "gs://${GCS_BUCKET_MODELS_FULL}" && \
+    log_info "  権限付与に成功しました: gs://${GCS_BUCKET_MODELS_FULL}" || \
+    log_warn "  権限付与に失敗しました（バケットが存在しない、または権限不足の可能性）"
+
+# ----------------------------------------
+# 修正2: monthly-model-retrain ジョブの確認と作成
+# ----------------------------------------
+log_info ""
+log_info "【修正2】monthly-model-retrain Cloud Schedulerジョブを確認します..."
+
+SERVICE_URL=$(gcloud run services describe "${SERVICE_NAME}" \
+    --region="${GCP_REGION}" \
+    --format="value(status.url)" 2>/dev/null)
+
+if [ -z "${SERVICE_URL}" ]; then
+    log_error "Cloud Runサービスが見つかりません: ${SERVICE_NAME}"
+    log_error "先にデプロイしてください: ./infrastructure/scripts/deploy_cloud_run.sh"
+    exit 1
+fi
+
+RETRAIN_JOB_NAME="monthly-model-retrain"
+RETRAIN_TARGET_URI="${SERVICE_URL}/api/v1/model/retrain/async"
+RETRAIN_SCHEDULE="0 8 1-7 * 1"
+TIME_ZONE="Asia/Tokyo"
+
+if gcloud scheduler jobs describe "${RETRAIN_JOB_NAME}" \
+    --location="${GCP_REGION}" > /dev/null 2>&1; then
+    log_info "  ジョブは既に存在します: ${RETRAIN_JOB_NAME}"
+    gcloud scheduler jobs describe "${RETRAIN_JOB_NAME}" \
+        --location="${GCP_REGION}" \
+        --format="table(name,schedule,timeZone,state,httpTarget.uri)"
+else
+    log_warn "  ジョブが存在しません。作成します: ${RETRAIN_JOB_NAME}"
+
+    tmp_body=$(mktemp /tmp/scheduler_body_XXXXXX.json)
+    printf '{}' > "${tmp_body}"
+
+    gcloud scheduler jobs create http "${RETRAIN_JOB_NAME}" \
+        --location="${GCP_REGION}" \
+        --schedule="${RETRAIN_SCHEDULE}" \
+        --time-zone="${TIME_ZONE}" \
+        --uri="${RETRAIN_TARGET_URI}" \
+        --http-method=POST \
+        --headers="Content-Type=application/json" \
+        --message-body-from-file="${tmp_body}" \
+        --oidc-service-account-email="${PIPELINE_SA_EMAIL}" \
+        --oidc-token-audience="${SERVICE_URL}" \
+        --attempt-deadline="60s" \
+        --max-retry-attempts=3 \
+        --min-backoff=5s \
+        --max-backoff=300s \
+        --quiet
+
+    rm -f "${tmp_body}"
+    log_info "  ジョブを作成しました: ${RETRAIN_JOB_NAME} (${RETRAIN_SCHEDULE} JST)"
+fi
+
+# ----------------------------------------
+# 修正3: Cloud Run に --no-cpu-throttling が設定されているか確認
+# ----------------------------------------
+log_info ""
+log_info "【確認】Cloud Runの--no-cpu-throttlingを確認します..."
+
+CPU_THROTTLING=$(gcloud run services describe "${SERVICE_NAME}" \
+    --region="${GCP_REGION}" \
+    --format="value(spec.template.metadata.annotations['run.googleapis.com/cpu-throttling'])" 2>/dev/null)
+
+if [ "${CPU_THROTTLING}" = "false" ]; then
+    log_info "  --no-cpu-throttling は設定済みです（バックグラウンドタスクが正常に動作します）"
+else
+    log_warn "  --no-cpu-throttling が設定されていません！"
+    log_warn "  バックグラウンドで動作するモデル再学習がCPU throttlingで中断される可能性があります。"
+    log_warn "  修正するには再デプロイが必要です:"
+    log_warn "    ./infrastructure/scripts/deploy_cloud_run.sh"
+    log_warn ""
+    log_warn "  または今すぐ gcloud で更新する場合:"
+    log_warn "    gcloud run services update ${SERVICE_NAME} \\"
+    log_warn "      --region=${GCP_REGION} \\"
+    log_warn "      --no-cpu-throttling"
+fi
+
+# ----------------------------------------
+# 完了サマリ
+# ----------------------------------------
+log_info ""
+log_info "=========================================="
+log_info "修正完了"
+log_info "=========================================="
+log_info ""
+log_info "今すぐ再学習をトリガーする場合:"
+log_info "  gcloud scheduler jobs run ${RETRAIN_JOB_NAME} --location=${GCP_REGION}"
+log_info ""
+log_info "または直接APIを呼び出す場合:"
+log_info "  SERVICE_URL=\$(gcloud run services describe ${SERVICE_NAME} --region=${GCP_REGION} --format='value(status.url)')"
+log_info "  curl -X POST \"\${SERVICE_URL}/api/v1/model/retrain/async\" \\"
+log_info "    -H \"Authorization: Bearer \$(gcloud auth print-identity-token)\" \\"
+log_info "    -H \"Content-Type: application/json\" \\"
+log_info "    -d '{}'"
+log_info ""
+log_info "再学習ログの確認:"
+log_info "  gcloud run services logs read ${SERVICE_NAME} --region=${GCP_REGION} --limit=50"


### PR DESCRIPTION
## 背景

GCS の `lgbm_ranker/` フォルダに 2/17 のモデルしかなく、4/6（第1月曜）に月次再学習が実行されなかった問題を調査・修正します。

## 根本原因

### 原因 1（主因）: Cloud Scheduler ジョブが本番環境に存在しない
- `monthly-model-retrain` ジョブが `setup_scheduler.sh` に追加されたのは PR #222（4/5 マージ）
- しかしデプロイ後に `setup_scheduler.sh` が再実行されておらず、本番環境にジョブが存在しなかった
- 4/6 には Cloud Scheduler ジョブがそもそもなかったため何も実行されなかった

### 原因 2（副因・重大）: モデルバケットの IAM 権限が読み取り専用
- `deploy_cloud_run.sh` でモデルバケットに `objectViewer`（読み取り専用）しか付与していなかった
- `upload_model_to_gcs()` はモデルを**書き込む**ため `objectAdmin` が必要
- ジョブが動いても `403 Permission Denied` で GCS 保存が必ず失敗する状態だった

### 原因 3（副因）: Cloud Run の CPU throttling でバックグラウンドタスクが停止
- `/retrain/async` は HTTP レスポンスを即時返し、`train_pipeline()` をバックグラウンドで実行
- Cloud Run のデフォルトではレスポンス返却後に CPU が throttle されるため、1〜2時間の学習処理が実質停止する

## 修正内容

| ファイル | 修正内容 |
|---------|---------|
| `infrastructure/scripts/deploy_cloud_run.sh` | モデルバケット権限 `objectViewer` → `objectAdmin` に修正 |
| `infrastructure/scripts/deploy_cloud_run.sh` | `--no-cpu-throttling` フラグを追加（バックグラウンドタスクの CPU 確保） |
| `infrastructure/scripts/deploy_cloud_run.sh` | デプロイ後に `setup_scheduler.sh` 再実行が必要な警告を追加 |
| `infrastructure/scripts/setup_scheduler.sh` | 作成ジョブの完全リストと再実行の重要性をコメントに追記 |
| `scripts/fix_retrain_setup.sh` | 既存本番環境への即時修正スクリプトを新規作成 |

## テスト計画

- [ ] `scripts/fix_retrain_setup.sh` を実行し、GCS 権限・Cloud Scheduler ジョブが正しく設定されることを確認
- [ ] `gcloud scheduler jobs run monthly-model-retrain --location=asia-northeast1` で手動トリガーして再学習が完了・GCS にモデルが保存されることを確認

## 本番環境への即時対応手順

```bash
# 1. GCS権限修正 + Cloud Schedulerジョブ作成
./scripts/fix_retrain_setup.sh

# 2. Cloud Run の --no-cpu-throttling を即時適用
gcloud run services update keiba-pipeline \
  --region=asia-northeast1 \
  --no-cpu-throttling

# 3. 再学習を手動トリガー
gcloud scheduler jobs run monthly-model-retrain --location=asia-northeast1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)