### PR TITLE
feat: 過去単複オッズバックフィルスクリプト追加・ライブ戦略フォールバック実装 (#283)

### DIFF
--- a/scripts/backfill_historical_place_odds.py
+++ b/scripts/backfill_historical_place_odds.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""
+過去単複オッズ バックフィルスクリプト
+
+netkeibaスクレイパー（Issue #131）稼働前の期間（2025-11-15〜2026-03-06）について、
+predictions.daily_odds にデータが存在しない race_id を対象に
+netkeibaから単複オッズを取得して保存する。
+
+すでに predictions.daily_odds にデータが存在する race_id は自動的にスキップするため、
+中断後の再実行でも安全に続きから再開できる。
+
+Usage:
+    # 対象期間のバックフィル（ドライラン）
+    .venv/bin/python scripts/backfill_historical_place_odds.py \\
+        --project-id keiba-prediction-1768734113 \\
+        --start-date 2025-11-15 \\
+        --end-date 2026-03-06 \\
+        --dry-run
+
+    # 実際に実行
+    .venv/bin/python scripts/backfill_historical_place_odds.py \\
+        --project-id keiba-prediction-1768734113 \\
+        --start-date 2025-11-15 \\
+        --end-date 2026-03-06
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import logging
+import sys
+from pathlib import Path
+
+import pandas as pd
+from google.cloud import bigquery
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.scrape_historical_odds import (
+    fetch_already_scraped_race_ids,
+    fetch_target_races,
+    jrdb_to_netkeiba_race_id,
+    scrape_win_place_odds_batch,
+)
+from src.automation.data.netkeiba_scraper import save_odds_to_bq
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+def fetch_missing_race_ids(
+    project_id: str,
+    start_date: str,
+    end_date: str,
+) -> list[dict]:
+    """
+    predictions.daily_odds にデータが存在しない race_id を返す。
+
+    raw.race_info の全 race_id を取得し、predictions.daily_odds に存在しない
+    ものだけを返すことで、バックフィル対象を絞り込む。
+
+    Args:
+        project_id: GCP プロジェクト ID
+        start_date: 取得開始日（YYYY-MM-DD）
+        end_date: 取得終了日（YYYY-MM-DD）
+
+    Returns:
+        [{"race_id": str, "race_date": date}] のリスト
+    """
+    all_races = fetch_target_races(project_id, start_date, end_date)
+    already_scraped = fetch_already_scraped_race_ids(project_id, "daily_odds")
+
+    missing = [r for r in all_races if r["race_id"] not in already_scraped]
+    logger.info(
+        f"バックフィル対象: {len(missing):,}レース "
+        f"（全{len(all_races):,}レースのうち既スクレイプ済み: {len(already_scraped):,}）"
+    )
+    return missing
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "predictions.daily_odds に未存在の race_id について "
+            "netkeibaから単複オッズを取得してバックフィルする"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("--project-id", required=True, help="GCPプロジェクトID")
+    parser.add_argument(
+        "--start-date",
+        default="2025-11-15",
+        help="バックフィル開始日（YYYY-MM-DD, デフォルト: 2025-11-15）",
+    )
+    parser.add_argument(
+        "--end-date",
+        default="2026-03-06",
+        help="バックフィル終了日（YYYY-MM-DD, デフォルト: 2026-03-06）",
+    )
+    parser.add_argument(
+        "--sleep-sec",
+        type=float,
+        default=2.0,
+        help="ページ間スリープ秒数（デフォルト: 2.0、netkeibaへの負荷軽減のため変更不推奨）",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=50,
+        help="BQへのバッチ保存単位のレース数（デフォルト: 50）",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="対象レース数の確認のみ行い、スクレイプは実行しない",
+    )
+    args = parser.parse_args()
+
+    missing_races = fetch_missing_race_ids(
+        args.project_id,
+        args.start_date,
+        args.end_date,
+    )
+
+    if not missing_races:
+        logger.info("バックフィル対象レースがありません（すべて取得済みです）")
+        sys.exit(0)
+
+    # netkeiba race_id を付与
+    converted: list[dict] = []
+    error_count = 0
+    for race in missing_races:
+        try:
+            netkeiba_id = jrdb_to_netkeiba_race_id(race["race_id"])
+            converted.append({**race, "netkeiba_race_id": netkeiba_id})
+        except ValueError as e:
+            logger.warning(f"race_id変換スキップ: {race['race_id']} - {e}")
+            error_count += 1
+
+    if error_count > 0:
+        logger.warning(f"変換エラー: {error_count}件スキップ")
+
+    logger.info(f"変換後のバックフィル対象: {len(converted):,}レース")
+
+    est_hours = len(converted) * args.sleep_sec * 2 / 3600
+    logger.info(f"推定所要時間: 約{est_hours:.1f}時間（sleep_sec={args.sleep_sec}）")
+
+    if args.dry_run:
+        logger.info("[DRY RUN] ここで終了します（--dry-run オプション）")
+        sys.exit(0)
+
+    total_saved = 0
+    for batch_start in range(0, len(converted), args.batch_size):
+        batch = converted[batch_start : batch_start + args.batch_size]
+        batch_end = min(batch_start + args.batch_size, len(converted))
+        logger.info(
+            f"バッチ処理: {batch_start + 1}〜{batch_end} / {len(converted):,}レース "
+            f"（{batch[0]['race_date']} ～ {batch[-1]['race_date']}）"
+        )
+
+        rows = scrape_win_place_odds_batch(batch, sleep_sec=args.sleep_sec)
+        if not rows:
+            logger.warning("  バッチ内でオッズが取得できませんでした")
+            continue
+
+        df = pd.DataFrame(rows)
+        saved = save_odds_to_bq(df, args.project_id)
+        total_saved += saved
+        logger.info(f"  保存: {saved}行 / 累計: {total_saved:,}行")
+
+    logger.info(f"バックフィル完了: 累計{total_saved:,}行保存")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/backfill_historical_place_odds.py
+++ b/scripts/backfill_historical_place_odds.py
@@ -33,7 +33,6 @@ import sys
 from pathlib import Path
 
 import pandas as pd
-from google.cloud import bigquery
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 

--- a/scripts/run_strategy.py
+++ b/scripts/run_strategy.py
@@ -216,7 +216,6 @@ def fetch_daily_odds(
     Returns:
         オッズ DataFrame (race_id, horse_number, place_odds_min, win_odds)
     """
-    _BASE_COLS = ["race_id", "horse_number", "place_odds_min", "win_odds"]
     all_results: list[pd.DataFrame] = []
 
     # Stage 1: predictions.daily_odds（netkeibaスクレイプ）
@@ -229,16 +228,14 @@ def fetch_daily_odds(
         df1 = client.query(query1).to_dataframe()
         if len(df1) > 0:
             all_results.append(df1)
-            covered_ids = set(df1["race_id"].unique())
             logger.info(
                 f"predictions.daily_odds から {len(df1)} 件取得"
-                f"（カバー: {len(covered_ids)} レース）"
+                f"（カバー: {df1['race_id'].nunique()} レース）"
             )
         else:
             logger.info("predictions.daily_odds にデータなし → raw.odds へ")
     except Exception as e:
         logger.info(f"predictions.daily_odds が存在しないか取得失敗: {e} → raw.odds へ")
-        covered_ids = set()
 
     # Stage 2: raw.odds（JRDB基準オッズ）
     # predictions.daily_odds でカバーできなかったレースのみ補完する

--- a/scripts/run_strategy.py
+++ b/scripts/run_strategy.py
@@ -204,15 +204,97 @@ def fetch_daily_odds(
     project_id: str,
     target_date: datetime.date,
 ) -> pd.DataFrame:
-    """predictions.daily_odds から当日のオッズを取得する"""
-    query = f"""
-    SELECT race_id, horse_number, win_odds, place_odds_min, place_odds_max, scraped_at
-    FROM `{project_id}.predictions.daily_odds`
-    WHERE race_date = '{target_date.isoformat()}'
     """
-    df = client.query(query).to_dataframe()
-    logger.info(f"オッズデータ取得: {len(df)}行 ({target_date})")
-    return df
+    当日のオッズを以下の優先順位で取得する
+
+    優先順位:
+      1. predictions.daily_odds（netkeibaスクレイプ）: 精度が高い
+      2. raw.odds（JRDB基準オッズ）: スクレイプ失敗時のフォールバック
+
+    レースIDでカバー済みのレースは後段のステージをスキップする。
+
+    Returns:
+        オッズ DataFrame (race_id, horse_number, place_odds_min, win_odds)
+    """
+    _BASE_COLS = ["race_id", "horse_number", "place_odds_min", "win_odds"]
+    all_results: list[pd.DataFrame] = []
+
+    # Stage 1: predictions.daily_odds（netkeibaスクレイプ）
+    try:
+        query1 = f"""
+        SELECT race_id, horse_number, win_odds, place_odds_min, place_odds_max, scraped_at
+        FROM `{project_id}.predictions.daily_odds`
+        WHERE race_date = '{target_date.isoformat()}'
+        """
+        df1 = client.query(query1).to_dataframe()
+        if len(df1) > 0:
+            all_results.append(df1)
+            covered_ids = set(df1["race_id"].unique())
+            logger.info(
+                f"predictions.daily_odds から {len(df1)} 件取得"
+                f"（カバー: {len(covered_ids)} レース）"
+            )
+        else:
+            logger.info("predictions.daily_odds にデータなし → raw.odds へ")
+    except Exception as e:
+        logger.info(f"predictions.daily_odds が存在しないか取得失敗: {e} → raw.odds へ")
+        covered_ids = set()
+
+    # Stage 2: raw.odds（JRDB基準オッズ）
+    # predictions.daily_odds でカバーできなかったレースのみ補完する
+    covered_ids_so_far = set()
+    if all_results:
+        covered_ids_so_far = set(all_results[0]["race_id"].unique())
+
+    try:
+        # 当日全レースを対象に raw.odds を取得し、未カバー分だけ使用する
+        query2 = f"""
+        SELECT
+            race_id, horse_number,
+            MAX(CASE WHEN odds_type = 'place' THEN odds_value END) AS place_odds_min,
+            MAX(CASE WHEN odds_type = 'win'   THEN odds_value END) AS win_odds
+        FROM (
+            SELECT race_id, horse_number, odds_type, odds_value,
+                   ROW_NUMBER() OVER (
+                       PARTITION BY race_id, horse_number, odds_type
+                       ORDER BY odds_timestamp DESC
+                   ) AS rn
+            FROM `{project_id}.raw.odds`
+            WHERE odds_type IN ('place', 'win')
+              AND race_id IN (
+                  SELECT race_id FROM `{project_id}.raw.race_info`
+                  WHERE race_date = '{target_date.isoformat()}'
+              )
+        )
+        WHERE rn = 1
+        GROUP BY race_id, horse_number
+        """
+        df2 = client.query(query2).to_dataframe()
+        if len(df2) > 0:
+            # 既カバー済みレースを除外して補完
+            df2_supplement = df2[~df2["race_id"].isin(covered_ids_so_far)]
+            if len(df2_supplement) > 0:
+                # place_odds_min / win_odds の scraped_at 列を補完 DataFrame には付けない
+                df2_supplement = df2_supplement.copy()
+                all_results.append(df2_supplement)
+                logger.info(
+                    f"raw.odds からフォールバック: {len(df2_supplement)} 件取得"
+                    f"（補完レース: {df2_supplement['race_id'].nunique()} ）"
+                )
+            else:
+                logger.info("raw.odds: predictions.daily_odds でカバー済み（補完不要）")
+        else:
+            logger.info("raw.odds にもデータなし")
+    except Exception as e:
+        logger.warning(f"raw.odds からのオッズ取得に失敗しました: {e}")
+
+    if not all_results:
+        logger.warning(f"オッズデータが取得できませんでした ({target_date})")
+        return pd.DataFrame()
+
+    merged = pd.concat(all_results, ignore_index=True)
+    logger.info(f"オッズデータ取得: 合計{len(merged)}行 ({target_date})")
+    return merged
 
 
 

--- a/tests/test_run_strategy.py
+++ b/tests/test_run_strategy.py
@@ -14,7 +14,7 @@ from unittest.mock import MagicMock, call, patch
 import pandas as pd
 import pytest
 
-from scripts.run_strategy import build_race_df, _build_decision_row, save_decisions_to_bq
+from scripts.run_strategy import build_race_df, _build_decision_row, fetch_daily_odds, save_decisions_to_bq
 
 
 # ---------------------------------------------------------------------------
@@ -209,6 +209,122 @@ def _make_decisions(n: int = 2) -> list[dict]:
         }
         for i in range(1, n + 1)
     ]
