### PR TITLE
fix: ワイド/馬連/三連複の馬番選択をjQuery tap triggerで修正

### DIFF
--- a/src/automation/data/ipat_purchaser.py
+++ b/src/automation/data/ipat_purchaser.py
@@ -24,6 +24,7 @@ Issue #213: 発走5分前JRA IPAT自動馬券購入パイプラインの実装
 
 import datetime
 import logging
+import re
 import uuid
 
 from google.cloud import bigquery
@@ -306,16 +307,53 @@ class IpatPurchaser:
             await self._page.click(f'.selectList a:text-is("{bet_label}")', timeout=PURCHASE_TIMEOUT_MS)
             await self._wait_for_jqm_ready()
 
-            # Step 6: 馬番選択（複数頭は1頭ずつクリック）
-            # 馬番セル: <a class="ui-link" data-value="3">3\n馬名\nオッズ</a>
-            # data-value 属性が馬番なのでそれを使う。テキストには馬名・オッズが含まれるため
-            # text-is では一致しない。
+            # Step 5b: 投票形式選択（複数頭馬券のみ: ワイド/馬連/三連複等）
+            # 式別選択後に「通常/ながし/ボックス/フォーメーション」画面が現れる場合のみ処理。
+            try:
+                await self._page.wait_for_selector(
+                    '.selectList a:text-is("通常")',
+                    state="visible",
+                    timeout=3000,
+                )
+                await self._page.click('.selectList a:text-is("通常")', timeout=PURCHASE_TIMEOUT_MS)
+                await self._wait_for_jqm_ready()
+            except Exception:
+                pass  # 単勝・複勝などはこの画面が存在しない
+
+            # Step 6: 馬番選択
+            # IPAT SP版は jqm.extend_260206.js が multichoice リスト項目に
+            #   $('ul[data-role=multichoice] li a').bind('tap', toggleClass('selected'))
+            # を、740_260206.js が extap で PAIRCHECK + KinBtnControl をバインドしている。
+            # JQM の tap イベントは touchstart/touchend か vmousedown+vmouseup から合成されるが、
+            # Playwright のマウス click() では tap が発火しないため jQuery.trigger('tap') を使う。
+            # tap 発火後 75ms でextap が動くため wait_for_timeout(200) でバッファを確保する。
             for h in horse_numbers:
+                await self._page.evaluate(
+                    """(h) => {
+                        window.jQuery('.ui-page-active .selectHorse [data-value="' + h + '"]')
+                            .trigger('tap');
+                    }""",
+                    h,
+                )
+                await self._page.wait_for_timeout(200)
+
+            # Step 6c: 複数頭馬券では「金額入力画面へ」ボタンで金額入力画面へ遷移
+            # 選択完了後は KinBtnControl が disabled を除去しているので click() で遷移できる。
+            # evaluate() 内から trigger('extap') すると JQM の内部 Deferred が壊れるため
+            # Playwright のネイティブ click() を使う（tap→extap の非同期チェーンが正常動作）。
+            try:
+                await self._page.wait_for_selector(
+                    '.ui-page-active a:text-is("金額入力画面へ")',
+                    state="attached",
+                    timeout=3000,
+                )
                 await self._page.click(
-                    f'a[data-value="{h}"]',
+                    '.ui-page-active a:text-is("金額入力画面へ")',
                     timeout=PURCHASE_TIMEOUT_MS,
                 )
                 await self._wait_for_jqm_ready()
