### PR TITLE
fix: JRDBパーサーのbase_popularity/win_popularity誤解析を修正する

### DIFF
--- a/scripts/diagnose_prediction_nan.py
+++ b/scripts/diagnose_prediction_nan.py
@@ -1,0 +1,331 @@
+"""
+当日 vs 過去日の特徴量NaN率・値分布比較診断スクリプト
+
+現象1（当日予測スコアが平均的で分散が狭い）の原因を特定するため、
+当日と過去比較日の features.training_data を全列にわたって比較する。
+
+Usage:
+    .venv/bin/python scripts/diagnose_prediction_nan.py \
+        --project-id <PROJECT_ID> \
+        --target-date 2026-05-17 \
+        --compare-date 2026-05-10
+
+Output:
+    - 全特徴量のNaN率一覧（当日 vs 比較日）
+    - NaN率が高い特徴量のグループ別サマリ
+    - base_popularity vs win_popularity の乖離確認（現象2調査）
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+import pandas as pd
+from google.cloud import bigquery
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def fetch_date_data(client: bigquery.Client, project_id: str, date: str) -> pd.DataFrame:
+    query = f"""
+    SELECT *
+    FROM `{project_id}.features.training_data`
+    WHERE race_date = '{date}'
+    ORDER BY race_id, horse_number
+    """
+    return client.query(query).to_dataframe()
+
+
+def print_section(title: str) -> None:
+    print(f"\n{'='*70}")
+    print(f"  {title}")
+    print("="*70)
+
+
+def report_all_nan_rates(today_df: pd.DataFrame, past_df: pd.DataFrame) -> pd.DataFrame:
+    """全列のNaN率を比較して返す（数値・カテゴリカル両方）"""
+    rows = []
+    all_cols = list(today_df.columns)
+    for col in all_cols:
+        today_nan = today_df[col].isna().mean()
+        past_nan = past_df[col].isna().mean() if col in past_df.columns else float("nan")
+        col_dtype = str(today_df[col].dtype)
+        rows.append({
+            "feature": col,
+            "dtype": col_dtype,
+            "today_nan_rate": today_nan,
+            "past_nan_rate": past_nan,
+            "diff": today_nan - past_nan,
+        })
+    return pd.DataFrame(rows).sort_values("today_nan_rate", ascending=False)
+
+
+def classify_feature_group(col: str) -> str:
+    """特徴量列をグループに分類する"""
+    if col in ("idm", "jockey_index", "info_index", "total_index",
+               "training_index", "stable_index", "popularity_index",
+               "surge_index", "base_odds", "base_popularity"):
+        return "JRDB指数"
+    if col in ("cha_training_index", "training_last_3f", "training_furlongs",
+               "training_intensity", "training_course_type", "training_count"):
+        return "調教CHA"
+    if col.endswith("_te") or col.endswith("_te_diff"):
+        return "Target Encoding"
+    if any(col.endswith(f"_{i}") for i in range(1, 6)) and any(
+        kw in col for kw in ("finish_position", "win_odds", "win_popularity",
+                              "idm", "finish_time", "last_3f", "corner",
+                              "race_date_diff", "popularity_rate", "upside_rate")
+    ):
+        return "過去走情報"
+    if any(kw in col for kw in ("top3_rate", "top2_rate", "top1_rate",
+                                  "finish_rate", "mean_finish", "ema_finish")):
+        return "馬成績集計"
+    if any(kw in col for kw in ("is_fresh", "is_renso", "continuous_run",
+                                  "idm_trend", "finish_position_trend",
+                                  "race_date_diff_3", "race_date_diff_4", "race_date_diff_5")):
+        return "ローテーション"
+    if any(kw in col for kw in ("weight_carried", "running_style", "pace_forecast",
+                                  "early_advantage", "behind_advantage",
+                                  "field_size", "pace_index", "ten_index",
+                                  "agari_index", "position_index")):
+        return "レース内指標"
+    if any(kw in col for kw in ("diff_sum", "diff", "surface", "rotation",
+                                  "bracket", "season", "direction")):
+        return "差分指標"
+    return "その他"
+
+
+def print_group_summary(nan_df: pd.DataFrame) -> None:
+    """グループ別のNaN率サマリを表示する"""
+    print_section("グループ別 NaN率サマリ（当日）")
+    nan_df["group"] = nan_df["feature"].apply(classify_feature_group)
+    summary = (
+        nan_df.groupby("group")
+        .agg(
+            列数=("feature", "count"),
+            当日NaN率_mean=("today_nan_rate", "mean"),
+            当日NaN率_max=("today_nan_rate", "max"),
+            過去NaN率_mean=("past_nan_rate", "mean"),
+            差分_mean=("diff", "mean"),
+        )
+        .sort_values("当日NaN率_mean", ascending=False)
+        .reset_index()
+    )
+    print(summary.to_string(index=False))
+    return nan_df  # group列を付加して返す
+
+
+def print_high_nan_features(nan_df: pd.DataFrame, threshold: float = 0.3) -> None:
+    """当日NaN率がthreshold以上の全列を表示する"""
+    high_nan = nan_df[nan_df["today_nan_rate"] >= threshold].copy()
+    print_section(f"当日NaN率 {threshold:.0%} 以上の特徴量（全{len(high_nan)}件）")
+    if len(high_nan) == 0:
+        print("  なし")
+        return
+    print(f"{'グループ':<20} {'特徴量':<50} {'当日NaN率':>10} {'過去NaN率':>10} {'差分':>8}")
+    print("-" * 100)
+    for _, row in high_nan.iterrows():
+        group = row.get("group", classify_feature_group(row["feature"]))
+        print(f"{group:<20} {row['feature']:<50} {row['today_nan_rate']:>10.1%} "
+              f"{row['past_nan_rate']:>10.1%} {row['diff']:>+8.1%}")
+
+
+def print_large_diff_features(nan_df: pd.DataFrame, diff_threshold: float = 0.1) -> None:
+    """当日と過去でNaN率の差が大きい特徴量を表示する"""
+    large_diff = nan_df[nan_df["diff"].abs() >= diff_threshold].copy()
+    large_diff = large_diff.sort_values("diff", ascending=False)
+    print_section(f"NaN率の乖離が {diff_threshold:.0%} 以上の特徴量（全{len(large_diff)}件）")
+    if len(large_diff) == 0:
+        print("  なし（当日と過去でNaN率のパターンはほぼ同じ）")
+        return
+    print(f"{'グループ':<20} {'特徴量':<50} {'当日NaN率':>10} {'過去NaN率':>10} {'差分':>8}")
+    print("-" * 100)
+    for _, row in large_diff.iterrows():
+        group = row.get("group", classify_feature_group(row["feature"]))
+        print(f"{group:<20} {row['feature']:<50} {row['today_nan_rate']:>10.1%} "
+              f"{row['past_nan_rate']:>10.1%} {row['diff']:>+8.1%}")
+
+
+def print_full_nan_table(nan_df: pd.DataFrame) -> None:
+    """全特徴量のNaN率を全件表示する"""
+    print_section(f"全特徴量のNaN率一覧（{len(nan_df)}列、当日NaN率降順）")
+    print(f"{'グループ':<20} {'特徴量':<50} {'dtype':<12} {'当日NaN率':>10} {'過去NaN率':>10} {'差分':>8}")
+    print("-" * 114)
+    for _, row in nan_df.iterrows():
+        group = row.get("group", classify_feature_group(row["feature"]))
+        print(f"{group:<20} {row['feature']:<50} {row['dtype']:<12} "
+              f"{row['today_nan_rate']:>10.1%} {row['past_nan_rate']:>10.1%} {row['diff']:>+8.1%}")
+
+
+def check_per_horse_nan(today_df: pd.DataFrame, past_df: pd.DataFrame) -> None:
+    """1馬あたりのNaN特徴量数の分布を確認する"""
+    print_section("1馬あたりのNaN特徴量数（全列対象）")
+    all_cols = [c for c in today_df.columns]
+    today_nan_counts = today_df[all_cols].isna().sum(axis=1)
+    past_nan_counts = past_df[all_cols].isna().sum(axis=1) if len(past_df) > 0 else pd.Series([0])
+
+    print(f"当日: mean={today_nan_counts.mean():.1f}, "
+          f"median={today_nan_counts.median():.1f}, "
+          f"max={today_nan_counts.max()}, min={today_nan_counts.min()}")
+    if len(past_nan_counts) > 0:
+        print(f"過去: mean={past_nan_counts.mean():.1f}, "
+              f"median={past_nan_counts.median():.1f}, "
+              f"max={past_nan_counts.max()}, min={past_nan_counts.min()}")
+
+    worst_idx = today_nan_counts.idxmax()
+    if pd.notna(worst_idx):
+        row = today_df.loc[worst_idx]
+        print(f"\nNaN最多馬: race_id={row.get('race_id','?')}, "
+              f"horse_number={row.get('horse_number','?')}, "
+              f"horse_name={row.get('horse_name','?')}, "
+              f"NaN数={today_nan_counts[worst_idx]}")
+
+
+def check_value_distribution(today_df: pd.DataFrame, past_df: pd.DataFrame,
+                              key_cols: list[str]) -> None:
+    """重要特徴量の値分布（mean/std）を当日と過去で比較する"""
+    print_section("重要特徴量の値分布比較（NaNを除外）")
+    print(f"{'特徴量':<40} {'当日mean':>10} {'当日std':>10} {'過去mean':>10} {'過去std':>10}")
+    print("-" * 74)
+    for col in key_cols:
+        if col not in today_df.columns:
+            continue
+        t_vals = today_df[col].dropna()
+        p_vals = past_df[col].dropna() if col in past_df.columns else pd.Series(dtype=float)
+        t_mean = t_vals.mean() if len(t_vals) > 0 else float("nan")
+        t_std = t_vals.std() if len(t_vals) > 0 else float("nan")
+        p_mean = p_vals.mean() if len(p_vals) > 0 else float("nan")
+        p_std = p_vals.std() if len(p_vals) > 0 else float("nan")
+        print(f"{col:<40} {t_mean:>10.3f} {t_std:>10.3f} {p_mean:>10.3f} {p_std:>10.3f}")
+
+
+def check_base_popularity_vs_actual(client: bigquery.Client, project_id: str,
+                                    date: str, race_id_example: str | None) -> None:
+    """
+    現象2調査: base_popularity(JRDB想定人気) vs win_popularity(実際の単勝人気) の乖離確認
+    """
+    print_section(f"現象2調査: base_popularity vs 実際の単勝人気 (date={date})")
+
+    where = f"r_i.race_date = '{date}'"
+    if race_id_example:
+        where += f" AND h_r.race_id = '{race_id_example}'"
+
+    query = f"""
+    SELECT
+        h_r.race_id
+        ,h_r.horse_number
+        ,h_r.horse_name
+        ,h_r.base_popularity
+        ,r_r.win_popularity
+        ,h_r.idm
+        ,r_r.finish_position
+    FROM `{project_id}`.raw.horse_results AS h_r
+    INNER JOIN `{project_id}`.raw.race_info AS r_i
+        ON h_r.race_id = r_i.race_id
+    LEFT JOIN `{project_id}`.raw.race_results AS r_r
+        ON h_r.race_id = r_r.race_id
+        AND h_r.horse_number = r_r.horse_number
+    WHERE {where}
+    ORDER BY h_r.race_id, h_r.horse_number
+    LIMIT 300
+    """
+    try:
+        df = client.query(query).to_dataframe()
+        if len(df) == 0:
+            print("  データなし")
+            return
+
+        print(f"取得行数: {len(df)}")
+        print(f"base_popularity NULL率: {df['base_popularity'].isna().mean():.1%}")
+        print(f"win_popularity  NULL率: {df['win_popularity'].isna().mean():.1%}")
+
+        valid = df.dropna(subset=["base_popularity", "win_popularity"]).copy()
+        if len(valid) > 0:
+            valid["diff"] = (valid["win_popularity"] - valid["base_popularity"]).abs()
+            print(f"\n乖離(|win_pop - base_pop|): "
+                  f"mean={valid['diff'].mean():.2f}, "
+                  f"max={valid['diff'].max():.0f}, "
+                  f"完全一致割合={(valid['diff']==0).mean():.1%}")
+
+            print("\n乖離Top10:")
+            top10 = valid.nlargest(10, "diff")[
+                ["race_id", "horse_number", "horse_name",
+                 "base_popularity", "win_popularity", "diff", "idm", "finish_position"]
+            ]
+            print(top10.to_string(index=False))
+        else:
+            print("  base_popularity/win_popularity が両方揃う行がない")
+    except Exception as e:
+        print(f"  クエリ失敗: {e}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="予測特徴量NaN診断スクリプト")
+    parser.add_argument("--project-id", required=True)
+    parser.add_argument("--target-date", default="2026-05-17",
+                        help="当日（スコア分散が小さい日）")
+    parser.add_argument("--compare-date", default="2026-05-10",
+                        help="比較対象（スコア分散が大きい過去日）")
+    parser.add_argument("--race-id", default=None,
+                        help="現象2調査用 race_id（例: 202605101212）")
+    parser.add_argument("--full", action="store_true",
+                        help="全特徴量のNaN率を全件表示する")
+    args = parser.parse_args()
+
+    client = bigquery.Client(project=args.project_id)
+
+    print(f"当日データ取得中: {args.target_date}")
+    today_df = fetch_date_data(client, args.project_id, args.target_date)
+    print(f"  → {len(today_df)} 行 / {len(today_df.columns)} 列")
+
+    print(f"比較日データ取得中: {args.compare_date}")
+    past_df = fetch_date_data(client, args.project_id, args.compare_date)
+    print(f"  → {len(past_df)} 行 / {len(past_df.columns)} 列")
+
+    if len(today_df) == 0:
+        print(f"\n[ERROR] 当日({args.target_date})のデータが features.training_data に存在しません。")
+        print("特徴量パイプラインが実行されていない可能性があります。")
+        sys.exit(1)
+
+    # 全列のNaN率を計算
+    nan_df = report_all_nan_rates(today_df, past_df)
+
+    # グループ分類を付加
+    nan_df["group"] = nan_df["feature"].apply(classify_feature_group)
+
+    # ── 診断1: グループ別サマリ ──
+    print_group_summary(nan_df)
+
+    # ── 診断2: 当日NaN率30%以上の特徴量（全件） ──
+    print_high_nan_features(nan_df, threshold=0.30)
+
+    # ── 診断3: 当日と過去でNaN率の差が10%以上の特徴量 ──
+    print_large_diff_features(nan_df, diff_threshold=0.10)
+
+    # ── 診断4: 1馬あたりNaN数の分布 ──
+    check_per_horse_nan(today_df, past_df)
+
+    # ── 診断5: 重要特徴量の値分布比較 ──
+    key_cols = [
+        "idm", "jockey_index", "info_index", "training_index", "stable_index",
+        "base_popularity", "base_odds", "surge_index",
+        "jockey_te", "trainer_te",
+        "cha_training_index", "training_last_3f",
+        "finish_position_1", "win_popularity_1", "idm_1",
+        "mean_finish_position", "ema_finish_position",
+        "is_fresh", "is_renso", "continuous_run_count",
+    ]
+    check_value_distribution(today_df, past_df, key_cols)
+
+    # ── 診断6: 全件表示（--full指定時） ──
+    if args.full:
+        print_full_nan_table(nan_df)
+
+    # ── 診断7: base_popularity vs 実際の人気（現象2調査） ──
+    check_base_popularity_vs_actual(
+        client, args.project_id, args.compare_date, args.race_id
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/automation/data/jrdb_parser.py
+++ b/src/automation/data/jrdb_parser.py
@@ -639,8 +639,8 @@ class JRDBParser:
             # === オッズ・人気 ===
             win_odds = JRDBParser.safe_float(line[115:121])
             _win_pop_raw = JRDBParser.safe_int(line[121:123])
-            # JRDB は取消馬に 99 (センチネル値) を使用する。競馬は最大18頭なので >18 は無効
-            win_popularity = _win_pop_raw if (_win_pop_raw is not None and _win_pop_raw <= 18) else None
+            # JRDB は取消馬に 99 (センチネル値) または 0 を使用する。有効値は 1〜18
+            win_popularity = _win_pop_raw if (_win_pop_raw is not None and 1 <= _win_pop_raw <= 18) else None
 
             # === JRDB指数 ===
             idm = JRDBParser.safe_float(line[123:126])

--- a/src/automation/data/jrdb_parser.py
+++ b/src/automation/data/jrdb_parser.py
@@ -290,10 +290,13 @@ class JRDBParser:
             improvement = None  # 上昇度は別位置
 
             # === 基準オッズ・人気 (位置77以降) ===
-            base_odds = JRDBParser.safe_float(line[78:83])  # 基準オッズ (5文字: 78-83) → "46.61"
-            base_popularity = JRDBParser.safe_int(line[83:85])  # 人気順位 (2文字: 83-85) → "3 " → 3
-            base_place_odds = JRDBParser.safe_float(line[86:91])  # 基準複勝オッズ (5文字: 86-91) → "8.613"
-            base_place_popularity = JRDBParser.safe_int(line[89:91])  # 複勝人気 (2文字: 89-91) → "13"
+            # 実データ検証による正しいフィールドレイアウト:
+            # [78:82]=基準オッズ(4文字"XX.X"), [82:84]=基準人気(2文字), スペース[84],
+            # [85:89]=基準複勝オッズ(4文字), [89:91]=基準複勝人気(2文字)
+            base_odds = JRDBParser.safe_float(line[78:82])         # 基準オッズ (4文字: 78-82) → "84.0"
+            base_popularity = JRDBParser.safe_int(line[82:84])     # 人気順位 (2文字: 82-84) → " 3" or "10"
+            base_place_odds = JRDBParser.safe_float(line[85:89])   # 基準複勝オッズ (4文字: 85-89) → "31.4"
+            base_place_popularity = JRDBParser.safe_int(line[89:91])  # 複勝人気 (2文字: 89-91) → "16"
 
             # === 特定情報マーク (位置93以降) ===
             specific_mark_circle = JRDBParser.safe_int(line[93:94]) if len(line) > 94 else None

--- a/src/automation/data/jrdb_parser.py
+++ b/src/automation/data/jrdb_parser.py
@@ -638,7 +638,9 @@ class JRDBParser:
 
             # === オッズ・人気 ===
             win_odds = JRDBParser.safe_float(line[115:121])
-            win_popularity = JRDBParser.safe_int(line[121:123])
+            _win_pop_raw = JRDBParser.safe_int(line[121:123])
+            # JRDB は取消馬に 99 (センチネル値) を使用する。競馬は最大18頭なので >18 は無効
+            win_popularity = _win_pop_raw if (_win_pop_raw is not None and _win_pop_raw <= 18) else None
 
             # === JRDB指数 ===
             idm = JRDBParser.safe_float(line[123:126])

--- a/tests/test_jrdb_parser.py
+++ b/tests/test_jrdb_parser.py
@@ -328,3 +328,80 @@ class TestParseKyfLineBasePopularity:
         assert result is not None
         assert result["base_place_odds"] == pytest.approx(1.3)
         assert result["base_place_popularity"] == 1
+
+
+def _make_sec_line(
+    race_key: str = "06263309",
+    horse_num: str = "01",
+    finish_pos: str = "01",
+    abnormal_code: str = "0",
+    win_popularity: str = " 5",
+) -> str:
+    """
+    テスト用の SEC 固定長行を生成する。
+
+    SECフォーマット（抜粋）:
+      [0:8]    レースキー
+      [8:10]   馬番
+      [10:18]  血統登録番号
+      [18:26]  日付
+      [26:44]  馬名 (全角18文字スロット)
+      [44:93]  距離・コース等 (49文字)
+      [93:95]  着順
+      [95:96]  異常コード
+      [96:115] タイム・斤量等 (19文字)
+      [115:121] win_odds (6文字)
+      [121:123] win_popularity (2文字)
+      [123:]   残余
+    """
+    return (
+        race_key      # [0:8]
+        + horse_num   # [8:10]
+        + "00000000"  # [10:18] horse_id
+        + "20260404"  # [18:26] race_date
+        + "A" * 18    # [26:44] horse_name
+        + " " * 49    # [44:93] 距離・コース等
+        + finish_pos  # [93:95]
+        + abnormal_code  # [95:96]
+        + " " * 19    # [96:115] タイム・斤量等
+        + "      "    # [115:121] win_odds (空白)
+        + win_popularity  # [121:123]
+        + " " * 152   # 残余パディング（200文字以上確保）
+    )
+
+
+class TestParseSecLineWinPopularity:
+    """parse_sec_line の win_popularity フィールドに関するテスト"""
+
+    def test_normal_popularity_returned(self):
+        """1〜18番人気は正常に返されること"""
+        line = _make_sec_line(finish_pos="05", win_popularity=" 5")
+        result = JRDBParser.parse_sec_line(line)
+        assert result is not None
+        assert result["win_popularity"] == 5
+
+    def test_cancelled_horse_sentinel_99_returns_none(self):
+        """取消馬の JRDB センチネル値 99 は None に変換されること"""
+        line = _make_sec_line(
+            finish_pos="00", abnormal_code="2", win_popularity="99"
+        )
+        result = JRDBParser.parse_sec_line(line)
+        assert result is not None
+        assert result["finish_position"] == 0
+        assert result["win_popularity"] is None, (
+            "取消馬の win_popularity=99 は None でなければならない"
+        )
+
+    def test_value_above_18_returns_none(self):
+        """18 超の値は無効なため None を返すこと"""
+        line = _make_sec_line(win_popularity="99")
+        result = JRDBParser.parse_sec_line(line)
+        assert result is not None
+        assert result["win_popularity"] is None
+
+    def test_max_valid_popularity_18(self):
+        """18番人気（最大頭数）は正常に返されること"""
+        line = _make_sec_line(win_popularity="18")
+        result = JRDBParser.parse_sec_line(line)
+        assert result is not None
+        assert result["win_popularity"] == 18

--- a/tests/test_jrdb_parser.py
+++ b/tests/test_jrdb_parser.py
@@ -3,6 +3,7 @@ JRDBParser のユニットテスト
 
 Issue #214: parse_baa_line が start_time を正しく返すことを検証する。
 Issue #272: parse_cha_line が調教本追切データを正しく解析することを検証する。
+Issue #290: parse_kyf_line が base_popularity を10+人気でも正しく返すことを検証する。
 """
 
 import sys
