### PR TITLE
fix: IPAT SP版購入ウィザードの全セレクタ修正（金額入力tel型・JQM遷移待機）

### DIFF
--- a/scripts/debug_ipat_html.py
+++ b/scripts/debug_ipat_html.py
@@ -1,0 +1,136 @@
+"""
+IPAT SP版 HTML構造診断スクリプト
+
+各画面のHTMLをダンプしてセレクタを確認する。
+購入は一切しない（readonlyモード）。
+
+実行:
+  IPAT_MEMBER_ID=xxx IPAT_PIN=xxx IPAT_PAT_NUMBER=xxx .venv/bin/python scripts/debug_ipat_html.py
+"""
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+IPAT_LOGIN_URL = "https://www.ipat.jra.go.jp/sp/index.cgi"
+IPAT_TOP_MENU_URL = "https://www.ipat.jra.go.jp/sp/pw_732_i.cgi"
+
+
+async def main():
+    member_id = os.environ["IPAT_MEMBER_ID"]
+    pin = os.environ["IPAT_PIN"]
+    pat_number = os.environ["IPAT_PAT_NUMBER"]
+
+    from playwright.async_api import async_playwright
+
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch(
+            headless=False,  # 画面を見ながらデバッグ
+            args=["--no-sandbox", "--disable-setuid-sandbox"],
+        )
+        page = await browser.new_page()
+        page.on("dialog", lambda d: asyncio.create_task(d.dismiss()))
+
+        # ---- Step 1: ログイン ----
+        print("=== Step 1: ログイン ===")
+        await page.goto(IPAT_LOGIN_URL, wait_until="domcontentloaded")
+        await page.fill("#userid", member_id)
+        await page.fill("#password", pin)
+        await page.fill("#pars", pat_number)
+        await page.click("li.btnColor a")
+        await page.wait_for_load_state("domcontentloaded")
+        print(f"ログイン後URL: {page.url}")
+
+        # ---- Step 2: ログイン後のページ HTML ダンプ（goto なし）----
+        print("\n=== Step 2: ログイン後のページ HTML（goto なし）===")
+        # ログイン後に自然に着地しているページをそのままキャプチャ
+        print(f"現在のURL: {page.url}")
+        html = await page.content()
+        Path("/tmp/ipat_top_menu.html").write_text(html, encoding="utf-8")
+        print("HTML を /tmp/ipat_top_menu.html に保存しました")
+
+        # 「通常投票」を含む要素を検索
+        print("\n--- 「通常投票」を含む要素 ---")
+        elems = await page.query_selector_all("*:has-text('通常投票')")
+        for el in elems:
+            tag = await el.evaluate("e => e.tagName")
+            cls = await el.evaluate("e => e.className")
+            href = await el.evaluate("e => e.href || ''")
+            inner = (await el.inner_text()).strip().replace("\n", " ")[:60]
+            print(f"  <{tag.lower()} class='{cls}' href='{href}'> {inner!r}")
+
+        # <a>タグをすべてリスト
+        print("\n--- 全 <a> タグ (最初の20件) ---")
+        anchors = await page.query_selector_all("a")
+        for a in anchors[:20]:
+            href = await a.evaluate("e => e.href || ''")
+            text = (await a.inner_text()).strip().replace("\n", " ")[:60]
+            print(f"  href={href!r}  text={text!r}")
+
+        await page.screenshot(path="/tmp/ipat_top_screenshot.png")
+        print("\nスクリーンショット: /tmp/ipat_top_screenshot.png")
+
+        # ---- Step 3: 通常投票をクリックして競馬場選択画面のHTML ----
+        print("\n=== Step 3: 通常投票クリック試行 ===")
+        # 複数の候補を試す
+        candidates = [
+            "a:has-text('通常投票')",
+            "a[href*='pw_']",
+            "*:has-text('通常投票') >> nth=0",
+        ]
+        clicked = False
+        for sel in candidates:
+            try:
+                el = await page.query_selector(sel)
+                if el:
+                    print(f"  ヒット: {sel}")
+                    tag = await el.evaluate("e => e.tagName")
+                    href = await el.evaluate("e => e.href || ''")
+                    text = (await el.inner_text()).strip()[:40]
+                    print(f"    <{tag.lower()} href={href!r}> {text!r}")
+                else:
+                    print(f"  なし: {sel}")
+            except Exception as e:
+                print(f"  エラー: {sel} -> {e}")
+
+        # 実際にクリックして次画面のHTMLを取得
+        print("\n=== Step 4: 実際にクリックして競馬場選択画面 ===")
+        # ログイン後のページからそのままクリックを試みる（goto なし）
+        try:
+            # li内のimg直後のテキストを含む<a>を探す
+            await page.click("a:has-text('通常投票')", timeout=5000)
+            await page.wait_for_load_state("domcontentloaded")
+            print(f"クリック成功 -> URL: {page.url}")
+            html2 = await page.content()
+            Path("/tmp/ipat_venue_select.html").write_text(html2, encoding="utf-8")
+            print("競馬場選択HTML -> /tmp/ipat_venue_select.html")
+
+            # 競馬場選択画面のリンクを確認
+            print("\n--- 競馬場選択画面の全 <a> タグ ---")
+            anchors2 = await page.query_selector_all("a")
+            for a in anchors2[:20]:
+                href = await a.evaluate("e => e.href || ''")
+                text = (await a.inner_text()).strip()[:60]
+                print(f"  href={href!r}  text={text!r}")
+
+        except Exception as e:
+            print(f"クリック失敗: {e}")
+            # href から直接推測を試みる
+            print("\n--- href に 'pw_' を含むリンク ---")
+            links = await page.query_selector_all("a[href*='pw_'], a[href*='vote'], a[href*='ticket']")
+            for l in links:
+                href = await l.evaluate("e => e.href")
+                text = (await l.inner_text()).strip()[:40]
+                print(f"  {href!r} -> {text!r}")
+
+        print("\n=== 診断完了 ===")
+        input("Enterキーでブラウザを閉じます...")
+        await browser.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/test_ipat_e2e.py
+++ b/scripts/test_ipat_e2e.py
@@ -1,0 +1,89 @@
+"""
+IPAT 自動購入 エンドツーエンド動作確認スクリプト
+
+実際の IPAT SP版に接続し、1件の馬券購入（最低100円）が
+正常に完了することを確認する。
+
+実行:
+  IPAT_MEMBER_ID=xxx IPAT_PIN=xxx IPAT_PAT_NUMBER=xxx \
+  .venv/bin/python scripts/test_ipat_e2e.py \
+    --venue "福島(土)" --race 9 --bet-type place --horse 3 --amount 100
+"""
+
+import argparse
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from src.automation.data.ipat_purchaser import IpatPurchaser, IpatLoginError, IpatPurchaseError
+
+
+async def run_test(venue: str, race: int, bet_type: str, horses: list[int], amount: int, dry_run: bool):
+    member_id = os.environ["IPAT_MEMBER_ID"]
+    pin = os.environ["IPAT_PIN"]
+    pat_number = os.environ["IPAT_PAT_NUMBER"]
+
+    print(f"=== IPAT E2E テスト ===")
+    print(f"会場: {venue} / {race}R / {bet_type} / 馬番:{horses} / {amount}円")
+    print(f"dry_run: {dry_run}")
+    print()
+
+    async with IpatPurchaser(member_id, pin, pat_number) as purchaser:
+        # ---- ログイン ----
+        print("1. ログイン中...")
+        ok = await purchaser.login()
+        if not ok:
+            print("❌ ログイン失敗")
+            return False
+        print(f"✅ ログイン成功 (URL: {purchaser._page.url})")
+
+        if dry_run:
+            print("\n[dry_run=True] 購入はスキップします")
+            return True
+
+        # ---- 購入 ----
+        print(f"\n2. 馬券購入: {venue} {race}R {bet_type} {horses} {amount}円")
+        result = await purchaser.purchase_bet(
+            bet_type=bet_type,
+            horse_numbers=horses,
+            amount=amount,
+            venue_name=venue,
+            race_number=race,
+        )
+        print(f"   結果: {result}")
+
+        if result["status"] == "success":
+            print("✅ 購入成功")
+            return True
+        else:
+            print(f"❌ 購入失敗: {result['error_message']}")
+            return False
+
+
+def main():
+    parser = argparse.ArgumentParser(description="IPAT E2Eテスト")
+    parser.add_argument("--venue", default="福島(土)", help="競馬場名 (例: 福島(土))")
+    parser.add_argument("--race", type=int, default=9, help="レース番号")
+    parser.add_argument("--bet-type", default="place", help="馬券種 (place/win/wide/umaren/sanrenpuku)")
+    parser.add_argument("--horses", nargs="+", type=int, default=[3], help="馬番 (複数可)")
+    parser.add_argument("--amount", type=int, default=100, help="購入金額 (100円単位)")
+    parser.add_argument("--dry-run", action="store_true", help="ログインのみ (購入しない)")
+    args = parser.parse_args()
+
+    ok = asyncio.run(run_test(
+        venue=args.venue,
+        race=args.race,
+        bet_type=args.bet_type,
+        horses=args.horses,
+        amount=args.amount,
+        dry_run=args.dry_run,
+    ))
+    sys.exit(0 if ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/automation/data/ipat_purchaser.py
+++ b/src/automation/data/ipat_purchaser.py
@@ -219,17 +219,36 @@ class IpatPurchaser:
             logger.error(f"馬券購入エラー: {bet_type_label} {horse_str} - {e}", exc_info=True)
             return {"status": "failed", "error_message": str(e)}
 
-    async def _navigate_to_top_menu(self) -> None:
-        """IPATのトップメニュー(pw_732_i.cgi)へ移動する。
+    async def _wait_for_jqm_ready(self) -> None:
+        """jQuery Mobile のページ遷移が完了するまで待機する。
 
-        条件分岐なく毎回 goto() することで、前のフローが途中で
-        失敗した場合でも確実にクリーンな状態からスタートできる。
+        IPAT SP版は pw_740_i.cgi 上で全ウィザードステップを jQuery Mobile の
+        ページ遷移で処理する。遷移中は <html class="... ui-loading"> となり
+        ui-loader-cover が画面を覆うため、その消滅を待つ必要がある。
+        wait_for_load_state("domcontentloaded") では不十分（URL が変わらず
+        DOMは既にロード済みのため即座に返る）。
         """
-        await self._page.goto(
-            IPAT_TOP_MENU_URL,
-            timeout=PURCHASE_TIMEOUT_MS,
-            wait_until="domcontentloaded",
-        )
+        try:
+            await self._page.wait_for_function(
+                "!document.documentElement.classList.contains('ui-loading')",
+                timeout=PURCHASE_TIMEOUT_MS,
+            )
+        except Exception:
+            # ui-loading が存在しないページ（トップメニュー等）では無視
+            pass
+
+    async def _navigate_to_top_menu(self) -> None:
+        """IPATのトップメニューへ遷移する。
+
+        直接 goto(IPAT_TOP_MENU_URL) を呼ぶとセッションエラー(120)が発生するため使用しない。
+        - ログイン直後は URL が pw_732_i.cgi のままなので何もしない。
+        - ウィザード途中/完了後は「トップメニュー」ボタンをクリックして戻る。
+        """
+        if "pw_732_i" in self._page.url:
+            return  # すでにトップメニューにいる
+        logger.info(f"「トップメニュー」ボタンで戻ります (現在URL: {self._page.url})")
+        await self._page.click('a:has-text("トップメニュー")', timeout=PURCHASE_TIMEOUT_MS)
+        await self._page.wait_for_load_state("domcontentloaded", timeout=PURCHASE_TIMEOUT_MS)
 
     async def _execute_purchase(
         self,
@@ -242,79 +261,78 @@ class IpatPurchaser:
         """
         IPAT SP版のウィザード形式で馬券を1件購入する内部メソッド。
 
-        購入フロー:
+        購入フロー（全ステップが pw_740_i.cgi 上で jQuery Mobile ページ遷移で処理される）:
           1. トップメニューへ遷移
-          2. 「通常投票」アイコンをクリック
-          3. 競馬場を選択（例: 「中山(土)」）
-          4. レースを選択（例: 「7R」）
-          5. 式別を選択（例: 「複勝」「３連複」）
-          6. 馬番を選択（1頭ずつ、複数頭は繰り返し）
+          2. 「通常投票」アイコンをクリック → 競馬場選択画面
+          3. 競馬場を選択（ul.selectList 内の完全一致）
+          4. レースを選択（ul.selectList 内の部分一致）
+          5. 式別を選択（ul.selectList 内の完全一致）
+          6. 馬番を選択（1頭ずつ、:text-is() 完全一致）
           7. 金額入力（__00円形式 = 入力値×100円）→「セット」
           8. 投票一覧 → 「入力終了」
           9. 合計金額入力（円単位）→「投票」
          10. 完了確認
+
+        各ステップ後に _wait_for_jqm_ready() を呼ぶことで、
+        jQuery Mobile の ui-loader-cover が消えてから次のクリックを行う。
         """
         try:
             # Step 1: トップメニューへ遷移
             await self._navigate_to_top_menu()
 
-            # Step 2: 「通常投票」アイコンをクリック
+            # Step 2: 「通常投票」アイコンをクリック → 競馬場選択画面
             await self._page.click('a:has-text("通常投票")', timeout=PURCHASE_TIMEOUT_MS)
             await self._page.wait_for_load_state("domcontentloaded", timeout=PURCHASE_TIMEOUT_MS)
+            await self._wait_for_jqm_ready()
 
             # Step 3: 競馬場選択（例: 「中山(土)」）
-            # has-text は部分一致のため venue_name だけでも機能するが、
-            # 同一競馬場が「中山(土)」「中山(日)」両方表示される場合があるので曜日付き名称を優先
-            await self._page.click(f'a:has-text("{venue_name}")', timeout=PURCHASE_TIMEOUT_MS)
-            await self._page.wait_for_load_state("domcontentloaded", timeout=PURCHASE_TIMEOUT_MS)
+            # ul.selectList 内の完全一致で指定。
+            # ページ内に存在する隠れた jQuery Mobile ページ（投票一覧等）の
+            # パンくず「中山(土)」と混同しないよう .selectList でスコープを絞る。
+            await self._page.click(f'.selectList a:text-is("{venue_name}")', timeout=PURCHASE_TIMEOUT_MS)
+            await self._wait_for_jqm_ready()
 
-            # Step 4: レース選択（例: 「7R」）
+            # Step 4: レース選択（例: 「7R」「9R 袖ケ浦特別」）
+            # レース名付き行も正しく選択するため has-text の部分一致を使用。
+            # ul.selectList でスコープを絞り、他ページ要素との混同を防ぐ。
             await self._page.click(
-                f'a:has-text("{race_number}R")',
+                f'.selectList a:has-text("{race_number}R")',
                 timeout=PURCHASE_TIMEOUT_MS,
             )
-            await self._page.wait_for_load_state("domcontentloaded", timeout=PURCHASE_TIMEOUT_MS)
+            await self._wait_for_jqm_ready()
 
             # Step 5: 式別選択（例: 「複勝」「３連複」）
             bet_label = BET_TYPE_MAP[bet_type]
-            await self._page.click(f'a:has-text("{bet_label}")', timeout=PURCHASE_TIMEOUT_MS)
-            await self._page.wait_for_load_state("domcontentloaded", timeout=PURCHASE_TIMEOUT_MS)
+            await self._page.click(f'.selectList a:text-is("{bet_label}")', timeout=PURCHASE_TIMEOUT_MS)
+            await self._wait_for_jqm_ready()
 
             # Step 6: 馬番選択（複数頭は1頭ずつクリック）
-            # IPAT SP版では馬番がゼロパディングなし（例: "3"）で表示されるため
-            # :text-is() による完全一致でマッチさせる
+            # 馬番セル: <a class="ui-link" data-value="3">3\n馬名\nオッズ</a>
+            # data-value 属性が馬番なのでそれを使う。テキストには馬名・オッズが含まれるため
+            # text-is では一致しない。
             for h in horse_numbers:
                 await self._page.click(
-                    f'a:text-is("{h}")',
+                    f'a[data-value="{h}"]',
                     timeout=PURCHASE_TIMEOUT_MS,
                 )
-                await self._page.wait_for_load_state("domcontentloaded", timeout=PURCHASE_TIMEOUT_MS)
+                await self._wait_for_jqm_ready()
 
             # Step 7: 金額入力（__00円形式: 500円 → 入力値「5」）
             amount_units = str(amount // 100)
-            await self._page.fill('input[type="text"]', amount_units, timeout=PURCHASE_TIMEOUT_MS)
+            await self._page.fill('input[type="tel"]', amount_units, timeout=PURCHASE_TIMEOUT_MS)
 
             # Step 8: 「セット」ボタンをクリック
-            await self._page.click(
-                'a:has-text("セット"), button:has-text("セット"), input[value="セット"]',
-                timeout=PURCHASE_TIMEOUT_MS,
-            )
-            await self._page.wait_for_load_state("domcontentloaded", timeout=PURCHASE_TIMEOUT_MS)
+            await self._page.click('a:has-text("セット")', timeout=PURCHASE_TIMEOUT_MS)
+            await self._wait_for_jqm_ready()
 
             # Step 9: 「入力終了」をクリック（投票一覧画面）
-            await self._page.click(
-                'a:has-text("入力終了"), button:has-text("入力終了")',
-                timeout=PURCHASE_TIMEOUT_MS,
-            )
-            await self._page.wait_for_load_state("domcontentloaded", timeout=PURCHASE_TIMEOUT_MS)
+            await self._page.click('a:has-text("入力終了")', timeout=PURCHASE_TIMEOUT_MS)
+            await self._wait_for_jqm_ready()
 
             # Step 10: 合計金額確認入力（円単位）→「投票」ボタン
-            await self._page.fill('input[type="text"]', str(amount), timeout=PURCHASE_TIMEOUT_MS)
-            await self._page.click(
-                'a:has-text("投票"), button:has-text("投票")',
-                timeout=PURCHASE_TIMEOUT_MS,
-            )
-            await self._page.wait_for_load_state("domcontentloaded", timeout=PURCHASE_TIMEOUT_MS)
+            await self._page.fill('input[type="tel"]', str(amount), timeout=PURCHASE_TIMEOUT_MS)
+            await self._page.click('a:has-text("投票")', timeout=PURCHASE_TIMEOUT_MS)
+            await self._wait_for_jqm_ready()
 
             # Step 11: 完了確認
             page_text = await self._page.text_content("body") or ""


### PR DESCRIPTION
## Summary

- `input[type="tel"]` 修正: 金額入力フィールドがSP版では `type="tel"` のため、`type="text"` で参照していたStep7/Step10がタイムアウトしていた問題を解消
- `_wait_for_jqm_ready()` 追加: jQuery Mobile のページ遷移中は `<html class="ui-loading">` が付与されPointerEventsがブロックされるため、その消滅を待機するヘルパーを追加。全ウィザードステップ後に呼び出す
- `_navigate_to_top_menu()` 修正: `goto(pw_732_i.cgi)` がセッションエラー(120)を引き起こすため廃止。URL確認でスキップ or 「トップメニュー」ボタンクリックに変更
- 競馬場/式別セレクタ: `.selectList a:text-is()` に変更（隠れたJQMページのパンくずとの混同を防ぐ）
- 馬番セレクタ: `a:text-is()` → `a[data-value="N"]` に変更（テキストに馬名・オッズが含まれるため完全一致不可）

## Test plan

- [x] ローカルE2Eテスト実行: `中山(日) 2R 複勝 1番 100円` で購入成功を確認 (2026-04-19)
- [x] `scripts/test_ipat_e2e.py` でステップごとの動作確認
- [ ] Cloud Runデプロイ後の本番動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)