### PR TITLE
feat: 距離帯カテゴリ化と距離変更・距離別成績特徴量を追加する (#271)

### DIFF
--- a/src/ml/features/feature_query_raw.sql
+++ b/src/ml/features/feature_query_raw.sql
@@ -54,6 +54,12 @@ with temp_race_horse_count as (
     ,h_r.total_index
     ,h_r.running_style -- 脚質(1逃げ、2先行、3差し、4追込)
     ,h_r.distance_aptitude -- 距離適性
+    ,case
+      when r_i.distance < 1400 then 'sprint'
+      when r_i.distance < 1800 then 'mile'
+      when r_i.distance < 2200 then 'intermediate'
+      else 'long'
+    end as distance_band
     ,h_r.improvement -- 上昇度
     ,h_r.base_odds -- 想定オッズ
     ,h_r.base_popularity -- 想定人気
@@ -143,6 +149,13 @@ with temp_race_horse_count as (
     ,SUBSTR(r_r_1.race_id, 1, 2) as venue_code_prev_1
     ,r_r_1.distance as distance_prev_1
     ,r_r_1.track_condition as track_condition_prev_1
+    ,t_b_r_e.distance - r_r_1.distance as distance_change
+    ,case
+      when r_r_1.distance is null then null
+      when t_b_r_e.distance > r_r_1.distance then 1
+      when t_b_r_e.distance < r_r_1.distance then -1
+      else 0
+    end as distance_change_flag
     -- 2走前のレース結果
     ,r_r_2.race_name as race_name_2
     ,round(safe_divide(date_diff(t_b_r_e.race_date, r_r_2.race_date, day), 7))-1 as race_date_diff_2
@@ -1172,6 +1185,167 @@ with temp_race_horse_count as (
     cross join temp_global_mean_te as g
 )
 
+/* 馬の距離帯別・距離別 TE 計算の元データ */
+,temp_horse_distance_base as (
+  select
+    r_r.race_id
+    ,h_r.horse_number
+    ,h_r.horse_id
+    ,r_i.race_date
+    ,r_i.distance
+    ,case
+      when r_i.distance < 1400 then 'sprint'
+      when r_i.distance < 1800 then 'mile'
+      when r_i.distance < 2200 then 'intermediate'
+      else 'long'
+    end as distance_band
+    ,case when r_r.finish_position between 1 and 3 then 1 else 0 end as is_top3
+    ,case when r_r.finish_position = 1 then 1 else 0 end as is_top1
+  from `{project_id}`.raw.race_results as r_r
+    inner join `{project_id}`.raw.race_info as r_i
+      on r_r.race_id = r_i.race_id
+    inner join `{project_id}`.raw.horse_results as h_r
+      on r_r.race_id = h_r.race_id
+      and r_r.horse_number = h_r.horse_number
+  where r_r.finish_position > 0
+)
+
+/* 馬の距離帯別 TE（累積3着以内率・1着率、スムージング係数m=10、同日除外） */
+,temp_horse_distance_band_te as (
+  select
+    race_id
+    ,horse_number
+    -- 距離帯別3着以内率
+    ,safe_divide(
+      coalesce(sum(is_top3) over (
+        partition by horse_id, distance_band
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10 * g.global_top3_rate,
+      coalesce(count(*) over (
+        partition by horse_id, distance_band
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10
+    ) as distance_band_top3_finish_rate
+    -- 距離帯別1着率
+    ,safe_divide(
+      coalesce(sum(is_top1) over (
+        partition by horse_id, distance_band
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10 * g.global_top3_rate,
+      coalesce(count(*) over (
+        partition by horse_id, distance_band
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10
+    ) as distance_band_top1_finish_rate
+    -- 距離帯成績 − 全体成績の差分
+    ,safe_divide(
+      coalesce(sum(is_top3) over (
+        partition by horse_id, distance_band
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10 * g.global_top3_rate,
+      coalesce(count(*) over (
+        partition by horse_id, distance_band
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10
+    ) - safe_divide(
+      coalesce(sum(is_top3) over (
+        partition by horse_id
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10 * g.global_top3_rate,
+      coalesce(count(*) over (
+        partition by horse_id
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10
+    ) as distance_band_rate_diff
+    -- その距離帯での初出走フラグ
+    ,case
+      when coalesce(count(*) over (
+        partition by horse_id, distance_band
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) = 0 then 1
+      else 0
+    end as new_distance_band_flag
+  from temp_horse_distance_base
+    cross join temp_global_mean_te as g
+)
+
+/* 馬の距離別 TE（累積3着以内率・1着率、スムージング係数m=10、同日除外） */
+,temp_horse_distance_te as (
+  select
+    race_id
+    ,horse_number
+    -- 距離別3着以内率
+    ,safe_divide(
+      coalesce(sum(is_top3) over (
+        partition by horse_id, distance
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10 * g.global_top3_rate,
+      coalesce(count(*) over (
+        partition by horse_id, distance
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10
+    ) as distance_top3_finish_rate
+    -- 距離別1着率
+    ,safe_divide(
+      coalesce(sum(is_top1) over (
+        partition by horse_id, distance
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10 * g.global_top3_rate,
+      coalesce(count(*) over (
+        partition by horse_id, distance
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10
+    ) as distance_top1_finish_rate
+    -- 距離別成績 − 全体成績の差分
+    ,safe_divide(
+      coalesce(sum(is_top3) over (
+        partition by horse_id, distance
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10 * g.global_top3_rate,
+      coalesce(count(*) over (
+        partition by horse_id, distance
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10
+    ) - safe_divide(
+      coalesce(sum(is_top3) over (
+        partition by horse_id
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10 * g.global_top3_rate,
+      coalesce(count(*) over (
+        partition by horse_id
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10
+    ) as distance_rate_diff
+    -- その距離での初出走フラグ
+    ,case
+      when coalesce(count(*) over (
+        partition by horse_id, distance
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) = 0 then 1
+      else 0
+    end as new_distance_flag
+  from temp_horse_distance_base
+    cross join temp_global_mean_te as g
+)
+
 select
   t_p_r_f.*
   ,t_h_m_f.* except(
@@ -1246,6 +1420,16 @@ select
   ,t_s_te.sire_course_type_venue_te
   ,t_s_te.sire_course_type_distance_te
   ,t_s_te.sire_course_type_distance_venue_te
+  -- 距離帯別特徴量
+  ,t_h_db_te.distance_band_top3_finish_rate
+  ,t_h_db_te.distance_band_top1_finish_rate
+  ,t_h_db_te.distance_band_rate_diff
+  ,t_h_db_te.new_distance_band_flag
+  -- 距離別特徴量
+  ,t_h_d_te.distance_top3_finish_rate
+  ,t_h_d_te.distance_top1_finish_rate
+  ,t_h_d_te.distance_rate_diff
+  ,t_h_d_te.new_distance_flag
 from
   temp_past_race_features2 as t_p_r_f
   left join temp_horse_master_feature2 as t_h_m_f
@@ -1260,3 +1444,9 @@ from
   left join temp_sire_te as t_s_te
     on t_p_r_f.race_id = t_s_te.race_id
     and t_p_r_f.horse_number = t_s_te.horse_number
+  left join temp_horse_distance_band_te as t_h_db_te
+    on t_p_r_f.race_id = t_h_db_te.race_id
+    and t_p_r_f.horse_number = t_h_db_te.horse_number
+  left join temp_horse_distance_te as t_h_d_te
+    on t_p_r_f.race_id = t_h_d_te.race_id
+    and t_p_r_f.horse_number = t_h_d_te.horse_number

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -242,6 +242,121 @@ class TestSQLTemplate:
             "グローバル平均で 3着以内判定 (finish_position between 1 and 3) が見つかりません"
         )
 
+    def test_sql_has_distance_band_in_base_entries(self):
+        """temp_base_race_entries に distance_band が含まれること（Issue #271）"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        base_section = content[
+            content.find("temp_base_race_entries"): content.find("temp_past_race_features")
+        ]
+        assert "distance_band" in base_section, "distance_band が temp_base_race_entries に見つかりません"
+        assert "'sprint'" in base_section, "距離帯 sprint の定義が見つかりません"
+        assert "'mile'" in base_section, "距離帯 mile の定義が見つかりません"
+        assert "'intermediate'" in base_section, "距離帯 intermediate の定義が見つかりません"
+        assert "'long'" in base_section, "距離帯 long の定義が見つかりません"
+
+    def test_sql_distance_band_thresholds_correct(self):
+        """distance_band の閾値が仕様通りであること（sprint<1400, mile<1800, intermediate<2200）（Issue #271）"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        base_section = content[
+            content.find("temp_base_race_entries"): content.find("temp_past_race_features")
+        ]
+        assert "distance < 1400" in base_section, "sprint の閾値 <1400 が見つかりません"
+        assert "distance < 1800" in base_section, "mile の閾値 <1800 が見つかりません"
+        assert "distance < 2200" in base_section, "intermediate の閾値 <2200 が見つかりません"
+
+    def test_sql_has_distance_change_features(self):
+        """temp_past_race_features に distance_change と distance_change_flag が含まれること（Issue #271）"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        past_section = content[
+            content.find("temp_past_race_features"): content.find("temp_past_race_features2")
+        ]
+        assert "distance_change" in past_section, "distance_change が見つかりません"
+        assert "distance_change_flag" in past_section, "distance_change_flag が見つかりません"
+
+    def test_sql_distance_change_uses_past_race_distance(self):
+        """distance_change が当日距離と1走前距離の差分を使っていること（Issue #271）"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        assert "t_b_r_e.distance - r_r_1.distance" in content, (
+            "distance_change の計算式 (t_b_r_e.distance - r_r_1.distance) が見つかりません"
+        )
+
+    def test_sql_distance_change_flag_handles_null(self):
+        """distance_change_flag が NULL（初出走）を正しく扱うこと（Issue #271）"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        assert "r_r_1.distance is null then null" in content, (
+            "distance_change_flag の NULL ハンドリングが見つかりません"
+        )
+
+    def test_sql_has_horse_distance_ctes(self):
+        """距離帯別・距離別 TE 用 CTE が存在すること（Issue #271）"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        assert "temp_horse_distance_base" in content, "temp_horse_distance_base CTE が見つかりません"
+        assert "temp_horse_distance_band_te" in content, "temp_horse_distance_band_te CTE が見つかりません"
+        assert "temp_horse_distance_te" in content, "temp_horse_distance_te CTE が見つかりません"
+
+    def test_sql_horse_distance_band_te_columns_present(self):
+        """距離帯別特徴量が最終 SELECT に含まれること（Issue #271）"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        expected = [
+            "distance_band_top3_finish_rate",
+            "distance_band_top1_finish_rate",
+            "distance_band_rate_diff",
+            "new_distance_band_flag",
+        ]
+        for col in expected:
+            assert col in content, f"距離帯別特徴量 '{col}' が見つかりません"
+
+    def test_sql_horse_distance_te_columns_present(self):
+        """距離別特徴量が最終 SELECT に含まれること（Issue #271）"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        expected = [
+            "distance_top3_finish_rate",
+            "distance_top1_finish_rate",
+            "distance_rate_diff",
+            "new_distance_flag",
+        ]
+        for col in expected:
+            assert col in content, f"距離別特徴量 '{col}' が見つかりません"
+
+    def test_sql_horse_distance_base_excludes_non_finishers(self):
+        """temp_horse_distance_base が取消・除外馬を除外していること（Issue #271）"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        base_section = content[
+            content.find("temp_horse_distance_base"): content.find("temp_horse_distance_band_te")
+        ]
+        assert "finish_position > 0" in base_section, (
+            "temp_horse_distance_base で finish_position > 0 フィルタが見つかりません"
+        )
+
+    def test_sql_horse_distance_te_uses_range_window(self):
+        """距離 TE Window 関数が RANGE で同日除外していること（Issue #271）"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        dist_te_section = content[content.find("temp_horse_distance_band_te"):]
+        assert "range between unbounded preceding and 1 preceding" in dist_te_section, (
+            "距離 TE Window 関数で同日除外 (RANGE BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) が見つかりません"
+        )
+
+    def test_sql_horse_distance_te_partitions_by_horse_id(self):
+        """距離 TE が horse_id で正しくパーティションされていること（Issue #271）"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        dist_section = content[content.find("temp_horse_distance_band_te"):]
+        assert "partition by horse_id, distance_band" in dist_section, (
+            "距離帯 TE で 'partition by horse_id, distance_band' が見つかりません"
+        )
+        assert "partition by horse_id, distance" in dist_section, (
+            "距離 TE で 'partition by horse_id, distance' が見つかりません"
+        )
+
+    def test_sql_horse_distance_te_final_joins(self):
+        """距離帯別・距離別 TE が最終 SELECT で JOIN されていること（Issue #271）"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        assert "left join temp_horse_distance_band_te as t_h_db_te" in content, (
+            "temp_horse_distance_band_te の JOIN が見つかりません"
+        )
+        assert "left join temp_horse_distance_te as t_h_d_te" in content, (
+            "temp_horse_distance_te の JOIN が見つかりません"
+        )
+
     def test_sql_normalized_features_have_time_boundary(self):
         """finish_time_normalized と last_3f_normalized が時系列ガードを持つこと"""
         content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")


### PR DESCRIPTION
## 概要

Issue #271 の実装。距離帯カテゴリ（sprint/mile/intermediate/long）と距離変更フラグ、および距離帯別・距離別の馬成績 Target Encoding を追加する。

## 追加特徴量

### 距離帯カテゴリ（temp_base_race_entries）
| カラム名 | 説明 |
|---|---|
| `distance_band` | sprint(<1400m) / mile(<1800m) / intermediate(<2200m) / long(≥2200m) |

### 距離変更（temp_past_race_features）
| カラム名 | 説明 |
|---|---|
| `distance_change` | 当日距離 − 1走前距離（正=延長, 負=短縮） |
| `distance_change_flag` | 1=延長 / -1=短縮 / 0=同距離 / null=初出走 |

### 距離帯別 TE（temp_horse_distance_band_te）
| カラム名 | 説明 |
|---|---|
| `distance_band_top3_finish_rate` | 距離帯ごとの通算3着以内率（スムージングm=10） |
| `distance_band_top1_finish_rate` | 距離帯ごとの通算1着率 |
| `distance_band_rate_diff` | 距離帯成績 − 全体成績の差分 |
| `new_distance_band_flag` | その距離帯での初出走フラグ |

### 距離別 TE（temp_horse_distance_te）
| カラム名 | 説明 |
|---|---|
| `distance_top3_finish_rate` | その距離での通算3着以内率（スムージングm=10） |
| `distance_top1_finish_rate` | その距離での通算1着率 |
| `distance_rate_diff` | 距離別成績 − 全体成績の差分 |
| `new_distance_flag` | その距離での初出走フラグ |

## モデル比較

### 学習・検証期間

| | 既存モデル | 新モデル |
|---|---|---|
| **学習期間** | 2016-01-05 〜 2025-11-09 (489,925行 / 34,090レース) | 同左 |
| **検証期間** | 2025-11-15 〜 2026-05-10 (24,112行 / 1,688レース) | 同左 |

### 精度比較

| 指標 | 既存モデル | 新モデル | 差分 | 判定 (±0.005) |
|---|---|---|---|---|
| **NDCG@3** | 0.5752 | 0.5736 | -0.0016 | ✅ 同等 |
| **AUC** | 0.8052 | 0.8159 | +0.0107 | ✅ 改善 |
| **Recall@3** | 0.5026 | 0.5039 | +0.0013 | ✅ 改善 |

特徴量数: 273 → 297（+24）

### 総合判定

✅ **マージ可**（全指標が合格基準を満たす）

## テスト計画

- [x] `/check-leak` 実施済み → リーク検出なし
  - `distance_band`: `r_i.distance`（発走前確定値）から導出
  - `distance_change/flag`: 1走前JOINに `race_date < 当日` 条件あり
  - 距離 TE: `RANGE BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING` で同日除外
- [x] `pytest tests/test_features.py` 通過（51件、うち12件が今回追加）
- [x] `pytest tests/` 全テスト通過

## 依存関係

- #270（TE）の `*_distance_band_te` は本 Issue 完了後に実装可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)