### PR TITLE
feat: Cloud Run Jobsによるモデル週次再学習とコスト最適化 (#276)

### DIFF
--- a/SCHEDULE.md
+++ b/SCHEDULE.md
@@ -12,14 +12,20 @@
 | `race-day-predict` | 毎日 AM 8:00 | `0 8 * * *` | `POST /api/v1/predict/daily` | レース予測・BQ/GCS保存 |
 | `race-day-odds-scrape` | 毎日 AM 8:15 | `15 8 * * *` | `POST /api/v1/odds/scrape` | netkeibaオッズ取得 |
 | `race-day-strategy` | 毎日 AM 8:30 | `30 8 * * *` | `POST /api/v1/strategy/daily` | 投資戦略策定（dry_run=true） |
-| `weekly-model-retrain` | 毎週月曜 AM 8:00 | `0 8 * * 1` | `POST /api/v1/model/retrain/async` | モデル週次再学習 |
+| `weekly-model-retrain` | 毎週月曜 AM 8:00 | `0 8 * * 1` | Cloud Run Jobs API（`keiba-model-retrain` 起動） | モデル週次再学習 |
 | `race-day-purchase` | 土日 8:00〜17:00 5分おき | `*/5 8-17 * * 6,0` | `POST /api/v1/purchase/daily` | 発走直前IPAT自動馬券購入 |
 
-**全ジョブ共通設定:**
+**全ジョブ共通設定（`weekly-model-retrain` を除く）:**
 - 認証: OIDCトークン（`keiba-pipeline-sa` サービスアカウント）
 - タイムアウト: 900秒（15分）
 - リトライ: 最大3回、バックオフ 5秒〜300秒
 - タイムゾーン: Asia/Tokyo
+
+**`weekly-model-retrain` ジョブの設定:**
+- 認証: OAuth2（`keiba-pipeline-sa`、スコープ: `https://www.googleapis.com/auth/cloud-platform`）
+- タイムアウト: 180秒（Cloud Run Jobs API 呼び出し完了まで。Job本体の実行は非同期）
+- リトライ: 0回（再学習の重複実行を防ぐため）
+- ターゲット: Cloud Run Jobs API（`keiba-model-retrain` Job を起動）
 
 ---
 
@@ -104,16 +110,38 @@
 
 **スケジュール**: 毎週月曜日 AM 8:00 JST
 
-**概要**: BigQueryの学習用データを用いてLightGBM LambdaRankモデルを再学習し、GCSに保存します。
+**概要**: Cloud Scheduler が Cloud Run Jobs API を呼び出し、`keiba-model-retrain` Job を起動します。Job は `python -m src.models.train --tune --project-id {PROJECT_ID}` を実行してLightGBM LambdaRankモデルを再学習し、GCSに保存します。
+
+**重要**: このジョブは従来の `POST /api/v1/model/retrain/async`（FastAPI BackgroundTasks）ではなく、**Cloud Run Jobs**（`keiba-model-retrain`）を使用します。Cloud Run Jobsはタスク完了まで実行を保証し、最大24時間のタスクタイムアウトをサポートします。keiba-pipeline Serviceが`min-instances=0`でコールドスタートする場合でも再学習が中断されません。
+
+**Cloud Run Jobs 設定**（`keiba-model-retrain`）:
+- メモリ: 8Gi、CPU: 4
+- タスクタイムアウト: 7200秒（2時間）
+- 最大リトライ: 0回
+- コマンド: `python -m src.models.train --tune --project-id {PROJECT_ID}`
+- セットアップ: `./infrastructure/scripts/setup_cloud_run_jobs.sh`
 
 **処理フロー**:
-1. `features.training_data` から学習データを取得
-2. 時系列分割（学習/検証/推論）
-3. Optuna/設定済みパラメータでLambdaRank学習
-4. NDCG@3・Recall@3・AUCを評価
-5. GCS `gs://{project}-keiba-models/lgbm_ranker/{YYYYMMDD}/` に保存
+1. Cloud Scheduler が Cloud Run Jobs API（OAuth2認証）を呼び出し Job を非同期起動
+2. `features.training_data` から学習データを取得
+3. 時系列分割（学習/検証/推論）
+4. Optuna ベイズ最適化でハイパーパラメータチューニング
+5. NDCG@3・Recall@3・AUCを評価
+6. GCS `gs://{project}-keiba-models/lgbm_ranker/{YYYYMMDD}/` に保存
 
-**リクエストボディ**: `{}` （空ボディ）
+**認証**: Cloud Scheduler → Cloud Run Jobs API は OAuth2（`cloud-platform` スコープ）を使用します（OIDCではなく）。
+
+**手動実行**:
+```bash
+# Cloud Schedulerジョブ経由（Jobs API 呼び出し）
+gcloud scheduler jobs run weekly-model-retrain --location=asia-northeast1
+
+# Cloud Run Jobs を直接実行
+gcloud run jobs execute keiba-model-retrain --region=asia-northeast1
+
+# 実行状況の確認
+gcloud run jobs executions list --job=keiba-model-retrain --region=asia-northeast1
+```
 
 ---
 
@@ -370,10 +398,20 @@ curl -X POST <CLOUD_RUN_URL>/api/v1/purchase/daily \
 
 ## ジョブ設定スクリプト
 
-ジョブの作成・更新は `infrastructure/scripts/setup_scheduler.sh` で行います:
+### Cloud Run Jobs のセットアップ（初回のみ）
+
+`weekly-model-retrain` Cloud Scheduler ジョブが依存する Cloud Run Job を作成します:
+
+```bash
+./infrastructure/scripts/setup_cloud_run_jobs.sh
+```
+
+### Cloud Scheduler ジョブの作成・更新
 
 ```bash
 ./infrastructure/scripts/setup_scheduler.sh
 ```
+
+**注意**: `setup_scheduler.sh` は `keiba-model-retrain` Cloud Run Job が存在することを確認してから実行します。未作成の場合はエラーになるため、先に `setup_cloud_run_jobs.sh` を実行してください。
 
 詳細なインフラセットアップ手順は [infrastructure/README.md](./infrastructure/README.md) を参照してください。

--- a/infrastructure/cloud_run_config.yaml
+++ b/infrastructure/cloud_run_config.yaml
@@ -12,14 +12,16 @@ platform: managed
 region: asia-northeast1
 
 # リソース設定
-# 予測処理（LightGBM + BigQuery取得）を考慮して 4Gi に増設
+# 予測処理（LightGBM + BigQuery取得）を考慮して 4Gi を確保
+# モデル再学習は Cloud Run Jobs（keiba-model-retrain）で実行するため Service は 4Gi で十分
 memory: 4Gi
 cpu: 2
 timeout: 900  # 15分（予測処理の長時間実行に対応）
 
 # 同時実行設定
 concurrency: 1  # パイプラインは1リクエストずつ処理
-max-instances: 1  # 同時に1インスタンスのみ
+min-instances: 0  # アイドル課金ゼロ（コールドスタートを許容）
+max-instances: 5  # 日次ジョブ並列実行に対応
 
 # 認証設定
 # Cloud Scheduler/内部呼び出しのみ許可

--- a/infrastructure/scripts/deploy_cloud_run.sh
+++ b/infrastructure/scripts/deploy_cloud_run.sh
@@ -94,13 +94,12 @@ gcloud run deploy "${SERVICE_NAME}" \
     --platform=managed \
     --region="${GCP_REGION}" \
     --service-account="${PIPELINE_SA_EMAIL}" \
-    --memory=8Gi \
+    --memory=4Gi \
     --cpu=2 \
     --timeout=900 \
     --concurrency=1 \
-    --min-instances=1 \
-    --max-instances=1 \
-    --no-cpu-throttling \
+    --min-instances=0 \
+    --max-instances=5 \
     --no-allow-unauthenticated \
     --set-env-vars="GCP_PROJECT_ID=${GCP_PROJECT_ID},GCP_REGION=${GCP_REGION},GCS_BUCKET_RAW=${GCS_BUCKET_RAW:-keiba-raw-data},GCS_BUCKET_MODELS=${GCS_BUCKET_MODELS:-keiba-models},BQ_DATASET_RAW=raw,BQ_DATASET_FEATURES=features,BQ_DATASET_PREDICTIONS=predictions,LOG_LEVEL=INFO" \
     --set-secrets="JRDB_USER=jrdb-user:latest,JRDB_PASSWORD=jrdb-password:latest,LINE_CHANNEL_ACCESS_TOKEN=line-channel-access-token:latest,LINE_CHANNEL_SECRET=line-channel-secret:latest,LINE_USER_ID=line-user-id:latest,IPAT_MEMBER_ID=ipat-member-id:latest,IPAT_PIN=ipat-pin:latest,IPAT_PAT_NUMBER=ipat-pat-number:latest" \

--- a/infrastructure/scripts/setup_cloud_run_jobs.sh
+++ b/infrastructure/scripts/setup_cloud_run_jobs.sh
@@ -113,9 +113,6 @@ gcloud projects add-iam-policy-binding "${GCP_PROJECT_ID}" \
     log_warn "roles/run.invoker の付与をスキップしました（既に付与済みの可能性があります）"
 }
 
