### PR TITLE
feat: Target Encoding（騎手・調教師・種牡馬）を特徴量として追加する (#270)

### DIFF
--- a/src/ml/features/feature_pipeline.py
+++ b/src/ml/features/feature_pipeline.py
@@ -226,6 +226,9 @@ class FeaturePipeline:
             job_config = bigquery.QueryJobConfig(
                 destination=table_ref,
                 write_disposition=bigquery.WriteDisposition.WRITE_APPEND,
+                schema_update_options=[
+                    bigquery.SchemaUpdateOption.ALLOW_FIELD_ADDITION,
+                ],
                 time_partitioning=bigquery.TimePartitioning(
                     field="race_date",
                 ),

--- a/src/ml/features/feature_query_raw.sql
+++ b/src/ml/features/feature_query_raw.sql
@@ -824,6 +824,354 @@ with temp_race_horse_count as (
     temp_horse_master_feature as t_h_m_f
 )
 
+/* TEスムージング用グローバル平均（全期間3着以内率） */
+,temp_global_mean_te as (
+  select
+    avg(case when finish_position between 1 and 3 then 1.0 else 0.0 end) as global_top3_rate
+  from `{project_id}`.raw.race_results
+  where finish_position > 0
+)
+
+/* TE計算の元となる全期間の騎手・調教師・種牡馬実績履歴（当日同日レースは除外） */
+,temp_te_history_base as (
+  select
+    r_r.race_id
+    ,r_r.horse_number
+    ,r_i.race_date
+    ,r_i.course_type
+    ,r_i.venue_code
+    ,r_i.distance
+    ,r_i.direction
+    ,h_r.jockey_code
+    ,h_r.trainer_code
+    ,h_m.sire_name
+    ,case when r_r.finish_position between 1 and 3 then 1 else 0 end as is_top3
+  from `{project_id}`.raw.race_results as r_r
+    inner join `{project_id}`.raw.race_info as r_i
+      on r_r.race_id = r_i.race_id
+    inner join `{project_id}`.raw.horse_results as h_r
+      on r_r.race_id = h_r.race_id
+      and r_r.horse_number = h_r.horse_number
+    inner join `{project_id}`.raw.horse_master as h_m
+      on h_r.horse_id = h_m.horse_id
+  where r_r.finish_position > 0
+)
+
+/* 騎手 Target Encoding（累積3着以内率、スムージング係数m=10、同日除外） */
+,temp_jockey_te as (
+  select
+    race_id
+    ,horse_number
+    ,safe_divide(
+      coalesce(sum(is_top3) over (
+        partition by jockey_code
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10 * g.global_top3_rate,
+      coalesce(count(*) over (
+        partition by jockey_code
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10
+    ) as jockey_te
+    ,safe_divide(
+      coalesce(sum(is_top3) over (
+        partition by jockey_code, course_type
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10 * g.global_top3_rate,
+      coalesce(count(*) over (
+        partition by jockey_code, course_type
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10
+    ) as jockey_course_type_te
+    ,safe_divide(
+      coalesce(sum(is_top3) over (
+        partition by jockey_code, venue_code
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10 * g.global_top3_rate,
+      coalesce(count(*) over (
+        partition by jockey_code, venue_code
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10
+    ) as jockey_venue_te
+    ,safe_divide(
+      coalesce(sum(is_top3) over (
+        partition by jockey_code, distance
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10 * g.global_top3_rate,
+      coalesce(count(*) over (
+        partition by jockey_code, distance
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10
+    ) as jockey_distance_te
+    ,safe_divide(
+      coalesce(sum(is_top3) over (
+        partition by jockey_code, direction
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10 * g.global_top3_rate,
+      coalesce(count(*) over (
+        partition by jockey_code, direction
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10
+    ) as jockey_direction_te
+    ,safe_divide(
+      coalesce(sum(is_top3) over (
+        partition by jockey_code, course_type, venue_code
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10 * g.global_top3_rate,
+      coalesce(count(*) over (
+        partition by jockey_code, course_type, venue_code
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10
+    ) as jockey_course_type_venue_te
+    ,safe_divide(
+      coalesce(sum(is_top3) over (
+        partition by jockey_code, course_type, distance
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10 * g.global_top3_rate,
+      coalesce(count(*) over (
+        partition by jockey_code, course_type, distance
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10
+    ) as jockey_course_type_distance_te
+    ,safe_divide(
+      coalesce(sum(is_top3) over (
+        partition by jockey_code, course_type, distance, venue_code
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10 * g.global_top3_rate,
+      coalesce(count(*) over (
+        partition by jockey_code, course_type, distance, venue_code
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10
+    ) as jockey_course_type_distance_venue_te
+  from temp_te_history_base
+    cross join temp_global_mean_te as g
+)
+
+/* 調教師 Target Encoding（累積3着以内率、スムージング係数m=10、同日除外） */
+,temp_trainer_te as (
+  select
+    race_id
+    ,horse_number
+    ,safe_divide(
+      coalesce(sum(is_top3) over (
+        partition by trainer_code
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10 * g.global_top3_rate,
+      coalesce(count(*) over (
+        partition by trainer_code
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10
+    ) as trainer_te
+    ,safe_divide(
+      coalesce(sum(is_top3) over (
+        partition by trainer_code, course_type
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10 * g.global_top3_rate,
+      coalesce(count(*) over (
+        partition by trainer_code, course_type
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10
+    ) as trainer_course_type_te
+    ,safe_divide(
+      coalesce(sum(is_top3) over (
+        partition by trainer_code, venue_code
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10 * g.global_top3_rate,
+      coalesce(count(*) over (
+        partition by trainer_code, venue_code
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10
+    ) as trainer_venue_te
+    ,safe_divide(
+      coalesce(sum(is_top3) over (
+        partition by trainer_code, distance
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10 * g.global_top3_rate,
+      coalesce(count(*) over (
+        partition by trainer_code, distance
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10
+    ) as trainer_distance_te
+    ,safe_divide(
+      coalesce(sum(is_top3) over (
+        partition by trainer_code, direction
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10 * g.global_top3_rate,
+      coalesce(count(*) over (
+        partition by trainer_code, direction
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10
+    ) as trainer_direction_te
+    ,safe_divide(
+      coalesce(sum(is_top3) over (
+        partition by trainer_code, course_type, venue_code
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10 * g.global_top3_rate,
+      coalesce(count(*) over (
+        partition by trainer_code, course_type, venue_code
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10
+    ) as trainer_course_type_venue_te
+    ,safe_divide(
+      coalesce(sum(is_top3) over (
+        partition by trainer_code, course_type, distance
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10 * g.global_top3_rate,
+      coalesce(count(*) over (
+        partition by trainer_code, course_type, distance
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10
+    ) as trainer_course_type_distance_te
+    ,safe_divide(
+      coalesce(sum(is_top3) over (
+        partition by trainer_code, course_type, distance, venue_code
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10 * g.global_top3_rate,
+      coalesce(count(*) over (
+        partition by trainer_code, course_type, distance, venue_code
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10
+    ) as trainer_course_type_distance_venue_te
+  from temp_te_history_base
+    cross join temp_global_mean_te as g
+)
+
+/* 種牡馬 Target Encoding（累積3着以内率、スムージング係数m=10、同日除外） */
+,temp_sire_te as (
+  select
+    race_id
+    ,horse_number
+    ,safe_divide(
+      coalesce(sum(is_top3) over (
+        partition by sire_name
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10 * g.global_top3_rate,
+      coalesce(count(*) over (
+        partition by sire_name
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10
+    ) as sire_te
+    ,safe_divide(
+      coalesce(sum(is_top3) over (
+        partition by sire_name, course_type
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10 * g.global_top3_rate,
+      coalesce(count(*) over (
+        partition by sire_name, course_type
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10
+    ) as sire_course_type_te
+    ,safe_divide(
+      coalesce(sum(is_top3) over (
+        partition by sire_name, venue_code
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10 * g.global_top3_rate,
+      coalesce(count(*) over (
+        partition by sire_name, venue_code
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10
+    ) as sire_venue_te
+    ,safe_divide(
+      coalesce(sum(is_top3) over (
+        partition by sire_name, distance
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10 * g.global_top3_rate,
+      coalesce(count(*) over (
+        partition by sire_name, distance
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10
+    ) as sire_distance_te
+    ,safe_divide(
+      coalesce(sum(is_top3) over (
+        partition by sire_name, direction
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10 * g.global_top3_rate,
+      coalesce(count(*) over (
+        partition by sire_name, direction
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10
+    ) as sire_direction_te
+    ,safe_divide(
+      coalesce(sum(is_top3) over (
+        partition by sire_name, course_type, venue_code
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10 * g.global_top3_rate,
+      coalesce(count(*) over (
+        partition by sire_name, course_type, venue_code
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10
+    ) as sire_course_type_venue_te
+    ,safe_divide(
+      coalesce(sum(is_top3) over (
+        partition by sire_name, course_type, distance
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10 * g.global_top3_rate,
+      coalesce(count(*) over (
+        partition by sire_name, course_type, distance
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10
+    ) as sire_course_type_distance_te
+    ,safe_divide(
+      coalesce(sum(is_top3) over (
+        partition by sire_name, course_type, distance, venue_code
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10 * g.global_top3_rate,
+      coalesce(count(*) over (
+        partition by sire_name, course_type, distance, venue_code
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10
+    ) as sire_course_type_distance_venue_te
+  from temp_te_history_base
+    cross join temp_global_mean_te as g
+)
+
 select
   t_p_r_f.*
   ,t_h_m_f.* except(
@@ -871,8 +1219,44 @@ select
     coalesce(bracket_top2_finish_rate_diff, 0) +
     coalesce(bracket_top1_finish_rate_diff, 0)
   ) as total_diff_sum
+  -- 騎手TE
+  ,t_j_te.jockey_te
+  ,t_j_te.jockey_course_type_te
+  ,t_j_te.jockey_venue_te
+  ,t_j_te.jockey_distance_te
+  ,t_j_te.jockey_direction_te
+  ,t_j_te.jockey_course_type_venue_te
+  ,t_j_te.jockey_course_type_distance_te
+  ,t_j_te.jockey_course_type_distance_venue_te
+  -- 調教師TE
+  ,t_tr_te.trainer_te
+  ,t_tr_te.trainer_course_type_te
+  ,t_tr_te.trainer_venue_te
+  ,t_tr_te.trainer_distance_te
+  ,t_tr_te.trainer_direction_te
+  ,t_tr_te.trainer_course_type_venue_te
+  ,t_tr_te.trainer_course_type_distance_te
+  ,t_tr_te.trainer_course_type_distance_venue_te
+  -- 種牡馬TE
+  ,t_s_te.sire_te
+  ,t_s_te.sire_course_type_te
+  ,t_s_te.sire_venue_te
+  ,t_s_te.sire_distance_te
+  ,t_s_te.sire_direction_te
+  ,t_s_te.sire_course_type_venue_te
+  ,t_s_te.sire_course_type_distance_te
+  ,t_s_te.sire_course_type_distance_venue_te
 from
   temp_past_race_features2 as t_p_r_f
   left join temp_horse_master_feature2 as t_h_m_f
     on t_p_r_f.race_id = t_h_m_f.race_id
     and t_p_r_f.horse_number = t_h_m_f.horse_number
+  left join temp_jockey_te as t_j_te
+    on t_p_r_f.race_id = t_j_te.race_id
+    and t_p_r_f.horse_number = t_j_te.horse_number
+  left join temp_trainer_te as t_tr_te
+    on t_p_r_f.race_id = t_tr_te.race_id
+    and t_p_r_f.horse_number = t_tr_te.horse_number
+  left join temp_sire_te as t_s_te
+    on t_p_r_f.race_id = t_s_te.race_id
+    and t_p_r_f.horse_number = t_s_te.horse_number

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -143,6 +143,105 @@ class TestSQLTemplate:
             "weight_carried_diff が r_r_1.weight_carried を参照していません"
         )
 
+    def test_sql_has_te_ctes(self):
+        """Target Encoding用のCTEが存在すること（Issue #270）"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        assert "temp_global_mean_te" in content, "グローバル平均CTE が見つかりません"
+        assert "temp_te_history_base" in content, "TE履歴ベースCTE が見つかりません"
+        assert "temp_jockey_te" in content, "騎手TE CTE が見つかりません"
+        assert "temp_trainer_te" in content, "調教師TE CTE が見つかりません"
+        assert "temp_sire_te" in content, "種牡馬TE CTE が見つかりません"
+
+    def test_sql_te_columns_present(self):
+        """TE特徴量カラムが最終SELECTに含まれること（Issue #270）"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        expected_columns = [
+            "jockey_te",
+            "jockey_course_type_te",
+            "jockey_venue_te",
+            "jockey_distance_te",
+            "jockey_direction_te",
+            "jockey_course_type_venue_te",
+            "jockey_course_type_distance_te",
+            "jockey_course_type_distance_venue_te",
+            "trainer_te",
+            "trainer_course_type_te",
+            "trainer_venue_te",
+            "trainer_distance_te",
+            "trainer_direction_te",
+            "trainer_course_type_venue_te",
+            "trainer_course_type_distance_te",
+            "trainer_course_type_distance_venue_te",
+            "sire_te",
+            "sire_course_type_te",
+            "sire_venue_te",
+            "sire_distance_te",
+            "sire_direction_te",
+            "sire_course_type_venue_te",
+            "sire_course_type_distance_te",
+            "sire_course_type_distance_venue_te",
+        ]
+        for col in expected_columns:
+            assert col in content, f"TE特徴量カラム '{col}' が見つかりません"
+
+    def test_sql_te_window_uses_range_for_same_day_exclusion(self):
+        """TE Window関数がRANGEを使って同日レースを除外すること（Issue #270）"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        assert "range between unbounded preceding and 1 preceding" in content, (
+            "TE Window関数で同日除外（RANGE BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING）が見つかりません"
+        )
+
+    def test_sql_te_window_uses_unix_date(self):
+        """TE Window関数がunix_dateで整数変換していること（同日を整数1単位として除外）（Issue #270）"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        assert "unix_date(race_date)" in content, (
+            "TE Window関数で unix_date(race_date) が見つかりません"
+        )
+
+    def test_sql_te_history_base_excludes_non_finishers(self):
+        """TE履歴ベースが取消・除外馬を除外していること（Issue #270）"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        te_base_section = content[
+            content.find("temp_te_history_base"): content.find("temp_jockey_te")
+        ]
+        assert "finish_position > 0" in te_base_section, (
+            "temp_te_history_base で finish_position > 0 フィルタが見つかりません"
+        )
+
+    def test_sql_te_history_base_joins_required_tables(self):
+        """TE履歴ベースが必要なテーブルをJOINしていること（Issue #270）"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        te_base_section = content[
+            content.find("temp_te_history_base"): content.find("temp_jockey_te")
+        ]
+        assert "raw.race_results" in te_base_section
+        assert "raw.race_info" in te_base_section
+        assert "raw.horse_results" in te_base_section
+        assert "raw.horse_master" in te_base_section
+
+    def test_sql_te_final_join_uses_race_id_and_horse_number(self):
+        """最終SELECTでTEテーブルをrace_id+horse_numberでJOINしていること（Issue #270）"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        assert "left join temp_jockey_te as t_j_te" in content
+        assert "left join temp_trainer_te as t_tr_te" in content
+        assert "left join temp_sire_te as t_s_te" in content
+        # JOINキーの確認
+        assert "t_j_te.race_id" in content
+        assert "t_j_te.horse_number" in content
+
+    def test_sql_te_global_mean_from_race_results(self):
+        """グローバル平均がrace_resultsから計算されること（Issue #270）"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        global_mean_section = content[
+            content.find("temp_global_mean_te"): content.find("temp_te_history_base")
+        ]
+        assert "raw.race_results" in global_mean_section, (
+            "temp_global_mean_te で raw.race_results が参照されていません"
+        )
+        assert "finish_position between 1 and 3" in global_mean_section, (
+            "グローバル平均で 3着以内判定 (finish_position between 1 and 3) が見つかりません"
+        )
+
     def test_sql_normalized_features_have_time_boundary(self):
         """finish_time_normalized と last_3f_normalized が時系列ガードを持つこと"""
         content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")


### PR DESCRIPTION
## 概要

Issue #270 の実装。騎手・調教師・種牡馬のTarget Encoding（累積3着以内率）をBigQuery Window関数で実装。

## 変更内容

- `src/ml/features/feature_query_raw.sql`：TE計算用CTE4本を追加（+384行）
  - `temp_global_mean_te`：グローバル3着以内率（スムージング基準値）
  - `temp_te_history_base`：全期間の騎手/調教師/種牡馬実績履歴
  - `temp_jockey_te` / `temp_trainer_te` / `temp_sire_te`：各カテゴリの8軸TE
- `src/ml/features/feature_pipeline.py`：`ALLOW_FIELD_ADDITION` オプション追加（新カラム追加時のスキーマ更新対応）
- `tests/test_features.py`：TE実装のリーク・構造テスト8件追加

## 追加特徴量（24カラム）

3カテゴリ（騎手/調教師/種牡馬）× 8軸：

| 軸 | カラム例 |
|---|---|
| 全体 | `jockey_te` |
| 芝ダ別 | `jockey_course_type_te` |
| 競馬場別 | `jockey_venue_te` |
| 距離別 | `jockey_distance_te` |
| 右/左回り別 | `jockey_direction_te` |
| 芝ダ×競馬場別 | `jockey_course_type_venue_te` |
| 芝ダ×距離別 | `jockey_course_type_distance_te` |
| 芝ダ×距離×競馬場別 | `jockey_course_type_distance_venue_te` |

※ distance_band_te は #271（距離帯カテゴリ化）完了後に追加予定

## リーク対策

- `ORDER BY unix_date(race_date) RANGE BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING` で当日レースを完全除外
- 騎手が同日複数レース騎乗しても当日分はTE計算に混入しない
- `/check-leak` スキルによるレビュー実施済み：重大なリーク検出なし ✓

## 精度比較（`scripts/compare_features.py` 実行結果）

### モデル別 学習・検証期間

| | 既存モデル | 新モデル |
|---|---|---|
| **学習期間** | 2016-01-05 〜 2025-11-09 (476,023行 / 34,090レース) | 2016-01-05 〜 2025-11-09 (489,925行 / 34,090レース) |
| **検証期間** | 2025-11-15 〜 2026-05-10 (24,112行 / 1,688レース) | 2025-11-15 〜 2026-05-10 (24,112行 / 1,688レース) |

### 精度比較

| 指標 | 既存モデル | 新モデル | 差分 | 判定（±0.005） |
|---|---|---|---|---|
| **NDCG@3** | 0.5752 | 0.5731 | -0.0021 | ✅ 同等 |
| **AUC** | 0.8052 | 0.8151 | +0.0099 | ✅ 改善 |
| **Recall@3** | 0.5026 | 0.5000 | -0.0027 | ✅ 同等 |

特徴量数: 273 → 297（+24）

### 総合判定: ✅ マージ可

## テスト計画

- [x] `/check-leak` によるデータリーク検証実施済み（重大なリーク検出なし）
- [x] `pytest tests/test_features.py` 全39件通過
- [x] `pytest tests/test_features.py tests/test_backtest_strategy.py tests/test_backtest_metrics.py tests/test_lgbm_ranker.py tests/test_jrdb_parser.py` 計123件通過
- [x] `scripts/compare_features.py` による精度比較実施済み（全指標合格）

🤖 Generated with [Claude Code](https://claude.com/claude-code)