+
+
+# ---------------------------------------------------------------------------
+# fetch_daily_odds のフォールバックテスト（Issue #283）
+# ---------------------------------------------------------------------------
+
+
+def _make_odds_df(race_ids: list[str], include_win_odds: bool = True) -> pd.DataFrame:
+    rows = []
+    for race_id in race_ids:
+        for hn in range(1, 4):
+            row = {"race_id": race_id, "horse_number": hn, "place_odds_min": 2.0 + hn}
+            if include_win_odds:
+                row["win_odds"] = 5.0 + hn
+            rows.append(row)
+    return pd.DataFrame(rows)
+
+
+class TestFetchDailyOdds:
+    """fetch_daily_odds の2段フォールバックテスト（Issue #283）"""
+
+    @patch("scripts.run_strategy.bigquery.Client")
+    def test_returns_daily_odds_when_available(self, mock_bq_cls):
+        """predictions.daily_odds にデータがある場合はそれを返す"""
+        target_date = datetime.date(2026, 5, 17)
+        odds_data = _make_odds_df(["race_001"])
+
+        mock_client = MagicMock()
+        mock_bq_cls.return_value = mock_client
+        # Stage1: daily_odds にデータあり
+        mock_client.query.return_value.to_dataframe.return_value = odds_data
+
+        result = fetch_daily_odds(mock_client, "test-project", target_date)
+
+        assert len(result) == len(odds_data)
+        assert set(result["race_id"]) == {"race_001"}
+
+    @patch("scripts.run_strategy.bigquery.Client")
+    def test_falls_back_to_raw_odds_when_daily_odds_empty(self, mock_bq_cls):
+        """predictions.daily_odds が空のとき raw.odds にフォールバックする"""
+        target_date = datetime.date(2026, 1, 10)
+        raw_odds_data = _make_odds_df(["race_002"])
+
+        mock_client = MagicMock()
+        mock_bq_cls.return_value = mock_client
+
+        # Stage1 は空 DataFrame、Stage2 は raw.odds データを返す
+        mock_client.query.return_value.to_dataframe.side_effect = [
+            pd.DataFrame(),   # daily_odds: empty
+            raw_odds_data,    # raw.odds: has data
+        ]
+
+        result = fetch_daily_odds(mock_client, "test-project", target_date)
+
+        assert len(result) == len(raw_odds_data)
+        assert set(result["race_id"]) == {"race_002"}
+
+    @patch("scripts.run_strategy.bigquery.Client")
+    def test_falls_back_to_raw_odds_when_daily_odds_raises(self, mock_bq_cls):
+        """predictions.daily_odds の取得で例外が発生したとき raw.odds にフォールバックする"""
+        target_date = datetime.date(2026, 1, 10)
+        raw_odds_data = _make_odds_df(["race_003"])
+
+        mock_client = MagicMock()
+        mock_bq_cls.return_value = mock_client
+
+        # Stage1 は例外、Stage2 は raw.odds データを返す
+        def side_effect_query(q):
+            result_mock = MagicMock()
+            if "daily_odds" in q:
+                result_mock.to_dataframe.side_effect = Exception("table not found")
+            else:
+                result_mock.to_dataframe.return_value = raw_odds_data
+            return result_mock
+
+        mock_client.query.side_effect = side_effect_query
+
+        result = fetch_daily_odds(mock_client, "test-project", target_date)
+
+        assert len(result) == len(raw_odds_data)
+
+    @patch("scripts.run_strategy.bigquery.Client")
+    def test_supplements_missing_races_from_raw_odds(self, mock_bq_cls):
+        """daily_odds にない race_id のみ raw.odds から補完する"""
+        target_date = datetime.date(2026, 1, 10)
+        daily_data = _make_odds_df(["race_001"])
+        raw_data = _make_odds_df(["race_001", "race_002"])  # race_001 は重複
+
+        mock_client = MagicMock()
+        mock_bq_cls.return_value = mock_client
+        mock_client.query.return_value.to_dataframe.side_effect = [
+            daily_data,   # Stage 1: daily_odds
+            raw_data,     # Stage 2: raw.odds
+        ]
+
+        result = fetch_daily_odds(mock_client, "test-project", target_date)
+
+        # race_001 は daily_odds のみ、race_002 は raw.odds から補完
+        race_ids = set(result["race_id"].unique())
+        assert "race_001" in race_ids
+        assert "race_002" in race_ids
+        # race_001 は重複しない（daily_odds 優先）
+        assert len(result[result["race_id"] == "race_001"]) == len(daily_data)
+
+    @patch("scripts.run_strategy.bigquery.Client")
+    def test_returns_empty_df_when_both_sources_empty(self, mock_bq_cls):
+        """両ソースにデータがない場合は空 DataFrame を返す"""
+        target_date = datetime.date(2025, 6, 1)
+
+        mock_client = MagicMock()
+        mock_bq_cls.return_value = mock_client
+        mock_client.query.return_value.to_dataframe.return_value = pd.DataFrame()
+
+        result = fetch_daily_odds(mock_client, "test-project", target_date)
+
+        assert result.empty
 
 
 class TestSaveDecisionsToBq:


