### PR TITLE
fix: IPAT馬番セレクタのゼロパディング除去と_navigate_to_top_menuの無条件遷移化

### DIFF
--- a/src/automation/data/ipat_purchaser.py
+++ b/src/automation/data/ipat_purchaser.py
@@ -220,13 +220,16 @@ class IpatPurchaser:
             return {"status": "failed", "error_message": str(e)}
 
     async def _navigate_to_top_menu(self) -> None:
-        """IPATのトップメニュー(pw_732_i.cgi)へ移動する。"""
-        if "pw_732_i" not in self._page.url:
-            await self._page.goto(
-                IPAT_TOP_MENU_URL,
-                timeout=PURCHASE_TIMEOUT_MS,
-                wait_until="domcontentloaded",
-            )
+        """IPATのトップメニュー(pw_732_i.cgi)へ移動する。
+
+        条件分岐なく毎回 goto() することで、前のフローが途中で
+        失敗した場合でも確実にクリーンな状態からスタートできる。
+        """
+        await self._page.goto(
+            IPAT_TOP_MENU_URL,
+            timeout=PURCHASE_TIMEOUT_MS,
+            wait_until="domcontentloaded",
+        )
 
     async def _execute_purchase(
         self,
@@ -278,11 +281,11 @@ class IpatPurchaser:
             await self._page.wait_for_load_state("domcontentloaded", timeout=PURCHASE_TIMEOUT_MS)
 
             # Step 6: 馬番選択（複数頭は1頭ずつクリック）
-            # IPATでは馬番が2桁ゼロパディングで表示される（例: 03）
+            # IPAT SP版では馬番がゼロパディングなし（例: "3"）で表示されるため
+            # :text-is() による完全一致でマッチさせる
             for h in horse_numbers:
-                horse_num_str = f"{h:02d}"
                 await self._page.click(
-                    f'a:has-text("{horse_num_str}")',
+                    f'a:text-is("{h}")',
                     timeout=PURCHASE_TIMEOUT_MS,
                 )
                 await self._page.wait_for_load_state("domcontentloaded", timeout=PURCHASE_TIMEOUT_MS)


### PR DESCRIPTION
## Summary

- 馬番選択セレクタを `a:has-text("03")` → `a:text-is("3")` に変更（IPAT SP版はゼロパディングなし）
- `_navigate_to_top_menu()` の条件分岐を削除し毎回 `goto()` を呼ぶよう変更（前フロー失敗後のページ状態不定を解消）

## 背景

PR #247 で IPAT SP版ウィザードフローを実装した後、本番ログで2種類のエラーが確認された。

**Bug 1: 馬番ゼロパディング**
- ログ: `waiting for locator("a:has-text(\"03\")")` タイムアウト
- 原因: `f"{h:02d}"` で "03" を生成していたが、IPAT SP版のスクリーンショット上は馬番が "3" (ゼロパディングなし) で表示される
- 修正: `a:text-is("{h}")` による完全一致マッチに変更

**Bug 2: _navigate_to_top_menu() の条件分岐**
- ログ: 馬番選択失敗後の次レースで `waiting for locator("a:has-text(\"通常投票\")")` タイムアウト
- 原因: 前フローが途中で失敗すると `self._page.url` には不定なURLが残り、条件 `if "pw_732_i" not in self._page.url` でも `goto()` がスキップされる場合がある
- 修正: 条件分岐を削除し、毎回無条件で `goto(IPAT_TOP_MENU_URL)` を呼ぶ

## Test plan
- [x] `.venv/bin/pytest tests/test_ipat_purchaser.py` → 34件全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)