-# GCSバケット名（プロジェクトIDをプレフィックスとして使用）
-GCS_BUCKET_MODELS_FULL="${GCP_PROJECT_ID}-${GCS_BUCKET_MODELS:-keiba-models}"
-
 # Cloud Run Jobs の作成または更新
 if gcloud run jobs describe "${JOB_NAME}" --region="${GCP_REGION}" > /dev/null 2>&1; then
     log_info "既存のCloud Run Jobs '${JOB_NAME}' を更新します..."

--- a/infrastructure/scripts/setup_cloud_run_jobs.sh
+++ b/infrastructure/scripts/setup_cloud_run_jobs.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+#
+# Cloud Run Jobs セットアップスクリプト
+#
+# keiba-model-retrain Cloud Run Job を作成または更新します。
+# このJobはCloud Scheduler（weekly-model-retrain）から週次で起動されます。
+#
+# 使用方法:
+#   ./infrastructure/scripts/setup_cloud_run_jobs.sh [image-tag]
+#
+# 引数:
+#   image-tag: Dockerイメージのタグ (デフォルト: latest)
+#
+# 前提条件:
+#   1. gcloud CLIがインストール済み
+#   2. 適切な権限を持つユーザーでログイン済み (gcloud auth login)
+#   3. .envファイルにGCP_PROJECT_IDが設定済み
+#   4. Artifact Registryにイメージがプッシュ済み
+#      （先にbuild_and_push.shを実行してください）
+#
+# 実行後の手順:
+#   Cloud Run Jobs作成後、Cloud Schedulerを設定してください:
+#     ./infrastructure/scripts/setup_scheduler.sh
+#
+
+set -e
+
+# 色付きログ出力
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log_info() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# スクリプトのディレクトリを取得
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+# .envファイルを読み込み
+if [ -f "${PROJECT_ROOT}/.env" ]; then
+    log_info ".envファイルを読み込んでいます..."
+    set -a
+    source "${PROJECT_ROOT}/.env"
+    set +a
+else
+    log_error ".envファイルが見つかりません: ${PROJECT_ROOT}/.env"
+    exit 1
+fi
+
+# 必須変数のチェック
+if [ -z "${GCP_PROJECT_ID}" ] || [ "${GCP_PROJECT_ID}" = "your-project-id" ]; then
+    log_error "GCP_PROJECT_IDが設定されていません。.envファイルを確認してください。"
+    exit 1
+fi
+
+# デフォルト値の設定
+GCP_REGION="${GCP_REGION:-asia-northeast1}"
+PIPELINE_SA_NAME="${PIPELINE_SA_NAME:-keiba-pipeline-sa}"
+IMAGE_TAG="${1:-latest}"
+
+# 変数設定
+JOB_NAME="keiba-model-retrain"
+SERVICE_NAME="keiba-pipeline"
+REPO_NAME="keiba-pipeline"
+IMAGE_URI="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/${REPO_NAME}/${SERVICE_NAME}:${IMAGE_TAG}"
+PIPELINE_SA_EMAIL="${PIPELINE_SA_NAME}@${GCP_PROJECT_ID}.iam.gserviceaccount.com"
+
+log_info "=========================================="
+log_info "Cloud Run Jobs keiba-model-retrain をセットアップします"
+log_info "=========================================="
+log_info "プロジェクトID: ${GCP_PROJECT_ID}"
+log_info "リージョン: ${GCP_REGION}"
+log_info "ジョブ名: ${JOB_NAME}"
+log_info "イメージ: ${IMAGE_URI}"
+log_info "サービスアカウント: ${PIPELINE_SA_EMAIL}"
+log_info "=========================================="
+
+# イメージの存在確認
+log_info "Dockerイメージの存在を確認しています..."
+if ! gcloud artifacts docker images describe "${IMAGE_URI}" 2>/dev/null; then
+    log_error "Dockerイメージが見つかりません: ${IMAGE_URI}"
+    log_error "先にイメージをビルド・プッシュしてください:"
+    log_error "  ./infrastructure/scripts/build_and_push.sh"
+    exit 1
+fi
+log_info "イメージが見つかりました"
+
+# Cloud Run Jobs API の有効化確認
+log_info "Cloud Run API を確認しています..."
+if ! gcloud services list --enabled --filter="name:run.googleapis.com" --format="value(name)" 2>/dev/null | grep -q "run"; then
+    log_info "Cloud Run API を有効化しています..."
+    gcloud services enable run.googleapis.com --quiet
+fi
+
+# サービスアカウントに Cloud Run Jobs 実行権限を付与
+log_info "サービスアカウントに Cloud Run Jobs 実行権限を付与しています..."
+gcloud projects add-iam-policy-binding "${GCP_PROJECT_ID}" \
+    --member="serviceAccount:${PIPELINE_SA_EMAIL}" \
+    --role="roles/run.invoker" \
+    --condition=None \
+    --quiet 2>/dev/null || {
+    log_warn "roles/run.invoker の付与をスキップしました（既に付与済みの可能性があります）"
+}
+
+# GCSバケット名（プロジェクトIDをプレフィックスとして使用）
+GCS_BUCKET_MODELS_FULL="${GCP_PROJECT_ID}-${GCS_BUCKET_MODELS:-keiba-models}"
+
+# Cloud Run Jobs の作成または更新
+if gcloud run jobs describe "${JOB_NAME}" --region="${GCP_REGION}" > /dev/null 2>&1; then
+    log_info "既存のCloud Run Jobs '${JOB_NAME}' を更新します..."
+
+    gcloud run jobs update "${JOB_NAME}" \
+        --image="${IMAGE_URI}" \
+        --region="${GCP_REGION}" \
+        --service-account="${PIPELINE_SA_EMAIL}" \
+        --memory=8Gi \
+        --cpu=4 \
+        --task-timeout=7200 \
+        --max-retries=0 \
+        --set-env-vars="GCP_PROJECT_ID=${GCP_PROJECT_ID},GCP_REGION=${GCP_REGION},GCS_BUCKET_MODELS=${GCS_BUCKET_MODELS:-keiba-models},BQ_DATASET_FEATURES=features,BQ_DATASET_PREDICTIONS=predictions,LOG_LEVEL=INFO" \
+        --set-secrets="JRDB_USER=jrdb-user:latest,JRDB_PASSWORD=jrdb-password:latest" \
+        --command="python" \
+        --args="-m,src.models.train,--tune,--project-id,${GCP_PROJECT_ID}" \
+        --quiet
+
+    log_info "Cloud Run Jobs '${JOB_NAME}' を更新しました"
+else
+    log_info "Cloud Run Jobs '${JOB_NAME}' を新規作成します..."
+
+    gcloud run jobs create "${JOB_NAME}" \
+        --image="${IMAGE_URI}" \
+        --region="${GCP_REGION}" \
+        --service-account="${PIPELINE_SA_EMAIL}" \
+        --memory=8Gi \
+        --cpu=4 \
+        --task-timeout=7200 \
+        --max-retries=0 \
+        --set-env-vars="GCP_PROJECT_ID=${GCP_PROJECT_ID},GCP_REGION=${GCP_REGION},GCS_BUCKET_MODELS=${GCS_BUCKET_MODELS:-keiba-models},BQ_DATASET_FEATURES=features,BQ_DATASET_PREDICTIONS=predictions,LOG_LEVEL=INFO" \
+        --set-secrets="JRDB_USER=jrdb-user:latest,JRDB_PASSWORD=jrdb-password:latest" \
+        --command="python" \
+        --args="-m,src.models.train,--tune,--project-id,${GCP_PROJECT_ID}" \
+        --quiet
+
+    log_info "Cloud Run Jobs '${JOB_NAME}' を作成しました"
+fi
+
+# 作成されたジョブの確認
+log_info "ジョブの確認..."
+gcloud run jobs describe "${JOB_NAME}" \
+    --region="${GCP_REGION}" \
+    --format="table(metadata.name,spec.template.spec.template.spec.containers[0].image,spec.template.spec.taskCount,spec.template.spec.maxRetries)"
+
+log_info ""
+log_info "=========================================="
+log_info "セットアップ完了"
+log_info "=========================================="
+log_info ""
+log_info "次のステップ:"
+log_info "  1. Cloud Schedulerを設定してください（weekly-model-retrain ジョブを作成）:"
+log_info "     ./infrastructure/scripts/setup_scheduler.sh"
+log_info ""
+log_info "  2. 手動でモデル再学習をテストする場合:"
+log_info "     gcloud run jobs execute ${JOB_NAME} --region=${GCP_REGION}"
+log_info ""
+log_info "  3. 実行中のジョブを確認する場合:"
+log_info "     gcloud run jobs executions list --job=${JOB_NAME} --region=${GCP_REGION}"
+log_info ""

