### PR TITLE
fix: OOSデータによるモデル評価のデータリークを修正 (#258)

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,12 +152,37 @@ python scripts/run_backtest.py \
 グリッドサーチで最適な投資パラメータを探索し、`config/strategy_config.yaml` に保存する。
 **この手順を一度実行するだけで、以降の日次自動実行（手順B）が正しいパラメータで動作する。**
 
+> **⚠️ OOS（アウトオブサンプル）評価の原則**
+> `--start-date` / `--end-date` には、モデルの学習期間・検証期間に**含まれない**日付を指定すること。
+> モデルの学習/検証期間を最適化データに使うと、パラメータが過去の学習データに過適合する（データリーク）。
+> 例: `--execution-date 2025-01-06` で学習した場合 → 検証期間は〜2025-01-06 → `--start-date 2025-01-11` 以降を指定する。
+
+> **⏱️ 実行時間の目安**（データ期間: 約1年、レース数: 約3,200）
+>
+> | グリッドサイズ | 組み合わせ数 | 推定時間 |
+> |---|---|---|
+> デフォルト（`--r-dominant-range` 未指定） | 1,296 | 約8時間 |
+> `--r-dominant-range 1.0 1.2 --r-standard-range 1.0 1.2` | 324 | 約2時間 |
+> `--r-dominant-range 1.0 --r-standard-range 1.0` | 81 | 約30分 |
+>
+> 初回は r 値を固定して p1 × threshold × top_n のみ探索することを推奨。
+
 ```bash
+# 推奨: r 値を固定して高速実行（約30分）
 python3 scripts/run_strategy_optimization.py \
     --project-id <PROJECT_ID> \
     --model-path gs://<PROJECT_ID>-keiba-models/lgbm_ranker/20260301/model.txt \
-    --start-date 2024-01-01 \
-    --end-date 2024-12-31
+    --start-date 2025-01-11 \
+    --end-date 2025-12-31 \
+    --r-dominant-range 1.0 \
+    --r-standard-range 1.0
+
+# フルグリッドサーチ（約8時間）
+python3 scripts/run_strategy_optimization.py \
+    --project-id <PROJECT_ID> \
+    --model-path gs://<PROJECT_ID>-keiba-models/lgbm_ranker/20260301/model.txt \
+    --start-date 2025-01-11 \
+    --end-date 2025-12-31
 ```
 
 #### B. 日次投資戦略策定（手動確認用 / Cloud Schedulerで自動実行）

--- a/config/model_config.yaml
+++ b/config/model_config.yaml
@@ -52,6 +52,12 @@ data:
   categorical_columns:
     - "course_type"
     - "track_condition"
+    - "direction"
+    - "age_condition"
+    - "race_class"
+    - "blinker"
+    - "pace_forecast"
+    - "trainer_affiliation"
 
 # GCS設定
 gcs:

--- a/scripts/run_strategy_optimization.py
+++ b/scripts/run_strategy_optimization.py
@@ -9,23 +9,46 @@ config/strategy_config.yaml に保存する。
   - POST /api/v1/strategy/daily（Cloud Scheduler）
   - scripts/run_strategy.py（手動確認用）
 
+OOS（アウトオブサンプル）評価の原則:
+  --start-date / --end-date にはモデルの学習期間・検証期間に含まれない日付を指定すること。
+  例: --execution-date 2025-01-06 で学習したモデル → 検証期間が ~2025-01-06 で終わるため
+      --start-date 2025-01-11 以降を指定する。
+
+実行時間の目安（データ期間: 約1年、レース数: 約3,200）:
+  - デフォルト（r_dominant 4値 × r_standard 4値）: 1,296 組み合わせ → 約8時間
+  - --r-dominant-range 1.0 --r-standard-range 1.0: 81 組み合わせ → 約30分（推奨）
+  - --r-dominant-range 1.0 1.2 --r-standard-range 1.0 1.2: 324 組み合わせ → 約2時間
+
 Usage:
+    # 推奨: r 値を固定して高速実行（約30分）
     python scripts/run_strategy_optimization.py \\
         --project-id <PROJECT_ID> \\
-        --model-path gs://<PROJECT_ID>-keiba-models/lgbm_ranker/20260301/model.txt \\
-        --start-date 2024-01-01 \\
-        --end-date 2024-12-31
+        --model-path gs://<PROJECT_ID>-keiba-models/lgbm_ranker/20250106/lgbm_ranker_20250106.txt \\
+        --start-date 2025-01-11 \\
+        --end-date 2025-12-31 \\
+        --r-dominant-range 1.0 \\
+        --r-standard-range 1.0
 
-    # 出力ファイルを指定（デフォルト: config/strategy_config.yaml）
+    # フルグリッドサーチ（約8時間）
+    python scripts/run_strategy_optimization.py \\
+        --project-id <PROJECT_ID> \\
+        --model-path gs://<PROJECT_ID>-keiba-models/lgbm_ranker/20250106/lgbm_ranker_20250106.txt \\
+        --start-date 2025-01-11 \\
+        --end-date 2025-12-31
+
+    # 出力ファイルを指定
     python scripts/run_strategy_optimization.py \\
         --project-id <PROJECT_ID> \\
         --model-path <MODEL_PATH> \\
-        --start-date 2024-01-01 \\
-        --end-date 2024-12-31 \\
-        --output-csv results/optimization_2024.csv \\
+        --start-date 2025-01-11 \\
+        --end-date 2025-12-31 \\
+        --r-dominant-range 1.0 \\
+        --r-standard-range 1.0 \\
+        --output-csv results/optimization_oos_2025.csv \\
         --metric recovery_rate
 
 Issue #105: 投資戦略モジュールをバックテストパイプラインに統合
+Issue #258: OOSデータによる評価でのデータリーク修正
 """
 
 from __future__ import annotations
@@ -173,6 +196,12 @@ def main() -> None:
         help="最適化の評価指標（デフォルト: recovery_rate）",
     )
     parser.add_argument("--initial-capital", type=float, default=100_000.0)
+    parser.add_argument(
+        "--budget-per-race",
+        type=float,
+        default=None,
+        help="1レースあたりの固定予算 (円)。デフォルト: strategy_config.yaml の値",
+    )
     parser.add_argument("--output-csv", help="全グリッドサーチ結果のCSV保存先")
     parser.add_argument("--top-n", type=int, default=10, help="上位N件の結果を表示")
     parser.add_argument(
@@ -279,7 +308,10 @@ def main() -> None:
         with open(STRATEGY_CONFIG_PATH) as _f:
             _strategy_cfg = yaml.safe_load(_f) or {}
     min_prob_threshold = float(_strategy_cfg.get("min_prob_threshold", 0.10))
+    budget_per_race = args.budget_per_race if args.budget_per_race is not None else \
+        float(_strategy_cfg.get("budget_per_race", 3000.0))
     logger.info(f"min_prob_threshold={min_prob_threshold} (固定パラメータ)")
+    logger.info(f"budget_per_race={budget_per_race} (固定パラメータ)")
 
     # グリッドサーチ最適化
     optimizer = StrategyOptimizer(
@@ -287,7 +319,7 @@ def main() -> None:
         payouts_df=payouts_df,
         initial_capital=args.initial_capital,
         combo_odds_df=combo_odds_df,
-        budget_per_race=3000.0,
+        budget_per_race=budget_per_race,
     )
     results = optimizer.run_grid_search(
         r_dominant_range=args.r_dominant_range,

--- a/src/models/README.md
+++ b/src/models/README.md
@@ -143,8 +143,8 @@ python3 -m src.models.train --project-id <PROJECT_ID> --tune --n-trials 50
 # チューニング（タイムアウト付き）
 python3 -m src.models.train --project-id <PROJECT_ID> --tune --tune-timeout 3600
 
-# 実行日を指定
-python3 -m src.models.train --project-id <PROJECT_ID> --execution-date 2026-02-15
+# 実行日を指定（OOS評価モデルの作成に使用）
+python3 -m src.models.train --project-id <PROJECT_ID> --execution-date 2025-01-06
 
 # カスタム設定ファイル
 python3 -m src.models.train --project-id <PROJECT_ID> --config ./my_config.yaml
@@ -152,6 +152,24 @@ python3 -m src.models.train --project-id <PROJECT_ID> --config ./my_config.yaml
 # 詳細ログ
 python3 -m src.models.train --project-id <PROJECT_ID> -v
 ```
+
+> **`--execution-date` とデータ分割の関係**
+>
+> `--execution-date YYYY-MM-DD` を指定すると、学習/検証/推論期間が以下のように決まる:
+>
+> | 期間 | 範囲 |
+> |---|---|
+> | 推論対象 | 指定日の週の土日 |
+> | 検証（Valid） | 推論対象の前日 〜 その6ヶ月前 |
+> | 学習（Train） | それ以前の全データ |
+>
+> **OOS（アウトオブサンプル）評価用モデルを作る場合**: バックテストや戦略最適化で使いたいデータ期間よりも前の日付を `--execution-date` に指定すること。  
+> 例: 2025年データで評価したい場合 → `--execution-date 2025-01-06`（検証期間が〜2025-01-06 で終わり、2025-01-11 以降がOOS）
+
+> **`finish_position` ラベルの取得元**
+>
+> `features.training_data` の `finish_position` 列は常に NULL のため、学習ラベルは `raw.race_results` テーブルから直接 JOIN して取得する。  
+> 推論時（未来のレース）はラベルが存在しないが、推論には `finish_position` を使用しないため問題ない。
 
 ---
 

--- a/src/models/lgbm_ranker.py
+++ b/src/models/lgbm_ranker.py
@@ -52,6 +52,7 @@ class LGBMRanker:
         self.config = config or LGBMRankerConfig()
         self.model: lgb.Booster | None = None
         self.feature_names: list[str] | None = None
+        self._categorical_feature_names: list[str] = []
 
     def train(
         self,
@@ -142,8 +143,9 @@ class LGBMRanker:
         """
         予測用にDataFrameをモデルの期待に合わせて整形する
 
-        1. モデルの特徴量名でフィルタ（学習後に追加されたカラムを除外）
-        2. object型カラムをcategory型に変換（LightGBMのpandas_categoricalと整合）
+        1. モデルの全特徴量を揃える（不足列はNaNで補完）
+        2. カテゴリカル特徴量を学習時のカテゴリ情報で category 型に変換
+           （pandas_categorical の数とカテゴリ型カラム数を一致させる）
 
         Args:
             X: 特徴量DataFrame
@@ -153,19 +155,24 @@ class LGBMRanker:
         """
         model_feature_names = self.feature_names or self.model.feature_name()
 
-        # モデルの特徴量名でフィルタ
-        available = [c for c in model_feature_names if c in X.columns]
         missing = [c for c in model_feature_names if c not in X.columns]
         if missing:
             logger.warning(f"モデルの特徴量がデータに不足: {missing}")
 
-        X_pred = X[available].copy()
+        # 不足特徴量をNaNで補完し、余剰カラムを除外してモデル順に並べ替え
+        X_pred = X.reindex(columns=model_feature_names)
 
-        # object型（文字列）カラムをcategory型に変換
-        # LightGBMはpandas_categoricalの数とcategory型カラム数が
-        # 一致しないとエラーになるため、全object型をcategory型に変換する
+        # カテゴリカル特徴量を学習時のカテゴリ情報で変換
+        # （不足特徴量がある場合でもpandas_categoricalの数を合わせる）
+        model_cats = getattr(self.model, "pandas_categorical", [])
+        for col, cats in zip(self._categorical_feature_names, model_cats):
+            dtype = pd.CategoricalDtype(categories=cats)
+            X_pred[col] = X_pred[col].astype(dtype)
+
+        # 残りのobject型カラムをcategory型に変換
         for col in X_pred.select_dtypes(include="object").columns:
-            X_pred[col] = X_pred[col].astype("category")
+            if not pd.api.types.is_categorical_dtype(X_pred[col]):
+                X_pred[col] = X_pred[col].astype("category")
 
         return X_pred
 
@@ -208,6 +215,9 @@ class LGBMRanker:
 
         self.model = lgb.Booster(model_file=str(model_path))
 
+        # カテゴリカル特徴量情報をモデルファイルからパースしてキャッシュ
+        self._categorical_feature_names = self._parse_categorical_feature_names(model_path)
+
         # メタデータを読み込み
         meta_path = model_path.with_suffix(".meta.json")
         if meta_path.exists():
@@ -220,6 +230,27 @@ class LGBMRanker:
         else:
             self.feature_names = self.model.feature_name()
             logger.info(f"Model loaded from {model_path} (no metadata)")
+
+    def _parse_categorical_feature_names(self, model_path: Path) -> list[str]:
+        """
+        モデルファイルの [categorical_feature: ...] 行からカテゴリカル特徴量名を取得する
+
+        LightGBMはモデルファイルのヘッダーにカテゴリカル特徴量のインデックスを保存する。
+        これとfeature_name()を組み合わせて特徴量名リストを返す。
+        """
+        feature_names = self.model.feature_name()
+        with open(model_path) as f:
+            for line in f:
+                line = line.strip()
+                if line.startswith("[categorical_feature:"):
+                    content = line.split(":", 1)[1].strip().rstrip("]").strip()
+                    if not content or content == "none":
+                        return []
+                    indices = [int(x.strip()) for x in content.split(",")]
+                    return [feature_names[i] for i in indices]
+                if line.startswith("[Tree"):
+                    break
+        return []
 
     def feature_importance(self, importance_type: str = "gain") -> pd.DataFrame:
         """

--- a/src/models/lgbm_ranker.py
+++ b/src/models/lgbm_ranker.py
@@ -117,6 +117,11 @@ class LGBMRanker:
             ],
         )
 
