### PR TITLE
fix: TE特徴量（騎手・調教師・種牡馬）の低頻度エンティティをNaNマスク（#293）

### DIFF
--- a/src/ml/features/feature_query_raw.sql
+++ b/src/ml/features/feature_query_raw.sql
@@ -902,11 +902,17 @@ with temp_race_horse_count as (
   where r_r.finish_position > 0 or r_r.race_id is null
 )
 
-/* 騎手 Target Encoding（累積3着以内率、スムージング係数m=10、同日除外） */
-,temp_jockey_te as (
+/* 騎手 Target Encoding（累積3着以内率、スムージング係数m=10、同日除外）
+   出走数 < 20 の騎手は全TE値をNULLとして扱う（低頻度エンティティのノイズ除去） */
+,temp_jockey_te_pre as (
   select
     race_id
     ,horse_number
+    ,coalesce(count(*) over (
+      partition by jockey_code
+      order by unix_date(race_date)
+      range between unbounded preceding and 1 preceding
+    ), 0) as jockey_count
     ,safe_divide(
       coalesce(sum(is_top3) over (
         partition by jockey_code
@@ -1018,12 +1024,34 @@ with temp_race_horse_count as (
   from temp_te_history_base
     cross join temp_global_mean_te as g
 )
-
-/* 調教師 Target Encoding（累積3着以内率、スムージング係数m=10、同日除外） */
-,temp_trainer_te as (
+/* 低頻度マスク適用: 騎手の過去出走数 < 20 の場合は全TE値をNULLにする */
+,temp_jockey_te as (
   select
     race_id
     ,horse_number
+    ,IF(jockey_count >= 20, jockey_te, NULL) as jockey_te
+    ,IF(jockey_count >= 20, jockey_course_type_te, NULL) as jockey_course_type_te
+    ,IF(jockey_count >= 20, jockey_venue_te, NULL) as jockey_venue_te
+    ,IF(jockey_count >= 20, jockey_distance_band_te, NULL) as jockey_distance_band_te
+    ,IF(jockey_count >= 20, jockey_distance_te, NULL) as jockey_distance_te
+    ,IF(jockey_count >= 20, jockey_direction_te, NULL) as jockey_direction_te
+    ,IF(jockey_count >= 20, jockey_course_type_venue_te, NULL) as jockey_course_type_venue_te
+    ,IF(jockey_count >= 20, jockey_course_type_distance_te, NULL) as jockey_course_type_distance_te
+    ,IF(jockey_count >= 20, jockey_course_type_distance_venue_te, NULL) as jockey_course_type_distance_venue_te
+  from temp_jockey_te_pre
+)
+
+/* 調教師 Target Encoding（累積3着以内率、スムージング係数m=10、同日除外）
+   出走数 < 20 の調教師は全TE値をNULLとして扱う（低頻度エンティティのノイズ除去） */
+,temp_trainer_te_pre as (
+  select
+    race_id
+    ,horse_number
+    ,coalesce(count(*) over (
+      partition by trainer_code
+      order by unix_date(race_date)
+      range between unbounded preceding and 1 preceding
+    ), 0) as trainer_count
     ,safe_divide(
       coalesce(sum(is_top3) over (
         partition by trainer_code
@@ -1135,12 +1163,34 @@ with temp_race_horse_count as (
   from temp_te_history_base
     cross join temp_global_mean_te as g
 )
-
-/* 種牡馬 Target Encoding（累積3着以内率、スムージング係数m=10、同日除外） */
-,temp_sire_te as (
+/* 低頻度マスク適用: 調教師の過去出走数 < 20 の場合は全TE値をNULLにする */
+,temp_trainer_te as (
   select
     race_id
     ,horse_number
+    ,IF(trainer_count >= 20, trainer_te, NULL) as trainer_te
+    ,IF(trainer_count >= 20, trainer_course_type_te, NULL) as trainer_course_type_te
+    ,IF(trainer_count >= 20, trainer_venue_te, NULL) as trainer_venue_te
+    ,IF(trainer_count >= 20, trainer_distance_band_te, NULL) as trainer_distance_band_te
+    ,IF(trainer_count >= 20, trainer_distance_te, NULL) as trainer_distance_te
+    ,IF(trainer_count >= 20, trainer_direction_te, NULL) as trainer_direction_te
+    ,IF(trainer_count >= 20, trainer_course_type_venue_te, NULL) as trainer_course_type_venue_te
+    ,IF(trainer_count >= 20, trainer_course_type_distance_te, NULL) as trainer_course_type_distance_te
+    ,IF(trainer_count >= 20, trainer_course_type_distance_venue_te, NULL) as trainer_course_type_distance_venue_te
+  from temp_trainer_te_pre
+)
+
+/* 種牡馬 Target Encoding（累積3着以内率、スムージング係数m=10、同日除外）
+   出走数 < 20 の種牡馬は全TE値をNULLとして扱う（低頻度エンティティのノイズ除去） */
+,temp_sire_te_pre as (
+  select
+    race_id
+    ,horse_number
+    ,coalesce(count(*) over (
+      partition by sire_name
+      order by unix_date(race_date)
+      range between unbounded preceding and 1 preceding
+    ), 0) as sire_count
     ,safe_divide(
       coalesce(sum(is_top3) over (
         partition by sire_name
@@ -1251,6 +1301,22 @@ with temp_race_horse_count as (
     ) as sire_course_type_distance_venue_te
   from temp_te_history_base
     cross join temp_global_mean_te as g
+)
+/* 低頻度マスク適用: 種牡馬の過去出走数 < 20 の場合は全TE値をNULLにする */
+,temp_sire_te as (
+  select
+    race_id
+    ,horse_number
+    ,IF(sire_count >= 20, sire_te, NULL) as sire_te
+    ,IF(sire_count >= 20, sire_course_type_te, NULL) as sire_course_type_te
+    ,IF(sire_count >= 20, sire_venue_te, NULL) as sire_venue_te
+    ,IF(sire_count >= 20, sire_distance_band_te, NULL) as sire_distance_band_te
+    ,IF(sire_count >= 20, sire_distance_te, NULL) as sire_distance_te
+    ,IF(sire_count >= 20, sire_direction_te, NULL) as sire_direction_te
+    ,IF(sire_count >= 20, sire_course_type_venue_te, NULL) as sire_course_type_venue_te
+    ,IF(sire_count >= 20, sire_course_type_distance_te, NULL) as sire_course_type_distance_te
+    ,IF(sire_count >= 20, sire_course_type_distance_venue_te, NULL) as sire_course_type_distance_venue_te
+  from temp_sire_te_pre
 )
 
 /* 馬の距離帯別・距離別 TE 計算の元データ

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -484,6 +484,97 @@ class TestSQLTemplate:
         )
 
 
+class TestTELowFrequencyMask:
+    """TE低頻度エンティティNaNマスク（Issue #293）のテスト"""
+
+    def test_sql_has_te_pre_ctes(self):
+        """騎手・調教師・種牡馬の _pre CTE（カウント計算用）が存在すること"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        assert "temp_jockey_te_pre" in content, "temp_jockey_te_pre が見つかりません"
+        assert "temp_trainer_te_pre" in content, "temp_trainer_te_pre が見つかりません"
+        assert "temp_sire_te_pre" in content, "temp_sire_te_pre が見つかりません"
+
+    def test_sql_count_columns_use_correct_window(self):
+        """jockey_count / trainer_count / sire_count が 1 preceding ウィンドウを使用すること"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        # jockey_count の定義部分を確認
+        jockey_pre_start = content.find("temp_jockey_te_pre")
+        jockey_pre_end = content.find("temp_jockey_te as (")
+        jockey_pre_section = content[jockey_pre_start:jockey_pre_end]
+        assert "jockey_count" in jockey_pre_section
+        assert "range between unbounded preceding and 1 preceding" in jockey_pre_section
+
+        trainer_pre_start = content.find("temp_trainer_te_pre")
+        trainer_pre_end = content.find("temp_trainer_te as (")
+        trainer_pre_section = content[trainer_pre_start:trainer_pre_end]
+        assert "trainer_count" in trainer_pre_section
+        assert "range between unbounded preceding and 1 preceding" in trainer_pre_section
+
+        sire_pre_start = content.find("temp_sire_te_pre")
+        sire_pre_end = content.find("temp_sire_te as (")
+        sire_pre_section = content[sire_pre_start:sire_pre_end]
+        assert "sire_count" in sire_pre_section
+        assert "range between unbounded preceding and 1 preceding" in sire_pre_section
+
+    def test_sql_mask_wrapper_applies_if_condition(self):
+        """マスクラッパーCTEが IF(count >= 20, ..., NULL) を適用していること"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        # 騎手マスク
+        jockey_wrapper_start = content.find("temp_jockey_te as (")
+        jockey_wrapper_end = content.find("temp_trainer_te_pre")
+        jockey_wrapper = content[jockey_wrapper_start:jockey_wrapper_end]
+        assert "IF(jockey_count >= 20, jockey_te, NULL)" in jockey_wrapper
+        assert "IF(jockey_count >= 20, jockey_course_type_te, NULL)" in jockey_wrapper
+
+        # 調教師マスク
+        trainer_wrapper_start = content.find("temp_trainer_te as (")
+        trainer_wrapper_end = content.find("temp_sire_te_pre")
+        trainer_wrapper = content[trainer_wrapper_start:trainer_wrapper_end]
+        assert "IF(trainer_count >= 20, trainer_te, NULL)" in trainer_wrapper
+
+        # 種牡馬マスク
+        sire_wrapper_start = content.find("temp_sire_te as (")
+        sire_wrapper_end = content.find("temp_horse_distance_base")
+        sire_wrapper = content[sire_wrapper_start:sire_wrapper_end]
+        assert "IF(sire_count >= 20, sire_te, NULL)" in sire_wrapper
+
+    def test_sql_mask_threshold_is_20(self):
+        """マスク閾値が 20 であること（変更時に気付けるよう）"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        assert "IF(jockey_count >= 20," in content
+        assert "IF(trainer_count >= 20," in content
+        assert "IF(sire_count >= 20," in content
+
+    def test_sql_all_9_jockey_te_columns_masked(self):
+        """9つの騎手TE基本特徴量がすべてマスク対象であること"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        jockey_wrapper_start = content.find("temp_jockey_te as (")
+        jockey_wrapper_end = content.find("temp_trainer_te_pre")
+        jockey_wrapper = content[jockey_wrapper_start:jockey_wrapper_end]
+        expected_columns = [
+            "jockey_te",
+            "jockey_course_type_te",
+            "jockey_venue_te",
+            "jockey_distance_band_te",
+            "jockey_distance_te",
+            "jockey_direction_te",
+            "jockey_course_type_venue_te",
+            "jockey_course_type_distance_te",
+            "jockey_course_type_distance_venue_te",
+        ]
+        for col in expected_columns:
+            assert f"IF(jockey_count >= 20, {col}, NULL)" in jockey_wrapper, (
+                f"騎手TE '{col}' のマスク条件が見つかりません"
+            )
+
+    def test_sql_final_join_still_references_wrapper_ctes(self):
+        """最終SELECTがマスクラッパーCTE（temp_jockey_te等）を参照していること"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        assert "left join temp_jockey_te as t_j_te" in content
+        assert "left join temp_trainer_te as t_tr_te" in content
+        assert "left join temp_sire_te as t_s_te" in content
+
+
 class TestFeaturePipeline:
     """FeaturePipelineのテスト"""
 


### PR DESCRIPTION
## 概要

過去出走数が少ない騎手・調教師・種牡馬のTE（Target Encoding）値は、スムージング後もグローバル平均に収束するだけのノイズになりやすい。出走数 < 20 のエンティティを NULL として扱い、モデルへの偽の確信を排除する。

## 変更内容

### `src/ml/features/feature_query_raw.sql`

`temp_jockey_te` / `temp_trainer_te` / `temp_sire_te` を二段階CTE方式に変更:

1. **`_pre` CTE**: 既存のTE計算 + 主エンティティの過去出走カウント列（`jockey_count` 等、`1 preceding` ウィンドウ使用）
2. **マスクラッパーCTE**: `IF(count >= 20, value, NULL)` を全9特徴量に適用

diff系8特徴量（e.g. `jockey_course_type_te_diff`）: 最終SELECT側の減算が `NULL - NULL = NULL` となるため、追加対応不要。

### `tests/test_features.py`

6件のテスト追加（`TestTELowFrequencyMask` クラス）:
- `_pre` CTE の存在確認
- カウントウィンドウが `1 preceding` を使用していること
- マスクラッパーに `IF(count >= 20, ...)` が適用されていること
- 閾値が 20 であること
- 騎手TE 9列が全てマスク対象であること
- 最終 JOIN が既存のマスクラッパー CTE を参照していること

## モデル別 学習・検証期間

| | 既存モデル | 新モデル |
|---|---|---|
| **学習期間** | 2016-01-05 〜 2025-11-16 (490,965行 / 34,162レース) | 2016-01-05 〜 2025-11-16 (490,965行 / 34,162レース) |
| **検証期間** | 2025-11-22 〜 2026-05-17 (24,049行 / 1,688レース) | 2025-11-22 〜 2026-05-17 (24,049行 / 1,688レース) |

## 精度比較

| 指標 | 既存モデル | 新モデル | 差分 | 判定（±0.005） |
|---|---|---|---|---|
| **NDCG@3** | 0.5748 | 0.5730 | -0.0019 | ✅ 同等 |
| **AUC** | 0.8133 | 0.8132 | -0.0001 | ✅ 同等 |
| **Recall@3** | 0.5043 | 0.5040 | -0.0003 | ✅ 同等 |

**総合判定: ✅ マージ可** — 全指標が ±0.005 以内

## テスト計画

- [x] `/check-leak` 実施済み — 今回の変更にリーク検出なし（`1 preceding` ウィンドウを正しく使用）
- [x] `pytest tests/test_features.py` 65件全件パス（新規6件含む）
- [x] `compare_features.py` 実行済み（Optuna 50試行 / 1800秒）

## 備考

- 閾値 `20` はコメントと `IF` 条件の数値で明示。将来の調整は各 `_pre` CTE のコメントと `IF` 条件の数値を変更するだけ
- 距離帯別・距離別TE（`temp_horse_distance_*`）への同様マスクは #293 スコープ外

Closes #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)