### PR DESCRIPTION
## Summary

- **タスク1**: `scripts/backfill_historical_place_odds.py` を新規追加。netkeibaスクレイパー稼働前の期間（2025-11-15〜2026-03-06）について `predictions.daily_odds` にデータが存在しない race_id を対象に、netkeibaから単複オッズを一括取得・保存する専用スクリプト。既スクレイプ済み race_id は自動スキップし、中断後の再実行も安全。
- **タスク2**: `scripts/run_strategy.py` の `fetch_daily_odds()` を `run_backtest.py` の `fetch_place_odds()` と同等の2段フォールバックに拡張。Stage1: `predictions.daily_odds`（netkeiba実オッズ）→ Stage2: `raw.odds`（JRDB基準オッズ）。スクレイプ失敗時に全馬スキップされる問題を解消。
- テスト5件追加（`TestFetchDailyOdds`）：daily_odds優先・raw.oddsフォールバック・例外時フォールバック・未カバーレース補完・両ソース空のケースを検証。

## Test plan

- [x] `tests/test_run_strategy.py` 全17件通過（既存9件 + 新規5件 + 既存3件）
- [x] `scripts/backfill_historical_place_odds.py` のimportが正常に動作
- [ ] 実際のGCP環境でのバックフィル実行（別途手動実行が必要）

## 使用方法

```bash
# バックフィル（ドライラン）
.venv/bin/python scripts/backfill_historical_place_odds.py \
    --project-id keiba-prediction-1768734113 \
    --start-date 2025-11-15 \
    --end-date 2026-03-06 \
    --dry-run

# 実行
.venv/bin/python scripts/backfill_historical_place_odds.py \
    --project-id keiba-prediction-1768734113 \
    --start-date 2025-11-15 \
    --end-date 2026-03-06
```

Closes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)