### PR TITLE
feat: min_prob_threshold を全馬共通ハイパーパラメータとして最適化対象に追加 (#261)

### DIFF
--- a/scripts/run_strategy_optimization.py
+++ b/scripts/run_strategy_optimization.py
@@ -147,6 +147,7 @@ def save_best_params_to_yaml(
     config["expected_return_threshold"] = best.params["expected_return_threshold"]
     config["top_n"] = best.params["top_n"]
     config["prob_weight_r"] = best.params["prob_weight_r"]
+    config["min_prob_threshold"] = best.params["min_prob_threshold"]
     # 廃止済みパラメータを削除（存在する場合）
     for key in ["p1", "top_n_dominant", "top_n_standard", "prob_weight_r_dominant",
                 "prob_weight_r_standard", "threshold_dominant", "threshold_standard"]:
@@ -169,7 +170,8 @@ def save_best_params_to_yaml(
     logger.info(
         f"  expected_return_threshold={best.params['expected_return_threshold']}, "
         f"top_n={best.params['top_n']}, "
-        f"prob_weight_r={best.params['prob_weight_r']}"
+        f"prob_weight_r={best.params['prob_weight_r']}, "
+        f"min_prob_threshold={best.params['min_prob_threshold']}"
     )
     logger.info(f"  回収率={best.recovery_rate:.2f}%, 的中率={best.hit_rate:.2f}%, "
                 f"最大ドローダウン={best.max_drawdown:.2f}%")
@@ -218,6 +220,13 @@ def main() -> None:
         nargs="+",
         default=None,
         help="top_n の探索値（複数指定可、デフォルト: 2 3 4 5）",
+    )
+    parser.add_argument(
+        "--min-prob-threshold-range",
+        type=float,
+        nargs="+",
+        default=None,
+        help="min_prob_threshold の探索値（複数指定可）。指定時は4次元グリッドサーチ。未指定時は strategy_config.yaml の固定値を使用",
     )
     args = parser.parse_args()
 
@@ -307,7 +316,10 @@ def main() -> None:
     min_prob_threshold = float(_strategy_cfg.get("min_prob_threshold", 0.10))
     budget_per_race = args.budget_per_race if args.budget_per_race is not None else \
         float(_strategy_cfg.get("budget_per_race", 3000.0))
-    logger.info(f"min_prob_threshold={min_prob_threshold} (固定パラメータ)")
+    if args.min_prob_threshold_range is not None:
+        logger.info(f"min_prob_threshold_range={args.min_prob_threshold_range} (探索パラメータ)")
+    else:
+        logger.info(f"min_prob_threshold={min_prob_threshold} (固定パラメータ)")
     logger.info(f"budget_per_race={budget_per_race} (固定パラメータ)")
 
     # グリッドサーチ最適化
@@ -322,6 +334,7 @@ def main() -> None:
         threshold_range=args.threshold_range,
         top_n_range=args.top_n_range,
         r_range=args.r_range,
+        min_prob_threshold_range=args.min_prob_threshold_range,
         min_prob_threshold=min_prob_threshold,
     )
 

--- a/src/backtest/strategy_optimizer.py
+++ b/src/backtest/strategy_optimizer.py
@@ -326,6 +326,8 @@ class StrategyOptimizer:
         threshold_range: list[float] | None = None,
         top_n_range: list[int] | None = None,
         r_range: list[float] | None = None,
+        min_prob_threshold_range: list[float] | None = None,
+        # 後方互換性: min_prob_threshold_range が None の場合に使用する固定値
         min_prob_threshold: float = 0.0,
         # 後方互換性のための旧パラメータ（無視される）
         p1_range: list[float] | None = None,
@@ -337,17 +339,22 @@ class StrategyOptimizer:
         """
         グリッドサーチを実行し、全パラメータ組み合わせのバックテスト結果を返す
 
-        デフォルト探索範囲:
+        デフォルト探索範囲（min_prob_threshold_range=None の場合）:
           - threshold:  [1.2, 1.35, 1.5, 1.75]  （期待回収率閾値）
           - top_n:      [2, 3, 4, 5]             （候補馬数）
           - r:          [0.6, 0.8, 1.0, 1.2, 1.5]（prob_weight_r）
         総組み合わせ数: 4×4×5 = 80通り
 
+        min_prob_threshold_range を指定した場合は4次元サーチになる:
+          - threshold × top_n × r × min_prob 全組み合わせを探索
+
         Args:
             threshold_range: 期待回収率閾値の探索値リスト
             top_n_range: 候補馬数の探索値リスト
             r_range: prob_weight_r の探索値リスト
-            min_prob_threshold: 軸馬の最低複勝率（固定パラメータ。全組み合わせで共通適用）
+            min_prob_threshold_range: 全候補馬共通の最低複勝率の探索値リスト。
+                None の場合は min_prob_threshold 固定値を全組み合わせに適用（後方互換）
+            min_prob_threshold: min_prob_threshold_range=None 時の固定値（後方互換）
             p1_range: 廃止済み（無視される）
             top_n_dominant_range: 廃止済み（無視される）
             top_n_standard_range: 廃止済み（無視される）
@@ -368,29 +375,39 @@ class StrategyOptimizer:
         if r_range is None:
             r_range = [0.6, 0.8, 1.0, 1.2, 1.5]
 
-        # 全パラメータ組み合わせを生成
-        param_grid = list(product(threshold_range, top_n_range, r_range))
-
-        total = len(param_grid)
-        logger.info(f"グリッドサーチ開始: {total} パラメータ組み合わせ (min_prob_threshold={min_prob_threshold})")
+        # min_prob_threshold_range が指定された場合のみ4次元グリッドサーチ
+        if min_prob_threshold_range is not None:
+            param_grid = list(product(threshold_range, top_n_range, r_range, min_prob_threshold_range))
+            total = len(param_grid)
+            logger.info(
+                f"グリッドサーチ開始: {total} パラメータ組み合わせ "
+                f"(threshold×top_n×r×min_prob = "
+                f"{len(threshold_range)}×{len(top_n_range)}×{len(r_range)}×{len(min_prob_threshold_range)})"
+            )
+        else:
+            param_grid_3d = list(product(threshold_range, top_n_range, r_range))
+            param_grid = [(th, tn, r, min_prob_threshold) for th, tn, r in param_grid_3d]
+            total = len(param_grid)
+            logger.info(f"グリッドサーチ開始: {total} パラメータ組み合わせ (min_prob_threshold={min_prob_threshold} 固定)")
 
         results: list[OptimizationResult] = []
 
-        for i, (th, tn, r) in enumerate(param_grid):
+        for i, (th, tn, r, mpt) in enumerate(param_grid):
             params = {
                 "expected_return_threshold": th,
                 "top_n": tn,
                 "prob_weight_r": r,
+                "min_prob_threshold": mpt,
             }
 
             if (i + 1) % 20 == 0 or (i + 1) == total:
                 logger.info(
-                    f"  [{i + 1}/{total}] th={th} top_n={tn} r={r}"
+                    f"  [{i + 1}/{total}] th={th} top_n={tn} r={r} min_prob={mpt}"
                 )
 
             history_df, pattern_stats = self._run_simulation(
                 expected_return_threshold=th,
-                min_prob_threshold=min_prob_threshold,
+                min_prob_threshold=mpt,
                 prob_weight_r=r,
                 top_n=tn,
             )

--- a/tests/test_backtest_strategy_optimizer.py
+++ b/tests/test_backtest_strategy_optimizer.py
@@ -233,7 +233,7 @@ class TestStrategyOptimizerRunGridSearch:
         assert len(results) == 80  # 4×4×5
 
     def test_grid_search_results_have_params(self):
-        """各結果に expected_return_threshold / top_n / prob_weight_r が含まれる（p1 は含まれない）"""
+        """各結果に expected_return_threshold / top_n / prob_weight_r / min_prob_threshold が含まれる"""
         df = _make_predictions_df(n_races=2, n_horses=5, win_place_prob=0.5, odds=3.0)
         optimizer = StrategyOptimizer(df, None, combo_odds_df=None)
         results = optimizer.run_grid_search()
@@ -241,6 +241,7 @@ class TestStrategyOptimizerRunGridSearch:
             assert "expected_return_threshold" in r.params
             assert "top_n" in r.params
             assert "prob_weight_r" in r.params
+            assert "min_prob_threshold" in r.params
             # 旧パラメータは含まれない
             assert "p1" not in r.params
             assert "p2" not in r.params
@@ -256,6 +257,46 @@ class TestStrategyOptimizerRunGridSearch:
             r_range=[1.0],
         )
         assert len(results) == 6  # threshold(3)×top_n(2)×r(1)
+
+    def test_min_prob_threshold_range_creates_4d_grid(self):
+        """Issue #261: min_prob_threshold_range 指定で4次元グリッドサーチになる"""
+        df = _make_predictions_df(n_races=2, n_horses=5, win_place_prob=0.5, odds=3.0)
+        optimizer = StrategyOptimizer(df, None, combo_odds_df=None)
+        results = optimizer.run_grid_search(
+            threshold_range=[1.0, 1.2],
+            top_n_range=[3],
+            r_range=[1.0],
+            min_prob_threshold_range=[0.0, 0.1, 0.2],
+        )
+        assert len(results) == 6  # threshold(2)×top_n(1)×r(1)×min_prob(3)
+
+    def test_min_prob_threshold_range_stored_in_params(self):
+        """Issue #261: min_prob_threshold が params に含まれ探索値が正しく記録される"""
+        df = _make_predictions_df(n_races=2, n_horses=5, win_place_prob=0.5, odds=3.0)
+        optimizer = StrategyOptimizer(df, None, combo_odds_df=None)
+        results = optimizer.run_grid_search(
+            threshold_range=[1.0],
+            top_n_range=[3],
+            r_range=[1.0],
+            min_prob_threshold_range=[0.0, 0.15],
+        )
+        mpt_values = {r.params["min_prob_threshold"] for r in results}
+        assert mpt_values == {0.0, 0.15}
+
+    def test_min_prob_threshold_fixed_when_range_is_none(self):
+        """min_prob_threshold_range=None の場合は固定値が全結果に適用される"""
+        df = _make_predictions_df(n_races=2, n_horses=5, win_place_prob=0.5, odds=3.0)
+        optimizer = StrategyOptimizer(df, None, combo_odds_df=None)
+        results = optimizer.run_grid_search(
+            threshold_range=[1.0, 1.2],
+            top_n_range=[3],
+            r_range=[1.0],
+            min_prob_threshold_range=None,
+            min_prob_threshold=0.1,
+        )
+        assert len(results) == 2  # threshold(2)×top_n(1)×r(1)（min_prob次元は追加されない）
+        for r in results:
+            assert r.params["min_prob_threshold"] == 0.1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `StrategyOptimizer.run_grid_search` に `min_prob_threshold_range` 引数を追加し、全馬共通の最低複勝率フィルタをハイパーパラメータ最適化の対象として加えた
- `--min-prob-threshold-range` 指定時は `threshold × top_n × r × min_prob` の4次元グリッドサーチを実行。未指定時は従来の固定値動作（後方互換）
- `params` 辞書に `min_prob_threshold` を常に記録し、`strategy_config.yaml` への保存にも対応

## Changes
- `src/backtest/strategy_optimizer.py`: `run_grid_search` に `min_prob_threshold_range` 追加、4次元グリッド対応
- `scripts/run_strategy_optimization.py`: `--min-prob-threshold-range` CLIフラグと YAML 保存処理を追加
- `tests/test_backtest_strategy_optimizer.py`: 新テスト3件追加（全27件 PASS）

## Test plan
- [ ] `pytest tests/test_backtest_strategy_optimizer.py` が 27件 PASS すること
- [ ] `min_prob_threshold_range` 未指定時はデフォルト80通り（後方互換）
- [ ] `min_prob_threshold_range=[0.0, 0.1, 0.2]` 指定時はグリッド数が3倍になること

Closes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)