### PR TITLE
fix: 三連複を housiki=c99 で全組み合わせ取得し raw.combo_odds でマージ補完 (#254)

### DIFF
--- a/scripts/run_strategy.py
+++ b/scripts/run_strategy.py
@@ -76,11 +76,13 @@ def fetch_combo_odds_for_date(
     race_ids: list[str],
 ) -> pd.DataFrame:
     """
-    コンボオッズを以下の優先順位で取得する（当日分）
+    コンボオッズを取得する（当日分）
 
-    優先順位:
-      1. predictions.daily_odds_combo（netkeibaスクレイピング）
-      2. raw.combo_odds（JRDB基準オッズ）
+    取得優先度:
+      - 馬連・ワイド: predictions.daily_odds_combo を優先し、未取得レースは raw.combo_odds で補完
+      - 三連複: predictions.daily_odds_combo は人気順上位100件の上限があるため、
+                daily_odds_combo（リアルタイムオッズ）+ raw.combo_odds（全件）をマージして使用。
+                同一組み合わせは daily_odds_combo（netkeiba実オッズ）を優先する。
 
     返り値の統一スキーマ:
         race_id, bet_type, horse_number_1, horse_number_2, horse_number_3, odds_value
@@ -107,7 +109,8 @@ def fetch_combo_odds_for_date(
                 df[col] = None
         return df[_UNIFIED_SCHEMA]
 
-    # Stage 1: predictions.daily_odds_combo
+    # Stage 1: predictions.daily_odds_combo（netkeibaリアルタイムオッズ）
+    df1 = pd.DataFrame()
     try:
         query1 = f"""
         SELECT race_id, ticket_type AS bet_type,
@@ -120,38 +123,16 @@ def fetch_combo_odds_for_date(
         df1 = client.query(query1).to_dataframe()
         if len(df1) > 0:
             df1 = _ensure_schema(df1)
-            covered_ids = set(df1["race_id"].unique())
-            remaining_ids = [r for r in race_ids if r not in covered_ids]
-            logger.info(
-                f"predictions.daily_odds_combo から {len(df1)} 件取得"
-                f"（カバー: {len(covered_ids)} レース）"
-            )
-            if not remaining_ids:
-                return df1
-            # 残りを Stage 2 で補完
-            rem_ids_str = ", ".join(f"'{r}'" for r in remaining_ids)
-            try:
-                query2 = f"""
-                SELECT race_id, bet_type,
-                       horse_number_1, horse_number_2, horse_number_3,
-                       odds_value
-                FROM `{project_id}.raw.combo_odds`
-                WHERE bet_type IN ({types_str})
-                  AND race_id IN ({rem_ids_str})
-                """
-                df2 = client.query(query2).to_dataframe()
-                if len(df2) > 0:
-                    df2 = _ensure_schema(df2)
-                    return pd.concat([df1, df2], ignore_index=True)
-            except Exception as e2:
-                logger.info(f"raw.combo_odds 取得スキップ: {e2}")
-            return df1
+            logger.info(f"predictions.daily_odds_combo から {len(df1)} 件取得")
         else:
             logger.info("predictions.daily_odds_combo にデータなし → raw.combo_odds へ")
+            df1 = pd.DataFrame()
     except Exception as e:
         logger.info(f"predictions.daily_odds_combo が存在しないか取得失敗: {e} → raw.combo_odds へ")
 
-    # Stage 2: raw.combo_odds
+    # Stage 2: raw.combo_odds（JRDB基準オッズ・全組み合わせ）
+    # 三連複は housiki=c99 でも上位100件までしか取得できないため、常に raw.combo_odds でマージする
+    df2 = pd.DataFrame()
     try:
         query2 = f"""
         SELECT race_id, bet_type,
@@ -165,10 +146,39 @@ def fetch_combo_odds_for_date(
         if len(df2) > 0:
             df2 = _ensure_schema(df2)
             logger.info(f"raw.combo_odds から {len(df2)} 件取得")
-            return df2
-        logger.info("raw.combo_odds にもデータなし")
+        else:
+            logger.info("raw.combo_odds にもデータなし")
     except Exception as e:
         logger.info(f"raw.combo_odds が存在しないか取得失敗: {e}")
+
+    if df1.empty and df2.empty:
+        return pd.DataFrame()
+
+    if df1.empty:
+        return df2
+
+    if df2.empty:
+        return df1
+
+    # Stage 1 を優先してマージ: Stage 1 にない組み合わせのみ Stage 2 から補完
+    merge_keys = ["race_id", "bet_type", "horse_number_1", "horse_number_2", "horse_number_3"]
+    df1_keys = set(
+        zip(df1["race_id"], df1["bet_type"], df1["horse_number_1"],
+            df1["horse_number_2"], df1["horse_number_3"])
+    )
+    df2_supplement = df2[
+        ~df2.apply(
+            lambda r: (r["race_id"], r["bet_type"], r["horse_number_1"],
+                       r["horse_number_2"], r["horse_number_3"]) in df1_keys,
+            axis=1,
+        )
+    ]
+    merged = pd.concat([df1, df2_supplement], ignore_index=True)
+    logger.info(
+        f"コンボオッズマージ完了: daily_odds_combo {len(df1)} 件"
+        f" + raw.combo_odds補完 {len(df2_supplement)} 件 = 計 {len(merged)} 件"
+    )
+    return merged[_UNIFIED_SCHEMA]
 
     return pd.DataFrame(columns=_UNIFIED_SCHEMA)
 

--- a/scripts/run_strategy.py
+++ b/scripts/run_strategy.py
@@ -161,7 +161,6 @@ def fetch_combo_odds_for_date(
         return df1
 
     # Stage 1 を優先してマージ: Stage 1 にない組み合わせのみ Stage 2 から補完
-    merge_keys = ["race_id", "bet_type", "horse_number_1", "horse_number_2", "horse_number_3"]
     df1_keys = set(
         zip(df1["race_id"], df1["bet_type"], df1["horse_number_1"],
             df1["horse_number_2"], df1["horse_number_3"])
@@ -179,8 +178,6 @@ def fetch_combo_odds_for_date(
         f" + raw.combo_odds補完 {len(df2_supplement)} 件 = 計 {len(merged)} 件"
     )
     return merged[_UNIFIED_SCHEMA]
-
-    return pd.DataFrame(columns=_UNIFIED_SCHEMA)
 
 
 def fetch_daily_predictions(

--- a/src/automation/data/netkeiba_scraper.py
+++ b/src/automation/data/netkeiba_scraper.py
@@ -781,18 +781,76 @@ def scrape_today_combo_odds(
     return total_saved
 
 
+def _parse_sanrenpuku_ninki_html(html: str) -> pd.DataFrame:
+    """
+    三連複の人気順全件ページ（housiki=c99）のHTMLをパースする
+    （テスト可能な純粋関数）
+
+    HTMLの構造:
+      <tr id="ninki-data_N">
+        <td class="Ninki">人気順位</td>
+        <td class="Check_Odd"></td>
+        <td>組み合わせ文字列</td>
+        <td class="Name_Odds">オッズ</td>
+        <td>馬番1</td>
+        <td class="Horse_Name Txt_L">馬名1</td>
+        <td>馬番2</td>
+        <td class="Horse_Name Txt_L">馬名2</td>
+        <td>馬番3</td>
+        <td class="Horse_Name Txt_L">馬名3</td>
+      </tr>
+
+    Args:
+        html: オッズページのHTML文字列
+
+    Returns:
+        DataFrame[ticket_type(str), horse_number_1(int), horse_number_2(int),
+                  horse_number_3(int), odds(float)]
+        パース失敗時は空のDataFrameを返す
+    """
+    soup = BeautifulSoup(html, "lxml")
+    pattern = re.compile(r"^ninki-data_\d+$")
+    rows = []
+    for tr in soup.find_all("tr", id=pattern):
+        tds = tr.find_all("td")
+        if len(tds) < 9:
+            continue
+        try:
+            odds_val = float(tds[3].get_text(strip=True).replace(",", ""))
+            h1 = int(tds[4].get_text(strip=True))
+            h2 = int(tds[6].get_text(strip=True))
+            h3 = int(tds[8].get_text(strip=True))
+        except (ValueError, IndexError):
+            continue
+        if odds_val <= 1.0:
+            continue
+        rows.append({
+            "ticket_type": "sanrenpuku",
+            "horse_number_1": min(h1, h2, h3),
+            "horse_number_2": sorted([h1, h2, h3])[1],
+            "horse_number_3": max(h1, h2, h3),
+            "odds": odds_val,
+        })
+
+    if not rows:
+        return pd.DataFrame(columns=_EMPTY_COMBO_COLUMNS)
+
+    return pd.DataFrame(rows)
+
+
 def _parse_combo_odds_html(html: str, ticket_type: str) -> pd.DataFrame:
     """
-    組み合わせ馬券（馬連・馬単・ワイド・三連複）のオッズページ HTML をパースする
+    組み合わせ馬券（馬連・馬単・ワイド）のオッズページ HTML をパースする
     （テスト可能な純粋関数）
 
     HTMLの span ID 形式:
       2頭組み合わせ: <span id="odds-{code}-XXYY">
-      3頭組み合わせ: <span id="odds-{code}-XXYYZZ">
+
+    三連複（b7）は _parse_sanrenpuku_ninki_html を使用すること。
 
     Args:
         html: オッズページのHTML文字列
-        ticket_type: 'b4'(馬連) / 'b5'(ワイド) / 'b6'(馬単) / 'b7'(三連複)
+        ticket_type: 'b4'(馬連) / 'b5'(ワイド) / 'b6'(馬単)
 
     Returns:
         DataFrame[ticket_type(str), horse_number_1(int), horse_number_2(int),
@@ -805,9 +863,7 @@ def _parse_combo_odds_html(html: str, ticket_type: str) -> pd.DataFrame:
         return pd.DataFrame(columns=_EMPTY_COMBO_COLUMNS)
 
     soup = BeautifulSoup(html, "lxml")
-    is_trio = (ticket_type == "b7")
-    # 三連複(b7)は6桁、2頭組(b4/b5/b6)は4桁
-    pattern = re.compile(rf'^odds-{code}-(\d{{6}})$' if is_trio else rf'^odds-{code}-(\d{{4}})$')
+    pattern = re.compile(rf'^odds-{code}-(\d{{4}})$')
 
     rows = []
     for span in soup.find_all("span", id=pattern):
@@ -823,24 +879,14 @@ def _parse_combo_odds_html(html: str, ticket_type: str) -> pd.DataFrame:
         if odds_val <= 1.0:
             continue
 
-        if is_trio:
-            h1, h2, h3 = int(digits[0:2]), int(digits[2:4]), int(digits[4:6])
-            rows.append({
-                "ticket_type": COMBO_TICKET_TYPES[ticket_type],
-                "horse_number_1": h1,
-                "horse_number_2": h2,
-                "horse_number_3": h3,
-                "odds": odds_val,
-            })
-        else:
-            h1, h2 = int(digits[0:2]), int(digits[2:4])
-            rows.append({
-                "ticket_type": COMBO_TICKET_TYPES[ticket_type],
-                "horse_number_1": h1,
-                "horse_number_2": h2,
-                "horse_number_3": None,
-                "odds": odds_val,
-            })
+        h1, h2 = int(digits[0:2]), int(digits[2:4])
+        rows.append({
+            "ticket_type": COMBO_TICKET_TYPES[ticket_type],
+            "horse_number_1": h1,
+            "horse_number_2": h2,
+            "horse_number_3": None,
+            "odds": odds_val,
+        })
 
     if not rows:
         return pd.DataFrame(columns=_EMPTY_COMBO_COLUMNS)
@@ -893,10 +939,17 @@ def get_combo_odds(
                     logger.warning(f"未対応の馬券種をスキップ: {ttype}")
                     continue
 
-                url = (
-                    f"{NETKEIBA_BASE_URL}/odds/index.html"
-                    f"?race_id={netkeiba_race_id}&type={ttype}"
-                )
+                # 三連複は housiki=c99 で人気順全件ページを取得する
+                if ttype == "b7":
+                    url = (
+                        f"{NETKEIBA_BASE_URL}/odds/index.html"
+                        f"?type=b7&race_id={netkeiba_race_id}&housiki=c99"
+                    )
+                else:
+                    url = (
+                        f"{NETKEIBA_BASE_URL}/odds/index.html"
+                        f"?race_id={netkeiba_race_id}&type={ttype}"
+                    )
                 logger.debug(f"組み合わせオッズ取得: {url}")
 
                 if i > 0:
@@ -916,7 +969,11 @@ def get_combo_odds(
                     except Exception:
                         pass
 
-                df = _parse_combo_odds_html(html, ttype)
+                # 三連複は ninki-data_N 形式のパーサーを使用
+                if ttype == "b7":
+                    df = _parse_sanrenpuku_ninki_html(html)
+                else:
+                    df = _parse_combo_odds_html(html, ttype)
                 if not df.empty:
                     all_dfs.append(df)
                     logger.debug(

--- a/tests/test_netkeiba_scraper.py
+++ b/tests/test_netkeiba_scraper.py
@@ -28,6 +28,7 @@ from src.automation.data.netkeiba_scraper import (
     _create_page_with_route_block,
     _parse_combo_odds_html,
     _parse_race_list_html,
+    _parse_sanrenpuku_ninki_html,
     _parse_win_place_odds_html,
     get_combo_odds,
     get_today_race_list,
@@ -298,16 +299,11 @@ class TestParseComboOddsHtml:
         assert df.iloc[0]["horse_number_2"] == 2
         assert df.iloc[0]["horse_number_3"] is None
 
-    def test_sanrenpuku_b7(self):
-        """b7 は三連複・6桁（Issue #167 修正: 旧 wide → 正しくは sanrenpuku）"""
+    def test_sanrenpuku_b7_returns_empty(self):
+        """b7（三連複）は _parse_combo_odds_html では処理しない（_parse_sanrenpuku_ninki_html を使用）"""
         html = _make_combo_html("b7", [(1, 2, 3, 12.5)])
         df = _parse_combo_odds_html(html, "b7")
-        assert len(df) == 1
-        assert df.iloc[0]["ticket_type"] == "sanrenpuku"
-        assert df.iloc[0]["horse_number_1"] == 1
-        assert df.iloc[0]["horse_number_2"] == 2
-        assert df.iloc[0]["horse_number_3"] == 3
-        assert df.iloc[0]["odds"] == pytest.approx(12.5)
+        assert df.empty
 
     def test_empty_html(self):
         df = _parse_combo_odds_html("<html><body></body></html>", "b4")
@@ -349,6 +345,88 @@ class TestParseComboOddsHtml:
 
 # ---------------------------------------------------------------------------
 # save_combo_odds_to_bq (BQモック)
+# ---------------------------------------------------------------------------
+# _parse_sanrenpuku_ninki_html
+# ---------------------------------------------------------------------------
+
+
+def _make_sanrenpuku_ninki_html(combos: list[tuple]) -> str:
+    """ninki-data_N 形式の三連複HTMLを生成するヘルパー
+
+    Args:
+        combos: [(h1, h2, h3, odds), ...] の形式
+    """
+    rows = ""
+    for i, (h1, h2, h3, odds) in enumerate(combos, start=1):
+        rows += (
+            f'<tr id="ninki-data_{i}">'
+            f'<td class="Ninki">{i}</td>'
+            f'<td class="Check_Odd"></td>'
+            f'<td>{h1}{h2}{h3}</td>'
+            f'<td class="Name_Odds">{odds}</td>'
+            f'<td>{h1}</td>'
+            f'<td class="Horse_Name Txt_L">馬名{h1}</td>'
+            f'<td>{h2}</td>'
+            f'<td class="Horse_Name Txt_L">馬名{h2}</td>'
+            f'<td>{h3}</td>'
+            f'<td class="Horse_Name Txt_L">馬名{h3}</td>'
+            f'</tr>'
+        )
+    return f"<html><body><table>{rows}</table></body></html>"
+
+
+class TestParseSanrenpukuNinkiHtml:
+    def test_basic(self):
+        """基本的な三連複パースが正常に動作する"""
+        html = _make_sanrenpuku_ninki_html([(1, 5, 6, 14.1), (5, 6, 10, 11.5)])
+        df = _parse_sanrenpuku_ninki_html(html)
+        assert len(df) == 2
+        assert set(df["ticket_type"]) == {"sanrenpuku"}
+
+    def test_horse_numbers_sorted_ascending(self):
+        """馬番は昇順に整列されて保存される"""
+        html = _make_sanrenpuku_ninki_html([(6, 1, 5, 14.1)])
+        df = _parse_sanrenpuku_ninki_html(html)
+        assert df.iloc[0]["horse_number_1"] == 1
+        assert df.iloc[0]["horse_number_2"] == 5
+        assert df.iloc[0]["horse_number_3"] == 6
+
+    def test_odds_value(self):
+        """オッズが正しく取得される"""
+        html = _make_sanrenpuku_ninki_html([(5, 6, 10, 11.5)])
+        df = _parse_sanrenpuku_ninki_html(html)
+        assert df.iloc[0]["odds"] == pytest.approx(11.5)
+
+    def test_filters_odds_lte_1(self):
+        """オッズが1.0以下の行は除外される"""
+        html = _make_sanrenpuku_ninki_html([(1, 2, 3, 1.0), (1, 5, 6, 14.1)])
+        df = _parse_sanrenpuku_ninki_html(html)
+        assert len(df) == 1
+        assert df.iloc[0]["odds"] == pytest.approx(14.1)
+
+    def test_comma_in_odds(self):
+        """カンマ区切りのオッズ（例: 1,234.5）を正しくパースできる"""
+        html = _make_sanrenpuku_ninki_html([(1, 2, 3, "1,234.5")])
+        df = _parse_sanrenpuku_ninki_html(html)
+        assert len(df) == 1
+        assert df.iloc[0]["odds"] == pytest.approx(1234.5)
+
+    def test_empty_html(self):
+        """ninki-data_N が存在しないHTMLは空のDFを返す"""
+        df = _parse_sanrenpuku_ninki_html("<html><body></body></html>")
+        assert df.empty
+        assert list(df.columns) == [
+            "ticket_type", "horse_number_1", "horse_number_2", "horse_number_3", "odds"
+        ]
+
+    def test_multiple_rows(self):
+        """複数行が全件パースされる"""
+        combos = [(1, 2, 3, 10.0), (1, 2, 4, 15.0), (1, 3, 4, 20.0)]
+        html = _make_sanrenpuku_ninki_html(combos)
+        df = _parse_sanrenpuku_ninki_html(html)
+        assert len(df) == 3
+
+
 # ---------------------------------------------------------------------------
 
 
@@ -707,6 +785,39 @@ class TestPlaywrightDomcontentloaded:
         mock_page.goto.assert_called()
         _, kwargs = mock_page.goto.call_args
         assert kwargs.get("wait_until") == "domcontentloaded"
+
+    def test_sanrenpuku_uses_housiki_c99_url(self):
+        """三連複（b7）は housiki=c99 パラメータ付きURLを使うこと"""
+        mock_cm, mock_browser, mock_page = self._make_playwright_mock()
+        visited_urls: list[str] = []
+
+        def capture_goto(url, **kwargs):
+            visited_urls.append(url)
+
+        mock_page.goto.side_effect = capture_goto
+
+        with patch("playwright.sync_api.sync_playwright", return_value=mock_cm):
+            get_combo_odds("202405021211", ticket_types=["b7"], sleep_sec=0)
+
+        assert len(visited_urls) == 1
+        assert "housiki=c99" in visited_urls[0]
+        assert "type=b7" in visited_urls[0]
+
+    def test_umaren_wide_do_not_use_housiki(self):
+        """馬連（b4）・ワイド（b5）は housiki=c99 を使わないこと"""
+        mock_cm, mock_browser, mock_page = self._make_playwright_mock()
+        visited_urls: list[str] = []
+
+        def capture_goto(url, **kwargs):
+            visited_urls.append(url)
+
+        mock_page.goto.side_effect = capture_goto
+
+        with patch("playwright.sync_api.sync_playwright", return_value=mock_cm):
+            get_combo_odds("202405021211", ticket_types=["b4", "b5"], sleep_sec=0)
+
+        for url in visited_urls:
+            assert "housiki" not in url
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 背景

三連複（b7）のnetkeibaスクレイピングURLがデフォルトで**軸馬選択式の流し表示**となっており、`predictions.daily_odds_combo` に **馬1を含む組み合わせしか保存されない**バグが存在していた。

`fetch_combo_odds_for_date` はStage 1（daily_odds_combo）にデータがあるとStage 2（raw.combo_odds）にフォールバックしないため、馬1を含まない組み合わせ（例: 5-6-10）が選定対象外になっていた。

**具体的な事象**: 2026-05-02 東京4R にて、5-6-10（odds=11.5）が1-5-6（odds=14.5）より低オッズであるにも関わらず購入されなかった。

## 変更内容

### `src/automation/data/netkeiba_scraper.py`
- **`_parse_sanrenpuku_ninki_html(html)`** を新規追加
  - `housiki=c99` ページの `tr id="ninki-data_N"` 形式をパース（td[3]=オッズ、td[4/6/8]=馬番）
  - 馬番は昇順ソートして保存
- **`get_combo_odds`**: 三連複（b7）のみ `?type=b7&race_id=...&housiki=c99` URLで取得するよう変更し、`_parse_sanrenpuku_ninki_html` を使用
- **`_parse_combo_odds_html`**: 三連複（b7）の処理を削除（span id 形式では軸馬の流しのみ取得される）

### `scripts/run_strategy.py`
- **`fetch_combo_odds_for_date`**: Stage 1（daily_odds_combo）と Stage 2（raw.combo_odds）を**常にマージ**する方式に変更
  - `housiki=c99` は人気順上位100件の表示上限があるため raw.combo_odds で欠落分を補完
  - 同一組み合わせは daily_odds_combo（netkeibaリアルタイムオッズ）を優先

### `tests/test_netkeiba_scraper.py`
- `TestParseSanrenpukuNinkiHtml` クラスを新規追加（7テスト）
- `test_sanrenpuku_b7_returns_empty`: b7 は `_parse_combo_odds_html` では空を返すことを確認
- `test_sanrenpuku_uses_housiki_c99_url`: b7 URLに `housiki=c99` が含まれることを確認
- `test_umaren_wide_do_not_use_housiki`: b4/b5 は `housiki` を使わないことを確認

## テスト結果

```
62 passed in 0.80s
```

## 動作確認

`housiki=c99` で三連複を取得した際に馬1を含まない64件を含む計100件が正常取得されることをローカルで確認済み。

Closes #254