@@ -237,3 +238,93 @@ class TestParseChaLine:
         assert result["race_id"] == "06161101"
         assert result["horse_number"] == 1
         assert result["training_date"] == "2015-12-31"
+
+
+def _make_kyf_line(odds_section: str = " 2.3 1  1.3 1  5 ") -> str:
+    """
+    テスト用の KYF 固定長行を生成する。
+
+    KYFフォーマット（抜粋）:
+      [0:8]   レースキー
+      [8:10]  馬番
+      [10:18] 血統登録番号
+      [18:36] 馬名 (全角18文字スロット)
+      [36:78] 各種指数・脚質など (42文字)
+      [78:82] 基準オッズ (4文字 "XX.X")
+      [82:84] 基準人気 (2文字 " N" or "NN")
+      [84:85] セパレータ (スペース)
+      [85:89] 基準複勝オッズ (4文字)
+      [89:91] 基準複勝人気 (2文字)
+      [91:]   残余
+    """
+    return (
+        "06263301"   # [0:8]  race_key
+        + "01"       # [8:10] horse_number
+        + "00000000" # [10:18] horse_id
+        + "A" * 18   # [18:36] horse_name (ASCIIでパディング)
+        + " " * 42   # [36:78] 指数フィールド群
+        + odds_section  # [78:95] オッズ・人気セクション
+        + " " * 350  # 残余パディング
+    )
+
+
+class TestParseKyfLineBasePopularity:
+    """parse_kyf_line の base_popularity フィールドに関するテスト (Issue #290)"""
+
+    def test_single_digit_popularity(self):
+        """1〜9番人気が正しく解析されること"""
+        # " 1" → 1番人気、odds=2.3、place_odds=1.3
+        line = _make_kyf_line(" 2.3 1  1.3 1  5 ")
+        result = JRDBParser.parse_kyf_line(line)
+        assert result is not None
+        assert result["base_popularity"] == 1
+        assert result["base_odds"] == pytest.approx(2.3)
+
+    def test_ninth_popularity(self):
+        """9番人気が正しく解析されること"""
+        line = _make_kyf_line("48.3 9  9.0 9  0 ")
+        result = JRDBParser.parse_kyf_line(line)
+        assert result is not None
+        assert result["base_popularity"] == 9
+        assert result["base_odds"] == pytest.approx(48.3)
+
+    def test_tenth_popularity(self):
+        """10番人気が正しく解析されること（旧コードでは0と誤解析）"""
+        # 実ファイルのデータ: horse 10 (10th pop, 67.2 odds)
+        line = _make_kyf_line("67.210 11.910  0 ")
+        result = JRDBParser.parse_kyf_line(line)
+        assert result is not None
+        assert result["base_popularity"] == 10, (
+            "10番人気馬は base_popularity=10 でなければならない（旧バグでは0）"
+        )
+        assert result["base_odds"] == pytest.approx(67.2)
+        assert result["base_place_popularity"] == 10
+
+    def test_fifteenth_popularity(self):
+        """15番人気が正しく解析されること（旧コードでは5と誤解析）"""
+        line = _make_kyf_line("77.915 30.415  0 ")
+        result = JRDBParser.parse_kyf_line(line)
+        assert result is not None
+        assert result["base_popularity"] == 15, (
+            "15番人気馬は base_popularity=15 でなければならない（旧バグでは5）"
+        )
+        assert result["base_place_popularity"] == 15
+
+    def test_sixteenth_popularity(self):
+        """16番人気が正しく解析されること（旧コードでは6と誤解析）"""
+        line = _make_kyf_line("84.016 31.416  0 ")
+        result = JRDBParser.parse_kyf_line(line)
+        assert result is not None
+        assert result["base_popularity"] == 16
+        assert result["base_odds"] == pytest.approx(84.0)
+        assert result["base_place_odds"] == pytest.approx(31.4)
+        assert result["base_place_popularity"] == 16
+
+    def test_place_odds_not_collide_with_popularity(self):
+        """base_place_odds が base_place_popularity と重複しないこと"""
+        # horse 08: place_odds=1.3, place_pop=1
+        line = _make_kyf_line(" 2.3 1  1.3 1  5 ")
+        result = JRDBParser.parse_kyf_line(line)
+        assert result is not None
+        assert result["base_place_odds"] == pytest.approx(1.3)
+        assert result["base_place_popularity"] == 1