--- a/infrastructure/scripts/setup_scheduler.sh
+++ b/infrastructure/scripts/setup_scheduler.sh
@@ -10,7 +10,7 @@
 #   2. race-day-predict       AM 8:00 JST  翌日レース予測
 #   3. race-day-odds-scrape   AM 8:15 JST  netkeibaオッズ取得（単複＋組み合わせ）
 #   4. race-day-strategy      AM 8:30 JST  投資戦略策定・investment_decisions保存
-#   5. weekly-model-retrain   毎週月曜 AM 8:00 JST  LightGBMモデル週次再学習
+#   5. weekly-model-retrain   毎週月曜 AM 8:00 JST  Cloud Run Jobs keiba-model-retrain を起動
 #   6. race-day-purchase      土日 8:00〜17:00 5分おき  IPAT自動馬券購入
 #
 # 使用方法:
@@ -21,6 +21,8 @@
 #   2. 適切な権限を持つユーザーでログイン済み (gcloud auth login)
 #   3. .envファイルにGCP_PROJECT_IDが設定済み
 #   4. Cloud Runサービス keiba-pipeline がデプロイ済み
+#   5. Cloud Run Jobs keiba-model-retrain が作成済み
+#      （未作成の場合: ./infrastructure/scripts/setup_cloud_run_jobs.sh を先に実行）
 #
 # 【重要】deploy_cloud_run.sh 実行後は必ずこのスクリプトを再実行してください。
 # Cloud Runのサービスを新たにデプロイするとURLが変わる場合があり、