+        # train() → predict() フローでも _align_for_predict が正しく動くよう
+        # カテゴリカル特徴量名を保持する
+        if categorical_feature:
+            self._categorical_feature_names = list(categorical_feature)
+
         logger.info(
             f"Training completed: best_iteration={self.model.best_iteration}"
         )

--- a/src/models/train.py
+++ b/src/models/train.py
@@ -76,7 +76,10 @@ def fetch_training_data(
     table: str,
 ) -> pd.DataFrame:
     """
-    BigQueryからtraining_dataを取得する
+    BigQueryからtraining_dataを取得し、raw.race_resultsからfinish_positionラベルをJOINして返す
+
+    features.training_data の finish_position 列は全 NULL のため、
+    学習ラベルは raw.race_results から直接取得する。
 
     Args:
         project_id: GCPプロジェクトID
@@ -84,13 +87,18 @@ def fetch_training_data(
         table: テーブル名
 
     Returns:
-        全データのDataFrame
+        finish_position ラベル付きの全データDataFrame
     """
     client = bigquery.Client(project=project_id)
     query = f"""
-    SELECT *
-    FROM `{project_id}.{dataset}.{table}`
-    ORDER BY race_date, race_id, horse_number
+    SELECT
+        t.* EXCEPT(finish_position),
+        r_r.finish_position
+    FROM `{project_id}.{dataset}.{table}` AS t
+    LEFT JOIN `{project_id}.raw.race_results` AS r_r
+        ON t.race_id = r_r.race_id
+        AND t.horse_number = r_r.horse_number
+    ORDER BY t.race_date, t.race_id, t.horse_number
     """
     logger.info(f"Fetching data from {project_id}.{dataset}.{table}...")
     df = client.query(query).to_dataframe()