--- a/tests/test_jrdb_parser.py
+++ b/tests/test_jrdb_parser.py
@@ -405,3 +405,12 @@ class TestParseSecLineWinPopularity:
         result = JRDBParser.parse_sec_line(line)
         assert result is not None
         assert result["win_popularity"] == 18
+
+    def test_zero_popularity_returns_none(self):
+        """取消馬が win_popularity=0 を持つ場合も None に変換されること"""
+        line = _make_sec_line(finish_pos="00", abnormal_code="2", win_popularity=" 0")
+        result = JRDBParser.parse_sec_line(line)
+        assert result is not None
+        assert result["win_popularity"] is None, (
+            "win_popularity=0 は無効値（1未満）のため None でなければならない"
+        )


### PR DESCRIPTION
## 背景

現象2（2026-05-10 東京12R の予測上位馬が実際には7〜12番人気だった）の根本原因調査で、JRDBパーサーに2つのバグを発見した。

## 変更内容

### 1. KYF: base_popularity のバイト位置ずれ修正

**バグ内容**: `line[83:85]` で人気順位を取得していたが、実際のフィールドは `line[82:84]` に存在する。

**影響**: 10番人気以上の馬が誤った人気値を持つ:
- 10番人気 → `"0 "` → 0 として保存（1番人気と衝突）
- 15番人気 → `"5 "` → 5 として保存（5番人気と衝突）
- 16番人気 → `"6 "` → 6 として保存（6番人気と衝突）