@@ -86,9 +88,10 @@ ODDS_SCRAPE_SCHEDULE="15 8 * * *"
 STRATEGY_JOB_NAME="race-day-strategy"
 STRATEGY_SCHEDULE="30 8 * * *"
 # 週次モデル再学習ジョブ（毎週月曜日 AM 8:00）
-# "0 8 * * 1" = 毎週月曜日の 8:00
+# Cloud Run Jobs keiba-model-retrain を起動する（Service のバックグラウンドタスクではなく Jobs で実行）
 RETRAIN_JOB_NAME="weekly-model-retrain"
 RETRAIN_SCHEDULE="0 8 * * 1"
+RETRAIN_CLOUD_RUN_JOB_NAME="keiba-model-retrain"
 # IPAT自動購入ジョブ（土日 8:00〜17:00 の5分おき）
 # race-day-strategy(AM 8:30) 完了後に稼働し、発走5分前のレースを自動購入する
 PURCHASE_JOB_NAME="race-day-purchase"
@@ -147,10 +150,10 @@ log_info "オッズ取得URI: ${ODDS_SCRAPE_TARGET_URI}"
 # ターゲットURL（投資戦略: 日次投資戦略エンドポイント）
 STRATEGY_TARGET_URI="${SERVICE_URL}/api/v1/strategy/daily"
 log_info "投資戦略URI: ${STRATEGY_TARGET_URI}"
