### PR TITLE
fix: 特徴量SQLのデータリーク防止フィルタを追加

### DIFF
--- a/src/automation/data/load_to_bq.py
+++ b/src/automation/data/load_to_bq.py
@@ -62,7 +62,7 @@ TABLE_UNIQUE_KEYS = {
     "race_results": ["race_id", "horse_number"],
     "horse_master": ["horse_id"],
     "horse_extended": ["race_id", "horse_number"],
-    "venue_info": ["venue_id"],
+    "venue_info": ["venue_id", "data_category"],
     "payouts": ["race_id", "bet_type", "rank"],
     "odds": ["race_id", "horse_number", "odds_type"],
     "combo_odds": ["race_id", "bet_type", "horse_number_1", "horse_number_2", "horse_number_3"],

--- a/src/ml/features/feature_query_raw.sql
+++ b/src/ml/features/feature_query_raw.sql
@@ -251,22 +251,27 @@ with temp_race_horse_count as (
     temp_base_race_entries as t_b_r_e
     left join `{project_id}`.raw.race_results as r_r_1
       on t_b_r_e.prev_race_key_1 = concat(r_r_1.horse_id, format_date('%Y%m%d', r_r_1.race_date))
+      and r_r_1.race_date < t_b_r_e.race_date
     left join temp_race_horse_count as t_r_h_c_1
       on r_r_1.race_id = t_r_h_c_1.race_id
     left join `{project_id}`.raw.race_results as r_r_2
       on t_b_r_e.prev_race_key_2 = concat(r_r_2.horse_id, format_date('%Y%m%d', r_r_2.race_date))
+      and r_r_2.race_date < t_b_r_e.race_date
     left join temp_race_horse_count as t_r_h_c_2
       on r_r_2.race_id = t_r_h_c_2.race_id
     left join `{project_id}`.raw.race_results as r_r_3
       on t_b_r_e.prev_race_key_3 = concat(r_r_3.horse_id, format_date('%Y%m%d', r_r_3.race_date))
+      and r_r_3.race_date < t_b_r_e.race_date
     left join temp_race_horse_count as t_r_h_c_3
       on r_r_3.race_id = t_r_h_c_3.race_id
     left join `{project_id}`.raw.race_results as r_r_4
       on t_b_r_e.prev_race_key_4 = concat(r_r_4.horse_id, format_date('%Y%m%d', r_r_4.race_date))
+      and r_r_4.race_date < t_b_r_e.race_date
     left join temp_race_horse_count as t_r_h_c_4
       on r_r_4.race_id = t_r_h_c_4.race_id
     left join `{project_id}`.raw.race_results as r_r_5
       on t_b_r_e.prev_race_key_5 = concat(r_r_5.horse_id, format_date('%Y%m%d', r_r_5.race_date))
+      and r_r_5.race_date < t_b_r_e.race_date
     left join temp_race_horse_count as t_r_h_c_5
       on r_r_5.race_id = t_r_h_c_5.race_id
 )
@@ -577,7 +582,16 @@ with temp_race_horse_count as (
     `{project_id}`.raw.race_info as r_i
     left join `{project_id}`.raw.horse_extended as h_e
       on r_i.race_id = h_e.race_id
-    left join `{project_id}`.raw.venue_info as v_i
+    -- data_categoryが複数存在する場合は最大値（最新段階）を優先して参照する
+    -- KAAは木曜以降に段階的に更新される（1:特別登録→2:想定確定→3:枠確定→4:前日）
+    left join (
+      select *
+      from `{project_id}`.raw.venue_info
+      qualify row_number() over (
+        partition by venue_code, race_date
+        order by coalesce(data_category, 0) desc
+      ) = 1
+    ) as v_i
       on r_i.race_date = v_i.race_date
       and r_i.venue_code = v_i.venue_code
     left join `{project_id}`.raw.horse_results as h_r


### PR DESCRIPTION
## Summary

データリークチェックで検出した2つの設計上の問題を修正します。

### 疑惑2: venue_info (KAA) の data_category 整合性

**問題**  
JRDBのKAAファイルは1つの開催に対して段階的に4回更新されます（`1:特別登録 → 2:想定確定 → 3:枠確定 → 4:前日`）。これまで `venue_info` のMERGEキーが `["venue_id"]` のみだったため、BQには常に1レコードのみが保持され、特徴量生成のタイミングによって参照されるバイアス値（`turf_bias`, `dirt_bias`, `straight_bias_*`）が異なっていました。

**修正内容**
- `TABLE_UNIQUE_KEYS["venue_info"]` に `data_category` を追加 → 各段階のデータを個別レコードとして保持可能に
- `feature_query_raw.sql` の `venue_info` JOIN を `QUALIFY row_number() ORDER BY data_category DESC` に変更 → 学習・推論で常に「その時点で利用可能な最新段階」を参照するよう一貫性を保証

### 疑惑3: prev_race_key の同日参照防止

**問題**  
過去走（`r_r_1`〜`r_r_5`）の JOIN に `race_date < 当日` のフィルタが存在せず、理論上は当日の別レース結果が「前走」として参照され得る設計でした。

**修正内容**
- `r_r_1`〜`r_r_5` のJOIN条件すべてに `AND r_r_N.race_date < t_b_r_e.race_date` を追加
- JRAでは同日2走は規則上起きませんが、SQL設計として明示的に保護

## Test plan

- [x] `tests/test_features.py` — 101件 PASSED
- [x] `tests/test_load_to_bq.py` — 全件 PASSED
- [ ] 実際のBigQuery環境で `features/generate` を実行し、`venue_info` のJOINが正しく機能することを確認（本番適用前に推奨）
- [ ] `venue_info` テーブルに複数 `data_category` のデータを再ロードし、QUALIFY句で最新段階のレコードが選択されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)