### PR TITLE
feat: max_wide_odds ワイドオッズ上限フィルタをハイパーパラメータとして追加 (#262)

### DIFF
--- a/config/strategy_config.yaml
+++ b/config/strategy_config.yaml
@@ -4,6 +4,7 @@ budget_per_race: 1000
 min_bet_amount: 100
 min_prob_threshold: 0.1
 top_n: 2
+max_wide_odds: 50.0
 optimization:
   last_run: '2026-05-04T18:20:51'
   metric: recovery_rate

--- a/scripts/run_backtest.py
+++ b/scripts/run_backtest.py
@@ -659,6 +659,7 @@ def run_full_strategy_backtest_pipeline(
     expected_return_threshold: float = 1.2,
     prob_weight_r: float = 1.0,
     top_n: int = 5,
+    max_wide_odds: float | None = None,
     initial_capital: float = 100_000.0,
     output_csv: str | None = None,
     save_bq: bool = False,
@@ -689,6 +690,7 @@ def run_full_strategy_backtest_pipeline(
         expected_return_threshold: 期待回収率閾値
         prob_weight_r: 選定スコア係数 (score = odds * prob^r)
         top_n: 候補馬数
+        max_wide_odds: ワイド購入の上限オッズ（None で無制限）
         initial_capital: 初期資金 (円)
         output_csv: CSV 出力パス (None でスキップ)
         save_bq: BigQuery 保存フラグ
@@ -782,6 +784,7 @@ def run_full_strategy_backtest_pipeline(
         min_prob_threshold=min_prob_threshold,
         prob_weight_r=prob_weight_r,
         top_n=top_n,
+        max_wide_odds=max_wide_odds,
     )
 
     # 6. 評価指標計算
@@ -905,6 +908,13 @@ def main() -> int:
         dest="top_n",
         help="ワイド/三連複/馬連の候補馬数。指定時はYAMLの値より優先",
     )
+    parser.add_argument(
+        "--max-wide-odds",
+        type=float,
+        default=None,
+        dest="max_wide_odds",
+        help="ワイド購入の上限オッズ（指定時はYAMLの値より優先。未指定はYAML値、YAMLに未設定なら無制限）",
+    )
     parser.add_argument("--verbose", "-v", action="store_true", help="詳細ログ")
 
     args = parser.parse_args()
@@ -944,6 +954,9 @@ def main() -> int:
     top_n = args.top_n if args.top_n is not None else int(strategy_cfg.get("top_n", 5))
     prob_weight_r = args.prob_weight_r if args.prob_weight_r is not None else \
         float(strategy_cfg.get("prob_weight_r", 1.0))
+    _yaml_mwo = strategy_cfg.get("max_wide_odds", None)
+    max_wide_odds = args.max_wide_odds if args.max_wide_odds is not None else \
+        (float(_yaml_mwo) if _yaml_mwo is not None else None)
 
     print(f"\nバックテスト設定:")
     print(f"  期間:                          {start_date} ~ {end_date}")
@@ -954,6 +967,7 @@ def main() -> int:
     print(f"  1レースあたり予算:             ¥{budget:,.0f}")
     print(f"  min_prob_threshold:            {min_prob}")
     print(f"  prob_weight_r:                 {prob_weight_r}")
+    print(f"  max_wide_odds:                 {max_wide_odds if max_wide_odds is not None else '無制限'}")
 
     history_df, metrics = run_full_strategy_backtest_pipeline(
         project_id=args.project_id,
@@ -966,6 +980,7 @@ def main() -> int:
         expected_return_threshold=expected_return_threshold,
         prob_weight_r=prob_weight_r,
         top_n=top_n,
+        max_wide_odds=max_wide_odds,
         initial_capital=args.initial_capital,
         output_csv=args.output_csv,
         save_bq=args.save_to_bq,

--- a/scripts/run_strategy.py
+++ b/scripts/run_strategy.py
@@ -450,6 +450,8 @@ def run_daily_strategy(
     min_bet_amount = config.get("min_bet_amount", 100.0)
     min_prob_threshold = config.get("min_prob_threshold", 0.10)
     prob_weight_r = float(config.get("prob_weight_r", 1.0))
+    _mwo = config.get("max_wide_odds", None)
+    max_wide_odds = float(_mwo) if _mwo is not None else None
 
     opt = config.get("optimization", {})
     logger.info(f"=== 日次投資戦略策定 ({target_date}) ===")
@@ -457,7 +459,7 @@ def run_daily_strategy(
         f"パラメータ: expected_return_threshold={expected_return_threshold}, "
         f"top_n={top_n}, budget_per_race={budget_per_race}, "
         f"min_bet_amount={min_bet_amount}, min_prob_threshold={min_prob_threshold}, "
-        f"prob_weight_r={prob_weight_r}"
+        f"prob_weight_r={prob_weight_r}, max_wide_odds={max_wide_odds}"
     )
     if opt.get("last_run"):
         logger.info(f"最終最適化: {opt['last_run']} "
@@ -505,6 +507,7 @@ def run_daily_strategy(
                 min_prob_threshold=min_prob_threshold,
                 prob_weight_r=prob_weight_r,
                 top_n=top_n,
+                max_wide_odds=max_wide_odds,
             )
         except ValueError as e:
             logger.debug(f"レース {race_id} スキップ: {e}")

--- a/scripts/run_strategy_optimization.py
+++ b/scripts/run_strategy_optimization.py
@@ -148,6 +148,7 @@ def save_best_params_to_yaml(
     config["top_n"] = best.params["top_n"]
     config["prob_weight_r"] = best.params["prob_weight_r"]
     config["min_prob_threshold"] = best.params["min_prob_threshold"]
+    config["max_wide_odds"] = best.params.get("max_wide_odds", None)
     # 廃止済みパラメータを削除（存在する場合）
     for key in ["p1", "top_n_dominant", "top_n_standard", "prob_weight_r_dominant",
                 "prob_weight_r_standard", "threshold_dominant", "threshold_standard"]:
@@ -171,7 +172,8 @@ def save_best_params_to_yaml(
         f"  expected_return_threshold={best.params['expected_return_threshold']}, "
         f"top_n={best.params['top_n']}, "
         f"prob_weight_r={best.params['prob_weight_r']}, "
-        f"min_prob_threshold={best.params['min_prob_threshold']}"
+        f"min_prob_threshold={best.params['min_prob_threshold']}, "
+        f"max_wide_odds={best.params.get('max_wide_odds', None)}"
     )
     logger.info(f"  回収率={best.recovery_rate:.2f}%, 的中率={best.hit_rate:.2f}%, "
                 f"最大ドローダウン={best.max_drawdown:.2f}%")
@@ -227,6 +229,13 @@ def main() -> None:
         nargs="+",
         default=None,
         help="min_prob_threshold の探索値（複数指定可）。指定時は4次元グリッドサーチ。未指定時は strategy_config.yaml の固定値を使用",
+    )
+    parser.add_argument(
+        "--max-wide-odds-range",
+        type=str,
+        nargs="+",
+        default=None,
+        help="max_wide_odds の探索値（複数指定可、'None' で無制限を探索可）。例: --max-wide-odds-range 30 50 80 None",
     )
     args = parser.parse_args()
 
@@ -316,10 +325,25 @@ def main() -> None:
     min_prob_threshold = float(_strategy_cfg.get("min_prob_threshold", 0.10))
     budget_per_race = args.budget_per_race if args.budget_per_race is not None else \
         float(_strategy_cfg.get("budget_per_race", 3000.0))
+    _yaml_mwo = _strategy_cfg.get("max_wide_odds", None)
+    max_wide_odds_fixed = float(_yaml_mwo) if _yaml_mwo is not None else None
+
+    # --max-wide-odds-range 引数を float | None のリストに変換
+    max_wide_odds_range: list[float | None] | None = None
+    if args.max_wide_odds_range is not None:
+        max_wide_odds_range = [
+            None if v.lower() == "none" else float(v)
+            for v in args.max_wide_odds_range
+        ]
+
     if args.min_prob_threshold_range is not None:
         logger.info(f"min_prob_threshold_range={args.min_prob_threshold_range} (探索パラメータ)")
     else:
         logger.info(f"min_prob_threshold={min_prob_threshold} (固定パラメータ)")
+    if max_wide_odds_range is not None:
+        logger.info(f"max_wide_odds_range={max_wide_odds_range} (探索パラメータ)")
+    else:
+        logger.info(f"max_wide_odds={max_wide_odds_fixed} (固定パラメータ)")
     logger.info(f"budget_per_race={budget_per_race} (固定パラメータ)")
 
     # グリッドサーチ最適化
@@ -336,6 +360,8 @@ def main() -> None:
         r_range=args.r_range,
         min_prob_threshold_range=args.min_prob_threshold_range,
         min_prob_threshold=min_prob_threshold,
+        max_wide_odds_range=max_wide_odds_range,
+        max_wide_odds=max_wide_odds_fixed,
     )
 
     if not results:

--- a/src/automation/api/app.py
+++ b/src/automation/api/app.py
@@ -1377,6 +1377,8 @@ def _refresh_investment_decisions_for_race(
         min_bet_amount = float(config.get("min_bet_amount", 100.0))
         min_prob_threshold = float(config.get("min_prob_threshold", 0.10))
         prob_weight_r = float(config.get("prob_weight_r", 1.0))
+        _mwo = config.get("max_wide_odds", None)
+        max_wide_odds = float(_mwo) if _mwo is not None else None
 
         # 推奨馬券を再計算
         bets = select_bets_for_race(
@@ -1388,6 +1390,7 @@ def _refresh_investment_decisions_for_race(
             min_prob_threshold=min_prob_threshold,
             prob_weight_r=prob_weight_r,
             top_n=top_n,
+            max_wide_odds=max_wide_odds,
         )
 
         # 投資判断 dict を構築して MERGE UPSERT 保存

--- a/src/backtest/strategy.py
+++ b/src/backtest/strategy.py
@@ -69,6 +69,7 @@ def select_base_bets(
     top_n: int = 5,
     min_prob_threshold: float = 0.0,
     prob_weight_r: float = 1.0,
+    max_wide_odds: float | None = None,
 ) -> list[dict]:
     """
     複勝/ワイド/三連複/馬連の候補を選定する（配分前）
@@ -89,6 +90,8 @@ def select_base_bets(
             複勝単体買いだけでなく、ワイド・三連複の候補馬（top_n）にも同フィルタを適用する。
         prob_weight_r: 選定スコアの確率ウェイト係数。スコア = odds * prob^r
             r=1 で通常の期待値と同等。r>1 で高確率馬が有利になる
+        max_wide_odds: ワイド購入の上限オッズ。これを超えるワイドはスキップ（馬連も連動スキップ）。
+            None の場合は上限なし
 
     Returns:
         bet dict のリスト（bet_amount は未設定）
@@ -157,6 +160,8 @@ def select_base_bets(
             prob_i = float(top_prob_map.get(h1, 0))
             prob_j = float(top_prob_map.get(h2, 0))
             wide_odds = float(row["odds_value"])
+            if max_wide_odds is not None and wide_odds > max_wide_odds:
+                continue
             if prob_i * prob_j * wide_odds > expected_return_threshold:
                 pair = tuple(sorted([h1, h2]))
                 combo_bets.append({
@@ -222,6 +227,7 @@ def select_bets_for_race(
     top_n: int = 5,
     min_prob_threshold: float = 0.0,
     prob_weight_r: float = 1.0,
+    max_wide_odds: float | None = None,
     # 後方互換性のための旧パラメータ（無視される）
     p1: float | None = None,
     top_n_dominant: int | None = None,
@@ -247,6 +253,7 @@ def select_bets_for_race(
         top_n: ワイド/三連複/馬連の候補数
         min_prob_threshold: 軸馬の最低複勝率（複勝単体買いの最低条件）
         prob_weight_r: 選定スコアの確率ウェイト係数（odds * prob^r）
+        max_wide_odds: ワイド購入の上限オッズ（None で無制限）。馬連も連動してスキップ
         p1: 廃止済み（無視される）
         top_n_dominant: 廃止済み（無視される）
         top_n_standard: 廃止済み（無視される）
@@ -287,6 +294,7 @@ def select_bets_for_race(
         top_n=top_n,
         min_prob_threshold=min_prob_threshold,
         prob_weight_r=prob_weight_r,
+        max_wide_odds=max_wide_odds,
     )
 
     # 同一 (bet_type, horse_numbers) の重複排除（先着優先）

--- a/src/backtest/strategy_optimizer.py
+++ b/src/backtest/strategy_optimizer.py
@@ -144,6 +144,7 @@ class StrategyOptimizer:
         min_prob_threshold: float = 0.0,
         prob_weight_r: float = 1.0,
         top_n: int = 5,
+        max_wide_odds: float | None = None,
         # 後方互換性のための旧パラメータ（無視される）
         p1: float | None = None,
         prob_weight_r_dominant: float | None = None,
@@ -160,6 +161,7 @@ class StrategyOptimizer:
             min_prob_threshold: 軸馬の最低複勝率
             prob_weight_r: 選定スコアの確率ウェイト係数
             top_n: 候補馬数
+            max_wide_odds: ワイド購入の上限オッズ（None で無制限）
 
         Returns:
             (history_df, pattern_stats) のタプル:
@@ -221,6 +223,7 @@ class StrategyOptimizer:
                     min_prob_threshold=min_prob_threshold,
                     prob_weight_r=prob_weight_r,
                     top_n=top_n,
+                    max_wide_odds=max_wide_odds,
                 )
             except ValueError:
                 continue
@@ -327,8 +330,11 @@ class StrategyOptimizer:
         top_n_range: list[int] | None = None,
         r_range: list[float] | None = None,
         min_prob_threshold_range: list[float] | None = None,
+        max_wide_odds_range: list[float | None] | None = None,
         # 後方互換性: min_prob_threshold_range が None の場合に使用する固定値
         min_prob_threshold: float = 0.0,
+        # 後方互換性: max_wide_odds_range が None の場合に使用する固定値
+        max_wide_odds: float | None = None,
         # 後方互換性のための旧パラメータ（無視される）
         p1_range: list[float] | None = None,
         top_n_dominant_range: list[int] | None = None,
@@ -339,14 +345,14 @@ class StrategyOptimizer:
         """
         グリッドサーチを実行し、全パラメータ組み合わせのバックテスト結果を返す
 
-        デフォルト探索範囲（min_prob_threshold_range=None の場合）:
+        デフォルト探索範囲（min_prob_threshold_range=None, max_wide_odds_range=None の場合）:
           - threshold:  [1.2, 1.35, 1.5, 1.75]  （期待回収率閾値）
           - top_n:      [2, 3, 4, 5]             （候補馬数）
           - r:          [0.6, 0.8, 1.0, 1.2, 1.5]（prob_weight_r）
         総組み合わせ数: 4×4×5 = 80通り
 
-        min_prob_threshold_range を指定した場合は4次元サーチになる:
-          - threshold × top_n × r × min_prob 全組み合わせを探索
+        max_wide_odds_range を指定した場合は追加次元のグリッドサーチになる:
+          - threshold × top_n × r × min_prob × max_wide_odds 全組み合わせを探索
 
         Args:
             threshold_range: 期待回収率閾値の探索値リスト
@@ -354,7 +360,10 @@ class StrategyOptimizer:
             r_range: prob_weight_r の探索値リスト
             min_prob_threshold_range: 全候補馬共通の最低複勝率の探索値リスト。
                 None の場合は min_prob_threshold 固定値を全組み合わせに適用（後方互換）
+            max_wide_odds_range: ワイドオッズ上限の探索値リスト（None を含む場合は無制限も探索）。
+                None の場合は max_wide_odds 固定値を全組み合わせに適用
             min_prob_threshold: min_prob_threshold_range=None 時の固定値（後方互換）
+            max_wide_odds: max_wide_odds_range=None 時の固定値（後方互換）
             p1_range: 廃止済み（無視される）
             top_n_dominant_range: 廃止済み（無視される）
             top_n_standard_range: 廃止済み（無視される）
@@ -375,34 +384,34 @@ class StrategyOptimizer:
         if r_range is None:
             r_range = [0.6, 0.8, 1.0, 1.2, 1.5]
 
-        # min_prob_threshold_range が指定された場合のみ4次元グリッドサーチ
-        if min_prob_threshold_range is not None:
-            param_grid = list(product(threshold_range, top_n_range, r_range, min_prob_threshold_range))
-            total = len(param_grid)
-            logger.info(
-                f"グリッドサーチ開始: {total} パラメータ組み合わせ "
-                f"(threshold×top_n×r×min_prob = "
-                f"{len(threshold_range)}×{len(top_n_range)}×{len(r_range)}×{len(min_prob_threshold_range)})"
-            )
-        else:
-            param_grid_3d = list(product(threshold_range, top_n_range, r_range))
-            param_grid = [(th, tn, r, min_prob_threshold) for th, tn, r in param_grid_3d]
-            total = len(param_grid)
-            logger.info(f"グリッドサーチ開始: {total} パラメータ組み合わせ (min_prob_threshold={min_prob_threshold} 固定)")
+        # min_prob の探索値リストを確定
+        mpt_values = min_prob_threshold_range if min_prob_threshold_range is not None else [min_prob_threshold]
+        # max_wide_odds の探索値リストを確定
+        mwo_values = max_wide_odds_range if max_wide_odds_range is not None else [max_wide_odds]
+
+        param_grid = list(product(threshold_range, top_n_range, r_range, mpt_values, mwo_values))
+        total = len(param_grid)
+
+        dim_info = (
+            f"threshold×top_n×r×min_prob×max_wide_odds = "
+            f"{len(threshold_range)}×{len(top_n_range)}×{len(r_range)}×{len(mpt_values)}×{len(mwo_values)}"
+        )
+        logger.info(f"グリッドサーチ開始: {total} パラメータ組み合わせ ({dim_info})")
 
         results: list[OptimizationResult] = []
 
-        for i, (th, tn, r, mpt) in enumerate(param_grid):
+        for i, (th, tn, r, mpt, mwo) in enumerate(param_grid):
             params = {
                 "expected_return_threshold": th,
                 "top_n": tn,
                 "prob_weight_r": r,
                 "min_prob_threshold": mpt,
+                "max_wide_odds": mwo,
             }
 
             if (i + 1) % 20 == 0 or (i + 1) == total:
                 logger.info(
-                    f"  [{i + 1}/{total}] th={th} top_n={tn} r={r} min_prob={mpt}"
+                    f"  [{i + 1}/{total}] th={th} top_n={tn} r={r} min_prob={mpt} max_wide_odds={mwo}"
                 )
 
             history_df, pattern_stats = self._run_simulation(
@@ -410,6 +419,7 @@ class StrategyOptimizer:
                 min_prob_threshold=mpt,
                 prob_weight_r=r,
                 top_n=tn,
+                max_wide_odds=mwo,
             )
 
             metrics = compute_metrics(history_df, self.initial_capital)

--- a/tests/test_backtest_strategy.py
+++ b/tests/test_backtest_strategy.py
@@ -793,3 +793,131 @@ class TestDeduplication:
         wide_bets = [b for b in bets if b["bet_type"] == "wide" and b["horse_numbers"] == [1, 2]]
         assert len(wide_bets) == 1
         assert wide_bets[0]["odds"] == 5.0
+
+
+# ---------------------------------------------------------------------------
+# max_wide_odds フィルタのテスト（Issue #262）
+# ---------------------------------------------------------------------------
+
+
+class TestMaxWideOdds:
+    """max_wide_odds（ワイドオッズ上限フィルタ）のテスト"""
+
+    def test_wide_skipped_when_odds_exceed_limit(self):
+        """max_wide_odds を超えるワイドはスキップされる"""
+        race_df = _make_race_df(
+            n_horses=3,
+            probs=[0.40, 0.30, 0.20],
+            odds=[3.0, 4.0, 5.0],
+        )
+        combo_df = _make_combo_odds_df([
+            {"bet_type": "wide", "horse_number_1": 1, "horse_number_2": 2, "odds_value": 60.0},
+            {"bet_type": "umaren", "horse_number_1": 1, "horse_number_2": 2, "odds_value": 80.0},
+        ])
+        bets = select_base_bets(
+            race_df,
+            combo_df,
+            expected_return_threshold=1.2,
+            top_n=3,
+            max_wide_odds=50.0,
+        )
+        wide_bets = [b for b in bets if b["bet_type"] == "wide"]
+        assert len(wide_bets) == 0
+
+    def test_wide_selected_when_odds_within_limit(self):
+        """max_wide_odds 以下のワイドは通常通り選定される"""
+        race_df = _make_race_df(
+            n_horses=3,
+            probs=[0.40, 0.30, 0.20],
+            odds=[3.0, 4.0, 5.0],
+        )
+        combo_df = _make_combo_odds_df([
+            {"bet_type": "wide", "horse_number_1": 1, "horse_number_2": 2, "odds_value": 10.0},
+            {"bet_type": "umaren", "horse_number_1": 1, "horse_number_2": 2, "odds_value": 15.0},
+        ])
+        bets = select_base_bets(
+            race_df,
+            combo_df,
+            expected_return_threshold=1.0,
+            top_n=3,
+            max_wide_odds=50.0,
+        )
+        wide_bets = [b for b in bets if b["bet_type"] == "wide"]
+        assert len(wide_bets) == 1
+        assert wide_bets[0]["horse_numbers"] == [1, 2]
+
+    def test_umaren_also_skipped_when_wide_skipped(self):
+        """ワイドがスキップされた場合は馬連も追加されない"""
+        race_df = _make_race_df(
+            n_horses=3,
+            probs=[0.40, 0.30, 0.20],
+            odds=[3.0, 4.0, 5.0],
+        )
+        combo_df = _make_combo_odds_df([
+            {"bet_type": "wide", "horse_number_1": 1, "horse_number_2": 2, "odds_value": 60.0},
+            {"bet_type": "umaren", "horse_number_1": 1, "horse_number_2": 2, "odds_value": 80.0},
+        ])
+        bets = select_base_bets(
+            race_df,
+            combo_df,
+            expected_return_threshold=1.2,
+            top_n=3,
+            max_wide_odds=50.0,
+        )
+        umaren_bets = [b for b in bets if b["bet_type"] == "umaren"]
+        assert len(umaren_bets) == 0
+
+    def test_none_max_wide_odds_allows_all(self):
+        """max_wide_odds=None (デフォルト) では制限なしにすべてのワイドが対象"""
+        race_df = _make_race_df(
+            n_horses=3,
+            probs=[0.40, 0.30, 0.20],
+            odds=[3.0, 4.0, 5.0],
+        )
+        combo_df = _make_combo_odds_df([
+            {"bet_type": "wide", "horse_number_1": 1, "horse_number_2": 2, "odds_value": 200.0},
+            {"bet_type": "umaren", "horse_number_1": 1, "horse_number_2": 2, "odds_value": 250.0},
+        ])
+        bets = select_base_bets(
+            race_df,
+            combo_df,
+            expected_return_threshold=1.0,
+            top_n=3,
+            max_wide_odds=None,
+        )
+        wide_bets = [b for b in bets if b["bet_type"] == "wide"]
+        assert len(wide_bets) == 1
+
+    def test_select_bets_for_race_passes_max_wide_odds(self):
+        """select_bets_for_race が max_wide_odds を select_base_bets に正しく渡す"""
+        race_df = _make_race_df(
+            n_horses=3,
+            probs=[0.40, 0.30, 0.20],
+            odds=[3.0, 4.0, 5.0],
+        )
+        # wide_odds=10.0: prob_i*prob_j*odds = 0.40*0.30*10 = 1.2 > 1.0 で期待値フィルタを通過し、
+        # かつ 3000 円予算での配分額が 100 円以上になる
+        combo_df = _make_combo_odds_df([
+            {"bet_type": "wide", "horse_number_1": 1, "horse_number_2": 2, "odds_value": 10.0},
+            {"bet_type": "umaren", "horse_number_1": 1, "horse_number_2": 2, "odds_value": 15.0},
+        ])
+
+        # max_wide_odds=9.0 → ワイドは除外（オッズ10.0 > 9.0）
+        bets_filtered = select_bets_for_race(
+            race_df,
+            combo_df,
+            expected_return_threshold=1.0,
+            max_wide_odds=9.0,
+        )
+        wide_filtered = [b for b in bets_filtered if b["bet_type"] == "wide"]
+        assert len(wide_filtered) == 0
+
+        # max_wide_odds=None → ワイドは除外されない（期待値チェックを通れば選定）
+        bets_no_limit = select_bets_for_race(
+            race_df,
+            combo_df,
+            expected_return_threshold=1.0,
+            max_wide_odds=None,
+        )
+        wide_no_limit = [b for b in bets_no_limit if b["bet_type"] == "wide"]
+        assert len(wide_no_limit) == 1


### PR DESCRIPTION
## Summary

- `select_base_bets` / `select_bets_for_race` に `max_wide_odds` パラメータを追加
- ワイドオッズ上限を超えるコンボはスキップ（馬連も連動スキップ）
- `strategy_optimizer.run_grid_search` に `max_wide_odds_range` を追加し感度分析が可能に
- `config/strategy_config.yaml` にデフォルト値 `max_wide_odds: 50.0` を追加
- CLIフラグ `--max-wide-odds` (run_backtest.py) / `--max-wide-odds-range` (run_strategy_optimization.py) を追加

## 背景

外れレース分析（2026年）から、外れワイドの平均オッズが36.7倍（中央値18.2倍）であることが判明。
`expected_return_threshold=1.75` が必然的に高オッズコンボを選好するため、超高倍率ワイド（50倍超）への
無駄な投資を削減するフィルタを追加。

## 変更ファイル

- `src/backtest/strategy.py` — `select_base_bets`, `select_bets_for_race` にフィルタ追加
- `src/backtest/strategy_optimizer.py` — `_run_simulation`, `run_grid_search` にパラメータ追加
- `config/strategy_config.yaml` — `max_wide_odds: 50.0` デフォルト値追加
- `scripts/run_backtest.py` — `--max-wide-odds` CLIフラグ追加
- `scripts/run_strategy.py` — YAML から `max_wide_odds` を読み込み
- `scripts/run_strategy_optimization.py` — `--max-wide-odds-range` CLIフラグ追加、`save_best_params_to_yaml` に保存
- `src/automation/api/app.py` — `_refresh_investment_decisions_for_race` で `max_wide_odds` 適用
- `tests/test_backtest_strategy.py` — `TestMaxWideOdds` クラス（5テスト）追加

## Test plan

- [x] `TestMaxWideOdds` の5テスト（上限超えスキップ / 範囲内選定 / 馬連連動スキップ / None で無制限 / select_bets_for_race経由）
- [x] 既存テスト44件すべて通過
- [x] `test_backtest_metrics.py`, `test_backtest_strategy_optimizer.py`, `test_run_strategy.py`, `test_run_backtest.py` 計77件通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)