-# ターゲットURL（週次モデル再学習: バックグラウンド実行エンドポイント）
-# /async を使用して Cloud Scheduler の attempt-deadline 超過を防ぐ
-RETRAIN_TARGET_URI="${SERVICE_URL}/api/v1/model/retrain/async"
-log_info "週次再学習URI: ${RETRAIN_TARGET_URI}"
+# ターゲットURL（週次モデル再学習: Cloud Run Jobs keiba-model-retrain を起動）
+# Cloud Run Jobs を Cloud Run API 経由で実行する（OAuth2 スコープが必要）
+RETRAIN_JOBS_URI="https://${GCP_REGION}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${GCP_PROJECT_ID}/jobs/${RETRAIN_CLOUD_RUN_JOB_NAME}:run"
+log_info "週次再学習Jobs起動URI: ${RETRAIN_JOBS_URI}"
 # ターゲットURL（IPAT自動購入: 発走5分前レースを自動購入）
 PURCHASE_TARGET_URI="${SERVICE_URL}/api/v1/purchase/daily"
 log_info "IPAT自動購入URI: ${PURCHASE_TARGET_URI}"
@@ -292,14 +295,50 @@ create_or_update_job \
     "800s"
 
 # 4-5. 週次モデル再学習ジョブ（weekly-model-retrain）