@@ -180,9 +188,15 @@ def build_feature_matrix(
     Returns:
         特徴量のDataFrame
     """
+    # exclude_columns に加え、数値型でもカテゴリカル指定でもない列（文字列・日付等）を自動除外
+    # BigQuery Storage API は文字列列を object 型で返すため明示的なフィルタが必要
     feature_cols = [
         c for c in df.columns
         if c not in exclude_columns
+        and (
+            pd.api.types.is_numeric_dtype(df[c])
+            or c in categorical_columns
+        )
     ]
 
     X = df[feature_cols].copy()
@@ -214,8 +228,9 @@ def prepare_features(
     X = build_feature_matrix(df, exclude_columns, categorical_columns)
 
     # ラベル: 3着以内=1, それ以外=0 の二値ラベル
-    # finish_position=0（出走取消等）は0として扱う
-    positions = df["finish_position"].values.astype(int)
+    # finish_position=0（出走取消等）またはNULL（欠損）は0として扱う
+    # BigQuery Storageモジュール経由だとNullable Int64で返るためfillna(0)が必要
+    positions = df["finish_position"].fillna(0).values.astype(int)
     y = np.where((positions >= 1) & (positions <= 3), 1, 0)
 
     # グループサイズ（各レースの馬数）
@@ -456,7 +471,7 @@ def train_pipeline(
     # 6. 検証データで評価
     valid_pred = ranker.predict(X_valid)
     metrics = evaluate_predictions(
-        y_true_positions=valid_df["finish_position"].values,
+        y_true_positions=valid_df["finish_position"].fillna(0).values.astype(int),
         y_pred=valid_pred,
         groups=groups_valid,
     )


### PR DESCRIPTION
## Summary

- **根本原因**: `features.training_data.finish_position` が常に NULL のため、従来の学習は全ゼロラベルで縮退モデル（NDCG=1.0, AUC=0.0, best_iteration=1）を生成していた
- **修正**: `fetch_training_data` で `raw.race_results` を LEFT JOIN し、実際の着順をラベルとして取得
- **OOSモデル**: `--execution-date 2025-01-06` で再学習 → best_iteration=145, NDCG@3=0.56, AUC=0.80（正常）
- **OOSバックテスト**: 2025-01-11〜2025-12-31 の真のOOSデータで評価 → 回収率 95.7%（リーク汚染なし）

## 変更一覧

| ファイル | 変更内容 |
|---|---|
| `src/models/train.py` | `fetch_training_data` で `raw.race_results` JOIN によるラベル取得、BQ Storage API 互換性修正 |
| `src/models/lgbm_ranker.py` | `_align_for_predict` の堅牢化（reindex + モデルファイルからカテゴリ情報復元） |
| `config/model_config.yaml` | `categorical_columns` に `direction` 等6列を追加 |
| `scripts/run_strategy_optimization.py` | `--budget-per-race` CLI引数追加、OOS 実行コマンド例と実行時間目安をdocstringに追記 |
| `README.md` | 戦略最適化コマンド例に OOS 原則・実行時間目安を追加 |
| `src/models/README.md` | `--execution-date` とデータ分割範囲の対応表、ラベル取得元の説明を追加 |

## 戦略最適化の実行時間（重要）

デフォルトグリッドは **約8時間** かかる。初回は以下の短縮コマンドを推奨：

```bash
python scripts/run_strategy_optimization.py \
    --project-id <PROJECT_ID> \
    --model-path gs://<PROJECT_ID>-keiba-models/lgbm_ranker/20250106/lgbm_ranker_20250106.txt \
    --start-date 2025-01-11 \
    --end-date 2025-12-31 \
    --r-dominant-range 1.0 \
    --r-standard-range 1.0
```

## Test plan

- [x] 107テスト通過（`tests/test_backtest_*.py`, `tests/test_lgbm_ranker.py`, `tests/test_run_strategy.py`）
- [x] OOSモデル学習（`--execution-date 2025-01-06`）: best_iteration=145, AUC=0.8046
- [x] OOSバックテスト（2025-01-11〜2025-12-31）: 回収率 95.7%

🤖 Generated with [Claude Code](https://claude.com/claude-code)