### PR TITLE
feat: 推論時にfeature_query_raw.sqlを直接実行（features.training_dataキャッシュ依存を排除）

### DIFF
--- a/src/models/predict.py
+++ b/src/models/predict.py
@@ -25,6 +25,7 @@ import pandas as pd
 import yaml
 from google.cloud import bigquery, storage
 
+from src.ml.features.feature_pipeline import FeaturePipeline
 from src.models.lgbm_ranker import LGBMRanker
 from src.models.train import (
     CONFIG_PATH,
@@ -43,33 +44,36 @@ VENUE_MAP = {
 
 def fetch_prediction_data(
     project_id: str,
-    dataset: str,
-    table: str,
     target_dates: list[datetime.date],
 ) -> pd.DataFrame:
     """
-    BigQueryから推論対象データを取得する
+    feature_query_raw.sql を直接実行して推論対象データを取得する
+
+    features.training_data キャッシュには依存しない。
+    当日マージされた特徴量SQL変更も即時反映される。
 
     Args:
         project_id: GCPプロジェクトID
-        dataset: データセット名
-        table: テーブル名
         target_dates: 推論対象日のリスト
 
     Returns:
         推論対象データのDataFrame
     """
-    client = bigquery.Client(project=project_id)
+    start_date = min(target_dates).isoformat()
+    end_date = max(target_dates).isoformat()
 
-    dates_str = ", ".join(f"'{d.isoformat()}'" for d in target_dates)
-    query = f"""
-    SELECT *
-    FROM `{project_id}.{dataset}.{table}`
-    WHERE race_date IN ({dates_str})
-    ORDER BY race_date, race_id, horse_number
-    """
-    logger.info(f"Fetching prediction data for dates: {target_dates}")
-    df = client.query(query).to_dataframe()
+    pipeline = FeaturePipeline(project_id)
+    sql = pipeline.generate_query(start_date, end_date)
+
+    logger.info(f"Executing feature SQL directly for dates: {target_dates}")
+    client = bigquery.Client(project=project_id)
+    df = client.query(sql).to_dataframe()
+
+    if len(df) > 0:
+        df["race_date"] = pd.to_datetime(df["race_date"]).dt.date
+        df = df[df["race_date"].isin(set(target_dates))].copy()
+        df = df.sort_values(["race_date", "race_id", "horse_number"]).reset_index(drop=True)
+
     logger.info(f"Fetched {len(df)} rows")
     return df
 
@@ -249,8 +253,6 @@ def predict_pipeline(
 
     df = fetch_prediction_data(
         project_id=project_id,
-        dataset=data_config["dataset"],
-        table=data_config["table"],
         target_dates=target_dates,
     )
 

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -3,7 +3,7 @@
 """
 
 import datetime
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pandas as pd
@@ -11,6 +11,7 @@ import pytest
 
 from src.models.lgbm_ranker import LGBMRanker, LGBMRankerConfig
 from src.models.predict import (
+    fetch_prediction_data,
     format_predictions,
     fetch_race_results,
     predict_pipeline,
@@ -507,3 +508,103 @@ class TestSavePredictionsToGCS:
         mock_client.bucket.assert_called_with("my-project-keiba-predictions")
         # blobパスが {date}/predictions.csv であること
         mock_client.bucket.return_value.blob.assert_called_with("2026-03-01/predictions.csv")
+
+
+class TestFetchPredictionData:
+    """fetch_prediction_data が feature_query_raw.sql を直接実行することを検証 (Issue #288)"""
+
+    def _make_mock_df(self, dates: list[datetime.date]) -> pd.DataFrame:
+        rows = []
+        for d in dates:
+            rows.append({
+                "race_id": f"race_{d.strftime('%Y%m%d')}_01",
+                "horse_id": "h1",
+                "horse_name": "テスト馬1",
+                "race_date": d,
+                "horse_number": 1,
+            })
+        return pd.DataFrame(rows)
+
+    @patch("src.models.predict.bigquery.Client")
+    @patch("src.models.predict.FeaturePipeline")
+    def test_uses_feature_pipeline_generate_query(self, mock_pipeline_cls, mock_bq_cls):
+        """FeaturePipeline.generate_query() が呼ばれてSQLが直接実行されること"""
+        target_dates = [datetime.date(2026, 5, 17)]
+        mock_pipeline = mock_pipeline_cls.return_value
+        mock_pipeline.generate_query.return_value = "SELECT 1"
+
+        mock_bq = mock_bq_cls.return_value
+        mock_df = self._make_mock_df(target_dates)
+        mock_bq.query.return_value.to_dataframe.return_value = mock_df
+
+        result = fetch_prediction_data(project_id="test-project", target_dates=target_dates)
+
+        mock_pipeline_cls.assert_called_once_with("test-project")
+        mock_pipeline.generate_query.assert_called_once_with("2026-05-17", "2026-05-17")
+        mock_bq.query.assert_called_once_with("SELECT 1")
+        assert len(result) == 1
+
+    @patch("src.models.predict.bigquery.Client")
+    @patch("src.models.predict.FeaturePipeline")
+    def test_does_not_query_training_data_table(self, mock_pipeline_cls, mock_bq_cls):
+        """features.training_data を直接参照するクエリが実行されないこと"""
+        target_dates = [datetime.date(2026, 5, 17)]
+        mock_pipeline = mock_pipeline_cls.return_value
+        mock_pipeline.generate_query.return_value = "SELECT * FROM raw.horse_results"
+
+        mock_bq = mock_bq_cls.return_value
+        mock_bq.query.return_value.to_dataframe.return_value = self._make_mock_df(target_dates)
+
+        fetch_prediction_data(project_id="test-project", target_dates=target_dates)
+
+        executed_sql = mock_bq.query.call_args[0][0]
+        assert "training_data" not in executed_sql
+
+    @patch("src.models.predict.bigquery.Client")
+    @patch("src.models.predict.FeaturePipeline")
+    def test_multi_date_uses_min_max_as_range(self, mock_pipeline_cls, mock_bq_cls):
+        """複数日指定時は min/max を start_date/end_date として渡すこと"""
+        target_dates = [datetime.date(2026, 5, 17), datetime.date(2026, 5, 18)]
+        mock_pipeline = mock_pipeline_cls.return_value
+        mock_pipeline.generate_query.return_value = "SELECT 1"
+
+        mock_bq = mock_bq_cls.return_value
+        mock_bq.query.return_value.to_dataframe.return_value = self._make_mock_df(target_dates)
+
+        fetch_prediction_data(project_id="test-project", target_dates=target_dates)
+
+        mock_pipeline.generate_query.assert_called_once_with("2026-05-17", "2026-05-18")
+
+    @patch("src.models.predict.bigquery.Client")
+    @patch("src.models.predict.FeaturePipeline")
+    def test_filters_by_target_dates(self, mock_pipeline_cls, mock_bq_cls):
+        """SQLの結果が target_dates に含まれない日付を除外すること"""
+        target_dates = [datetime.date(2026, 5, 17)]
+        mock_pipeline = mock_pipeline_cls.return_value
+        mock_pipeline.generate_query.return_value = "SELECT 1"
+
+        mock_bq = mock_bq_cls.return_value
+        # 2日分を返すが target_dates は1日のみ
+        extra_dates = [datetime.date(2026, 5, 17), datetime.date(2026, 5, 16)]
+        mock_bq.query.return_value.to_dataframe.return_value = self._make_mock_df(extra_dates)
+
+        result = fetch_prediction_data(project_id="test-project", target_dates=target_dates)
+
+        # target_dates にある 2026-05-17 の行のみ残ること
+        assert len(result) == 1
+        assert all(r == datetime.date(2026, 5, 17) for r in result["race_date"])
+
+    @patch("src.models.predict.bigquery.Client")
+    @patch("src.models.predict.FeaturePipeline")
+    def test_returns_empty_df_when_no_rows(self, mock_pipeline_cls, mock_bq_cls):
+        """SQLが0行を返す場合、空DataFrameを返すこと"""
+        target_dates = [datetime.date(2026, 5, 17)]
+        mock_pipeline = mock_pipeline_cls.return_value
+        mock_pipeline.generate_query.return_value = "SELECT 1"
+
+        mock_bq = mock_bq_cls.return_value
+        mock_bq.query.return_value.to_dataframe.return_value = pd.DataFrame()
+
+        result = fetch_prediction_data(project_id="test-project", target_dates=target_dates)
+
+        assert len(result) == 0

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -3,7 +3,7 @@
 """
 
 import datetime
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import numpy as np
 import pandas as pd


### PR DESCRIPTION
## Summary

- `fetch_prediction_data()` の内部実装を `features.training_data` 参照から `feature_query_raw.sql` 直接実行方式に変更（Issue #288）
- 当日マージされた特徴量 SQL 変更（TE系カラム修正等）が即時反映されるようになる
- `features.training_data` への書き込みは行わない（読み捨て方式）
- `TestFetchPredictionData` クラス（5件）を追加して SQL 直接実行を検証

## 背景

2026-05-17 に PR #284/#285（TE NaN修正）を当日マージした後、朝9:37 の推論が前日夜生成の `features.training_data`（旧SQL）を読んでしまい TE 系 51 カラムが全 NULL になった。この構造的な問題を解消する。

## 変更ファイル

- `src/models/predict.py`:
  - `fetch_prediction_data()` シグネチャから `dataset`, `table` 引数を削除
  - `FeaturePipeline.generate_query()` で SQL を生成して BigQuery に直接実行
  - 複数日指定時は `min(target_dates)` / `max(target_dates)` を start/end として使用
  - SQL 結果を `target_dates` でフィルタリング
  - `predict_pipeline()` 内の呼び出しを更新
- `tests/test_predict.py`:
  - `TestFetchPredictionData` クラス（5件）を追加

## Test plan

- [x] `tests/test_predict.py` - 22件全通過（既存17件 + 新規5件）
- [x] `tests/test_app_predict.py` - 7件全通過
- [x] `tests/test_predict_daily_endpoint.py` - 7件全通過

Closes #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)