-# 毎週月曜日 AM 8:00 JST に /api/v1/model/retrain/async を呼び出す
-# バックグラウンド実行のため attempt-deadline=60s で即時レスポンスを受け取る
-log_info "--- 週次モデル再学習ジョブの設定 ---"
-create_or_update_job \
-    "${RETRAIN_JOB_NAME}" \
-    "${RETRAIN_SCHEDULE}" \
-    "${RETRAIN_TARGET_URI}" \
-    "60s"
+# 毎週月曜日 AM 8:00 JST に Cloud Run Jobs keiba-model-retrain を起動する
+# Cloud Run Jobs は OAuth2 スコープが必要なため create_or_update_job とは別実装
+# attempt-deadline=180s: Cloud Run API の呼び出し完了まで待機（Job 実行は非同期）
+log_info "--- 週次モデル再学習ジョブの設定（Cloud Run Jobs起動）---"
+
+# Cloud Run Jobs が存在するか確認
+if ! gcloud run jobs describe "${RETRAIN_CLOUD_RUN_JOB_NAME}" \
+    --region="${GCP_REGION}" > /dev/null 2>&1; then
+    log_error "Cloud Run Jobs '${RETRAIN_CLOUD_RUN_JOB_NAME}' が見つかりません"
+    log_error "先に以下を実行してください:"
+    log_error "  ./infrastructure/scripts/setup_cloud_run_jobs.sh"
+    exit 1
+fi
+
+if gcloud scheduler jobs describe "${RETRAIN_JOB_NAME}" \
+    --location="${GCP_REGION}" > /dev/null 2>&1; then
+    log_info "既存のジョブ ${RETRAIN_JOB_NAME} を更新します..."
+    gcloud scheduler jobs update http "${RETRAIN_JOB_NAME}" \
+        --location="${GCP_REGION}" \
+        --schedule="${RETRAIN_SCHEDULE}" \
+        --time-zone="${TIME_ZONE}" \
+        --uri="${RETRAIN_JOBS_URI}" \
+        --http-method=POST \
+        --oauth-service-account-email="${PIPELINE_SA_EMAIL}" \
+        --oauth-token-scope="https://www.googleapis.com/auth/cloud-platform" \
+        --attempt-deadline="180s" \
+        --max-retry-attempts=0 \
+        --quiet
+    log_info "ジョブを更新しました: ${RETRAIN_JOB_NAME}"
+else
+    log_info "新しいジョブ ${RETRAIN_JOB_NAME} を作成します..."
+    gcloud scheduler jobs create http "${RETRAIN_JOB_NAME}" \
+        --location="${GCP_REGION}" \
+        --schedule="${RETRAIN_SCHEDULE}" \
+        --time-zone="${TIME_ZONE}" \
+        --uri="${RETRAIN_JOBS_URI}" \
+        --http-method=POST \
+        --oauth-service-account-email="${PIPELINE_SA_EMAIL}" \
+        --oauth-token-scope="https://www.googleapis.com/auth/cloud-platform" \
+        --attempt-deadline="180s" \
+        --max-retry-attempts=0 \
+        --quiet
+    log_info "ジョブを作成しました: ${RETRAIN_JOB_NAME}"
+fi
 
 # 4-7. IPAT自動購入ジョブ（race-day-purchase）
 # 土日 8:00〜17:00 の5分おきに /api/v1/purchase/daily を呼び出す