+            except Exception:
+                pass  # 単勝・複勝など「金額入力画面へ」ボタンが存在しない場合はスキップ
 
             # Step 7: 金額入力（__00円形式: 500円 → 入力値「5」）
             amount_units = str(amount // 100)

--- a/src/automation/data/ipat_purchaser.py
+++ b/src/automation/data/ipat_purchaser.py
@@ -22,6 +22,7 @@ Issue #213: 発走5分前JRA IPAT自動馬券購入パイプラインの実装
   8. 合計金額入力（円単位）→「投票」
 """
 
+import asyncio
 import datetime
 import logging
 import re
@@ -124,8 +125,9 @@ class IpatPurchaser:
         try:
             logger.info("JRA IPAT ログイン開始")
 
-            # バリデーション失敗時に出る alert を自動 dismiss
-            self._page.on("dialog", lambda d: d.dismiss())
+            # alert は accept/dismiss どちらでも閉じる。
+            # 購入確認の confirm ダイアログは accept() が必要なので全て accept に統一する。
+            self._page.on("dialog", lambda d: asyncio.create_task(d.accept()))
 
             await self._page.goto(IPAT_LOGIN_URL, timeout=PURCHASE_TIMEOUT_MS, wait_until="domcontentloaded")
 
@@ -356,28 +358,72 @@ class IpatPurchaser:
                 pass  # 単勝・複勝など「金額入力画面へ」ボタンが存在しない場合はスキップ
 
             # Step 7: 金額入力（__00円形式: 500円 → 入力値「5」）
+            # .ui-page-active でスコープし、非アクティブページの入力欄と混同しない。
             amount_units = str(amount // 100)
-            await self._page.fill('input[type="tel"]', amount_units, timeout=PURCHASE_TIMEOUT_MS)
+            await self._page.fill(
+                '.ui-page-active input[type="tel"]', amount_units, timeout=PURCHASE_TIMEOUT_MS
+            )
 
-            # Step 8: 「セット」ボタンをクリック
-            await self._page.click('a:has-text("セット")', timeout=PURCHASE_TIMEOUT_MS)
+            # Step 8: 「セット」ボタンをクリック → 投票一覧へ
+            await self._page.click(
+                '.ui-page-active a:text-is("セット")', timeout=PURCHASE_TIMEOUT_MS
+            )
             await self._wait_for_jqm_ready()
 
-            # Step 9: 「入力終了」をクリック（投票一覧画面）
-            await self._page.click('a:has-text("入力終了")', timeout=PURCHASE_TIMEOUT_MS)
+            # Step 9: 「入力終了」をクリック → 合計金額入力へ
+            await self._page.click(
+                '.ui-page-active a:text-is("入力終了")', timeout=PURCHASE_TIMEOUT_MS
+            )
             await self._wait_for_jqm_ready()
 
             # Step 10: 合計金額確認入力（円単位）→「投票」ボタン
-            await self._page.fill('input[type="tel"]', str(amount), timeout=PURCHASE_TIMEOUT_MS)
-            await self._page.click('a:has-text("投票")', timeout=PURCHASE_TIMEOUT_MS)
+            # 合計金額入力ページの入力欄は id="sum"。.ui-page-active スコープで
+            # 非アクティブページの tel 入力と混在しないよう id 指定する。
+            # 合計金額確認入力ページは FORM0 (POST) を持つ。
+            # 「投票」ボタンの extap→FORM0.submit() は Playwright click / trigger('tap') では
+            # 発火しないため、#sum を fill してから直接 submit する。
+            # wait_for_selector で DOM の準備を確認してから操作する。
+            # #sum は FORM0 の外にある独立した入力欄。
+            # JS の投票ハンドラが #sum を読んで検証し、confirm ダイアログ後に FORM0.submit() する。
+            # Playwright の click() は JQM tap を発火しないので trigger('tap') を使う。
+            # confirm ダイアログは login() の accept ハンドラで自動承認される。
+            await self._page.wait_for_selector('#sum', state='attached', timeout=PURCHASE_TIMEOUT_MS)
+            await self._page.locator('#sum').fill(str(amount), timeout=PURCHASE_TIMEOUT_MS)
+            async with self._page.expect_navigation(
+                wait_until="domcontentloaded", timeout=PURCHASE_TIMEOUT_MS
+            ):
+                # 75ms 後に extap → 投票 JS ハンドラ → confirm（accept）→ FORM0.submit()
+                await self._page.evaluate(
+                    "window.jQuery('.ui-page-active .btnColor a').trigger('tap')"
+                )
             await self._wait_for_jqm_ready()
 
             # Step 11: 完了確認
-            page_text = await self._page.text_content("body") or ""
-            if "残高不足" in page_text:
-                return {"status": "failed", "error_message": "残高不足"}
+            # 投票完了なら active page に「受付番号」が表示される。
+            # inner_text() で display:none の noscript テキストを除外し正確に判定する。
+            active_text = await self._page.locator('.ui-page-active').inner_text() or ""
+            logger.info(f"Step 11 active_text: {active_text[:300]}")
 
-            return {"status": "success", "error_message": None}
+            ERROR_PATTERNS = [
+                "残高不足",
+                "締め切られました",
+                "締め切り",
+                "金額が一致しません",
+                "合計金額が違います",
+                "投票できません",
+                "エラーが発生",
+                "ご確認ください",
+            ]
+            for pat in ERROR_PATTERNS:
+                if pat in active_text:
+                    return {"status": "failed", "error_message": pat}
+
+            if "受付番号" in active_text:
+                return {"status": "success", "error_message": None}
+
+            # 受付番号が見つからない場合はページ内容を添えて失敗扱い
+            snippet = active_text.strip()[:200]
+            return {"status": "failed", "error_message": f"完了確認できず: {snippet}"}
 
         except Exception as e:
             error_msg = str(e)

--- a/src/automation/data/ipat_purchaser.py
+++ b/src/automation/data/ipat_purchaser.py
@@ -25,7 +25,6 @@ Issue #213: 発走5分前JRA IPAT自動馬券購入パイプラインの実装
 import asyncio
 import datetime
 import logging
-import re
 import uuid
 
 from google.cloud import bigquery
@@ -319,8 +318,10 @@ class IpatPurchaser:
                 )
                 await self._page.click('.selectList a:text-is("通常")', timeout=PURCHASE_TIMEOUT_MS)
                 await self._wait_for_jqm_ready()
-            except Exception:
-                pass  # 単勝・複勝などはこの画面が存在しない
+            except Exception as e:
+                if "Timeout" not in type(e).__name__:
+                    logger.warning(f"Step 5b 予期しないエラー（スキップ）: {e}")
+                # 単勝・複勝などはこの画面が存在しないため TimeoutError は無視
 
             # Step 6: 馬番選択
             # IPAT SP版は jqm.extend_260206.js が multichoice リスト項目に
@@ -354,8 +355,10 @@ class IpatPurchaser:
                     timeout=PURCHASE_TIMEOUT_MS,
                 )
                 await self._wait_for_jqm_ready()
-            except Exception:
-                pass  # 単勝・複勝など「金額入力画面へ」ボタンが存在しない場合はスキップ
+            except Exception as e:
+                if "Timeout" not in type(e).__name__:
+                    logger.warning(f"Step 6c 予期しないエラー（スキップ）: {e}")
+                # 単勝・複勝など「金額入力画面へ」ボタンが存在しない場合は TimeoutError を無視
 
             # Step 7: 金額入力（__00円形式: 500円 → 入力値「5」）
             # .ui-page-active でスコープし、非アクティブページの入力欄と混同しない。
@@ -377,16 +380,10 @@ class IpatPurchaser:
             await self._wait_for_jqm_ready()
 
             # Step 10: 合計金額確認入力（円単位）→「投票」ボタン
-            # 合計金額入力ページの入力欄は id="sum"。.ui-page-active スコープで
-            # 非アクティブページの tel 入力と混在しないよう id 指定する。
-            # 合計金額確認入力ページは FORM0 (POST) を持つ。
-            # 「投票」ボタンの extap→FORM0.submit() は Playwright click / trigger('tap') では
-            # 発火しないため、#sum を fill してから直接 submit する。
-            # wait_for_selector で DOM の準備を確認してから操作する。
-            # #sum は FORM0 の外にある独立した入力欄。
-            # JS の投票ハンドラが #sum を読んで検証し、confirm ダイアログ後に FORM0.submit() する。
-            # Playwright の click() は JQM tap を発火しないので trigger('tap') を使う。
-            # confirm ダイアログは login() の accept ハンドラで自動承認される。
+            # #sum は FORM0 の外にある独立した入力欄。JS の投票ハンドラが #sum を読んで
+            # 検証し、confirm ダイアログ（login() の accept ハンドラで自動承認）後に
+            # FORM0.submit() する。Playwright click() は JQM tap を発火しないため
+            # trigger('tap') 経由で JS ハンドラを起動する。
             await self._page.wait_for_selector('#sum', state='attached', timeout=PURCHASE_TIMEOUT_MS)
             await self._page.locator('#sum').fill(str(amount), timeout=PURCHASE_TIMEOUT_MS)
             async with self._page.expect_navigation(


### PR DESCRIPTION
## Summary
- IPAT SP版のmultichoice馬番選択において、`jQuery.trigger('tap')`を使うことで正しく`selected`クラスが付与されるよう修正
- Playwright `click()` / JS `el.click()` ではJQMの`tap`イベントが発火せず馬番が選択されなかった問題を解消
- `evaluate()`内から`trigger('extap')`するとJQMの内部Deferredが破壊されるため「金額入力画面へ」ボタンはPlaywrightネイティブ`click()`を使用

## Root Cause
- `jqm.extend_260206.js`: `ul[data-role=multichoice] li a`に`tap`イベントで`toggleClass('selected')`をバインド
- `740_260206.js`: `tap → 75ms → extap → PAIRCHECK + KinBtnControl`の順で処理
- Playwrightのマウスイベントはvmousedown+vmouseupを発火するがJQMの`tap`（touchstart/touchend由来）は発火しない

## Test plan
- [x] 中山(日) 11R ワイド 1-12 100円 ローカルE2Eテスト購入成功を確認
- [x] ログイン → 競馬場/レース/式別/方式選択 → 馬番選択 → 金額入力 → 投票完了の全ステップ動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)