### PR TITLE
fix: investment_decisions の日次保存を日付全件置換方式に変更

### DIFF
--- a/scripts/run_strategy.py
+++ b/scripts/run_strategy.py
@@ -245,77 +245,102 @@ def build_race_df(
 def save_decisions_to_bq(
     decisions: list[dict],
     project_id: str,
+    target_date: datetime.date | None = None,
 ) -> int:
     """
-    投資判断結果を predictions.investment_decisions テーブルに UPSERT 保存する。
+    投資判断結果を predictions.investment_decisions テーブルに保存する。
 
-    1馬券を1行で保存する（マルチ馬券も horse_numbers をカンマ区切り文字列で保持）。
-    MERGE キー: race_id + bet_type + horse_numbers
+    target_date を指定した場合（日次全件置換モード）:
+        対象日の全レコードを race_date で DELETE してから INSERT する。
+        ベットなしになったレースの旧データも確実に消去できる。
+
+    target_date を省略した場合（1レース更新モード）:
+        decisions に含まれる race_id のみを DELETE してから MERGE する。
+        発走直前リフレッシュ（_refresh_investment_decisions_for_race）向け。
 
     Args:
         decisions: 投資判断リスト（各 dict は _build_decision_row() で生成）
         project_id: GCP プロジェクト ID
+        target_date: 対象日。指定時は対象日の全レコードを先に削除する
 
     Returns:
         保存した行数
     """
+    client = bigquery.Client(project=project_id)
+    table_ref = f"{project_id}.predictions.investment_decisions"
+
+    if target_date is not None:
+        # 日次全件置換: 対象日の全レコードを削除（ベットなしになったレースも確実に消去）
+        delete_query = f"""
+        DELETE FROM `{table_ref}`
+        WHERE race_date = '{target_date.isoformat()}'
+        """
+        client.query(delete_query).result()
+        logger.info(f"対象日 {target_date} の既存行を全削除")
+
     if not decisions:
         logger.info("投資判断なし（保存スキップ）")
         return 0
 
     df = pd.DataFrame(decisions)
-    client = bigquery.Client(project=project_id)
-    table_ref = f"{project_id}.predictions.investment_decisions"
     temp_table = f"{table_ref}_temp_{datetime.datetime.now().strftime('%Y%m%d%H%M%S')}"
 
+    _SCHEMA = [
+        bigquery.SchemaField("race_id", "STRING", mode="REQUIRED"),
+        bigquery.SchemaField("race_date", "DATE", mode="REQUIRED"),
+        bigquery.SchemaField("horse_numbers", "STRING", mode="REQUIRED"),
+        bigquery.SchemaField("horse_names", "STRING"),
+        bigquery.SchemaField("venue_code", "STRING"),
+        bigquery.SchemaField("race_number", "INTEGER"),
+        bigquery.SchemaField("race_pattern", "STRING"),
+        bigquery.SchemaField("bet_type", "STRING"),
+        bigquery.SchemaField("bet_amount", "FLOAT64"),
+        bigquery.SchemaField("win_place_prob", "FLOAT64"),
+        bigquery.SchemaField("place_odds", "FLOAT64"),
+        bigquery.SchemaField("expected_return", "FLOAT64"),
+        bigquery.SchemaField("created_at", "TIMESTAMP", mode="REQUIRED"),
+    ]
     job_config = bigquery.LoadJobConfig(
         write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
-        schema=[
-            bigquery.SchemaField("race_id", "STRING", mode="REQUIRED"),
-            bigquery.SchemaField("race_date", "DATE", mode="REQUIRED"),
-            bigquery.SchemaField("horse_numbers", "STRING", mode="REQUIRED"),
-            bigquery.SchemaField("horse_names", "STRING"),
-            bigquery.SchemaField("venue_code", "STRING"),
-            bigquery.SchemaField("race_number", "INTEGER"),
-            bigquery.SchemaField("race_pattern", "STRING"),
-            bigquery.SchemaField("bet_type", "STRING"),
-            bigquery.SchemaField("bet_amount", "FLOAT64"),
-            bigquery.SchemaField("win_place_prob", "FLOAT64"),
-            bigquery.SchemaField("place_odds", "FLOAT64"),
-            bigquery.SchemaField("expected_return", "FLOAT64"),
-            bigquery.SchemaField("created_at", "TIMESTAMP", mode="REQUIRED"),
-        ],
+        schema=_SCHEMA,
     )
     client.load_table_from_dataframe(df, temp_table, job_config=job_config).result()
 
-    # 対象 race_id の既存行を削除してから MERGE（BigQuery は WHEN 句での相関サブクエリ非対応）
-    delete_query = f"""
-    DELETE FROM `{table_ref}`
-    WHERE race_id IN (SELECT DISTINCT race_id FROM `{temp_table}`)
-    """
-    client.query(delete_query).result()
+    if target_date is not None:
+        # 日付単位で全削除済みなので単純 INSERT
+        insert_query = f"INSERT INTO `{table_ref}` SELECT * FROM `{temp_table}`"
+        client.query(insert_query).result()
+    else:
+        # 1レース更新: 対象 race_id の既存行を削除してから MERGE
+        # （BigQuery は WHEN 句での相関サブクエリ非対応のため先に DELETE）
+        delete_query = f"""
+        DELETE FROM `{table_ref}`
+        WHERE race_id IN (SELECT DISTINCT race_id FROM `{temp_table}`)
+        """
+        client.query(delete_query).result()
 
-    merge_query = f"""
-    MERGE `{table_ref}` AS target
-    USING `{temp_table}` AS source
-    ON target.race_id = source.race_id
-       AND target.bet_type = source.bet_type
-       AND target.horse_numbers = source.horse_numbers
-    WHEN MATCHED THEN UPDATE SET
-        race_date = source.race_date,
-        horse_names = source.horse_names,
-        venue_code = source.venue_code,
-        race_number = source.race_number,
-        race_pattern = source.race_pattern,
-        bet_type = source.bet_type,
-        bet_amount = source.bet_amount,
-        win_place_prob = source.win_place_prob,
-        place_odds = source.place_odds,
-        expected_return = source.expected_return,
-        created_at = source.created_at
-    WHEN NOT MATCHED BY TARGET THEN INSERT ROW
-    """
-    client.query(merge_query).result()
+        merge_query = f"""
+        MERGE `{table_ref}` AS target
+        USING `{temp_table}` AS source
+        ON target.race_id = source.race_id
+           AND target.bet_type = source.bet_type
+           AND target.horse_numbers = source.horse_numbers
+        WHEN MATCHED THEN UPDATE SET
+            race_date = source.race_date,
+            horse_names = source.horse_names,
+            venue_code = source.venue_code,
+            race_number = source.race_number,
+            race_pattern = source.race_pattern,
+            bet_type = source.bet_type,
+            bet_amount = source.bet_amount,
+            win_place_prob = source.win_place_prob,
+            place_odds = source.place_odds,
+            expected_return = source.expected_return,
+            created_at = source.created_at
+        WHEN NOT MATCHED BY TARGET THEN INSERT ROW
+        """
+        client.query(merge_query).result()
+
     client.delete_table(temp_table, not_found_ok=True)
 
     logger.info(f"投資判断を保存: {len(df)}行 → {table_ref}")
@@ -518,7 +543,7 @@ def run_daily_strategy(
         logger.info(f"  馬券種別: {bet_types}")
 
     if not dry_run:
-        save_decisions_to_bq(decisions, project_id)
+        save_decisions_to_bq(decisions, project_id, target_date=target_date)
     else:
         logger.info("(--dry-run: BQ保存をスキップ)")
         for d in decisions:

--- a/tests/test_run_strategy.py
+++ b/tests/test_run_strategy.py
@@ -3,15 +3,18 @@ run_strategy.py の build_race_df と _build_decision_row のユニットテス�
 
 Issue #166: win_odds が race_df に渡されないため単勝が常に0件になるバグの修正検証。
 Issue #194: 単勝の expected_return に複勝率を使っているため誤った値になる問題の修正検証。
+Issue #XXX: save_decisions_to_bq が target_date 指定時に日付全体削除→INSERTで保存すること。
 """
 
 from __future__ import annotations
 
 import datetime
+from unittest.mock import MagicMock, call, patch
+
 import pandas as pd
 import pytest
 
-from scripts.run_strategy import build_race_df, _build_decision_row
+from scripts.run_strategy import build_race_df, _build_decision_row, save_decisions_to_bq
 
 
 # ---------------------------------------------------------------------------
@@ -179,3 +182,103 @@ class TestBuildDecisionRow:
             created_at=datetime.datetime(2026, 3, 29, 9, 0, 0),
         )
         assert abs(row["win_place_prob"] - 0.733) < 1e-6
+
+
+# ---------------------------------------------------------------------------
+# save_decisions_to_bq の target_date 挙動テスト
+# ---------------------------------------------------------------------------
+
+
+def _make_decisions(n: int = 2) -> list[dict]:
+    """テスト用の最小限 decisions リストを生成する"""
+    return [
+        {
+            "race_id": "race_001",
+            "race_date": datetime.date(2026, 4, 12),
+            "horse_numbers": str(i),
+            "horse_names": f"テストホース{i}",
+            "venue_code": "09",
+            "race_number": 1,
+            "race_pattern": "standard",
+            "bet_type": "place",
+            "bet_amount": 300.0,
+            "win_place_prob": 0.3,
+            "place_odds": 3.0,
+            "expected_return": 0.9,
+            "created_at": datetime.datetime(2026, 4, 12, 9, 0, 0, tzinfo=datetime.timezone.utc),
+        }
+        for i in range(1, n + 1)
+    ]
+
+
+class TestSaveDecisionsToBq:
+    """save_decisions_to_bq の保存モード切替テスト"""
+
+    @patch("scripts.run_strategy.bigquery.Client")
+    def test_target_date_deletes_by_date_then_inserts(self, mock_bq_cls):
+        """target_date 指定時は race_date で全削除してから INSERT する（日次全件置換モード）"""
+        mock_client = MagicMock()
+        mock_bq_cls.return_value = mock_client
+        mock_client.load_table_from_dataframe.return_value.result.return_value = None
+        mock_client.query.return_value.result.return_value = None
+
+        target_date = datetime.date(2026, 4, 12)
+        save_decisions_to_bq(_make_decisions(), "test-project", target_date=target_date)
+
+        # query() の呼び出し引数を収集
+        query_calls = [c.args[0].strip() for c in mock_client.query.call_args_list]
+
+        # 1回目: race_date による全削除
+        assert any("race_date = '2026-04-12'" in q for q in query_calls), (
+            "target_date 指定時は race_date で全削除すべき"
+        )
+        # 2回目: INSERT INTO（MERGE ではない）
+        assert any(q.startswith("INSERT INTO") for q in query_calls), (
+            "target_date 指定時は MERGE ではなく INSERT INTO を使うべき"
+        )
+        # MERGE は呼ばれない
+        assert not any("MERGE" in q for q in query_calls), (
+            "target_date 指定時に MERGE が呼ばれてはいけない"
+        )
+
+    @patch("scripts.run_strategy.bigquery.Client")
+    def test_no_target_date_uses_race_id_delete_and_merge(self, mock_bq_cls):
+        """target_date 未指定時は race_id で削除してから MERGE する（1レース更新モード）"""
+        mock_client = MagicMock()
+        mock_bq_cls.return_value = mock_client
+        mock_client.load_table_from_dataframe.return_value.result.return_value = None
+        mock_client.query.return_value.result.return_value = None
+
+        save_decisions_to_bq(_make_decisions(), "test-project", target_date=None)
+
+        query_calls = [c.args[0].strip() for c in mock_client.query.call_args_list]
+
+        # race_date による全削除は呼ばれない
+        assert not any("race_date" in q and "DELETE" in q for q in query_calls), (
+            "target_date 未指定時に race_date DELETE が呼ばれてはいけない"
+        )
+        # race_id による削除が呼ばれる
+        assert any("race_id IN" in q for q in query_calls), (
+            "target_date 未指定時は race_id で削除すべき"
+        )
+        # MERGE が呼ばれる
+        assert any("MERGE" in q for q in query_calls), (
+            "target_date 未指定時は MERGE を使うべき"
+        )
+
+    @patch("scripts.run_strategy.bigquery.Client")
+    def test_target_date_with_empty_decisions_still_deletes(self, mock_bq_cls):
+        """decisions が空でも target_date 指定時は削除だけ実行される（ベットなしレースの旧データ消去）"""
+        mock_client = MagicMock()
+        mock_bq_cls.return_value = mock_client
+        mock_client.query.return_value.result.return_value = None
+
+        target_date = datetime.date(2026, 4, 12)
+        result = save_decisions_to_bq([], "test-project", target_date=target_date)
+
+        assert result == 0
+        query_calls = [c.args[0].strip() for c in mock_client.query.call_args_list]
+        # 削除クエリは実行される
+        assert any("race_date = '2026-04-12'" in q for q in query_calls), (
+            "decisions が空でも target_date 指定時は race_date で削除すべき"
+        )


### PR DESCRIPTION
## 問題

`save_decisions_to_bq` が「新しい decisions に含まれる **race_id のみ** DELETE → MERGE」する方式だったため、再実行でベットなしになったレースの旧データが `investment_decisions` テーブルに残り続けた。

**具体的な発生ケース:**
- `min_prob_threshold` 修正により、あるレースの全候補馬が除外されてベットなし
- 再実行の decisions にその race_id が含まれない → DELETE 対象外 → 旧データが残存

## 修正内容

`save_decisions_to_bq` に `target_date: datetime.date | None = None` を追加し、2つのモードを切り替える。

| モード | target_date | 削除範囲 | INSERT方式 |
|--------|-------------|----------|-----------|
| 日次全件置換 | 指定あり | `race_date = target_date` で全削除 | INSERT INTO |
| 1レース更新 | 省略 (None) | `race_id IN (decisions)` で削除 | MERGE |

`run_daily_strategy` から呼ぶ際に `target_date=target_date` を渡すよう変更。
発走直前リフレッシュ（`_refresh_investment_decisions_for_race`）は変更なし（1レース更新モードを継続）。

## テスト追加

`tests/test_run_strategy.py` に `TestSaveDecisionsToBq` クラスを追加（3件）:
- `target_date` 指定時: `race_date` で全削除 → `INSERT INTO` が呼ばれる
- `target_date` 未指定時: `race_id IN` で削除 → `MERGE` が呼ばれる
- `decisions` が空でも `target_date` 指定時は削除が実行される（ベットなしレースの旧データ消去）

## テスト結果

246 passed in 23.42s

🤖 Generated with [Claude Code](https://claude.ai/claude-code)