### PR DESCRIPTION
## Summary

- **Cloud Run Service（keiba-pipeline）のコスト削減**
  - `min-instances`: 1 → 0（アイドル課金ゼロ、月約¥7,000削減見込み）
  - `memory`: 8Gi → 4Gi（予測処理に十分な容量）
  - `max-instances`: 1 → 5（日次ジョブ並列実行に対応）
  - `--no-cpu-throttling` フラグを削除（min-instances=0ではアイドルインスタンスが存在しないため不要）

- **モデル週次再学習をCloud Run Jobsに移行**
  - 従来: FastAPI BackgroundTasks（`POST /api/v1/model/retrain/async`）→ min-instances=1が必要だった
  - 新規: Cloud Run Jobs（`keiba-model-retrain`）→ タスク完了まで実行保証、最大24時間対応
  - `setup_cloud_run_jobs.sh`: `keiba-model-retrain` Job作成スクリプトを新規追加
  - `setup_scheduler.sh`: `weekly-model-retrain` をCloud Run Jobs API（OAuth2認証）呼び出しに変更

- **SCHEDULE.md更新**: `weekly-model-retrain`の説明をCloud Run Jobs方式に更新

## コスト削減根拠

- 4月コスト急増（¥11,388 Cloud Run）の原因: 2026-04-12にリビジョン00050でmin-instances=1が設定
- SKU「Services CPU (Instance-based billing)」として常時課金されていた
- min-instances=0に戻すことでアイドル課金をゼロにする

## セットアップ手順（初回デプロイ時）

```bash
# 1. Cloud Run Jobsを作成
./infrastructure/scripts/setup_cloud_run_jobs.sh

# 2. Cloud Schedulerジョブを更新
./infrastructure/scripts/setup_scheduler.sh
```

## Test plan

- [ ] `setup_cloud_run_jobs.sh` のシェルスクリプト構文チェック（`bash -n`）
- [ ] `deploy_cloud_run.sh` のシェルスクリプト構文チェック
- [ ] `setup_scheduler.sh` のシェルスクリプト構文チェック
- [ ] `SCHEDULE.md` の記述が実装と一致することを確認
- [ ] Cloud Run Jobsへの移行で既存APIエンドポイント（`/api/v1/model/retrain/async`）に影響がないことを確認（APIは残す、Schedulerからの呼び出しのみ変更）

🤖 Generated with [Claude Code](https://claude.com/claude-code)