**修正**:
```python
# Before (誤): 5文字 → 4文字
base_odds = safe_float(line[78:83])        → safe_float(line[78:82])
base_popularity = safe_int(line[83:85])    → safe_int(line[82:84])
base_place_odds = safe_float(line[86:91])  → safe_float(line[85:89])
# base_place_popularity は [89:91] のまま（偶然正しい位置だった）
```

実データ検証済み（KYF260404.txt 16頭レースで1〜16番人気が正しく取得されることを確認）。

### 2. SEC: win_popularity センチネル値 99 を None に変換

**バグ内容**: JRDB は取消馬（abnormal_code=2, finish_position=0）の win_popularity に 99 を格納するが、パーサーはそのまま 99 として BQ に保存していた。

**影響**: 特徴量 SQL の `popularity_rate_N = win_popularity / num_horses` が 99/16 ≈ 6.2 (本来最大 1.0) になり、過去に取消のある馬のモデル入力が破綻。

**修正**:
```python
# 18超（最大出走頭数）はすべて無効値として None に変換
win_popularity = raw_val if (raw_val is not None and raw_val <= 18) else None
```

### 3. 予測NaN診断スクリプト追加

`scripts/diagnose_prediction_nan.py`: 全374特徴量のNaN率を当日vs過去日付で比較するツール。  
現象1（2026-05-17 当日予測のTE特徴量51列がNaN）の根本原因特定に使用した。

## テスト

```
23 passed in 0.03s
```

- `TestParseKyfLineBasePopularity` (6件): 1/9/10/15/16番人気の正しい解析、place_oddsとの重複なし
- `TestParseSecLineWinPopularity` (4件): 正常値、センチネル99→None、18超→None、18=正常

## 関連Issue

- Issue #288: 推論時に features.training_data に依存しない直接SQL実行方式（案B、別PRで対応）
- 現象1の一時的な問題（2026-05-17）は PR #284/#285 マージ後の夜間パイプラインで自動解消する見込み

## データ再ロードについて

この修正を本番に反映するには:
1. PR マージ・Cloud Run デプロイ後
2. KYF/SECファイルを再解析してBQにフルロード（`raw.horse_results`, `raw.race_results`）
3. `features.training_data` を再生成

🤖 Generated with [Claude Code](https://claude.com/claude-code)