### PR TITLE
refactor: 過去2〜5走の個別特徴量を直近1走+統計量に集約（Issue #292）

### DIFF
--- a/src/ml/features/feature_query_raw.sql
+++ b/src/ml/features/feature_query_raw.sql
@@ -1536,6 +1536,58 @@ select
     ,running_style_front_count
     ,is_sole_leader
     ,is_renso
+    -- 過去2〜5走の個別カラム（Issue #292: _2~5系を直近1走+統計量に集約）
+    -- idm_3 は idm_trend_3, finish_position_3 は finish_position_trend_3 の中間値として保持
+    ,race_name_2
+    ,race_name_3
+    ,race_name_4
+    ,race_name_5
+    ,idm_2
+    ,idm_3
+    ,idm_4
+    ,idm_5
+    ,finish_position_2
+    ,finish_position_3
+    ,finish_position_4
+    ,finish_position_5
+    ,finish_position_rate_2
+    ,finish_position_rate_3
+    ,finish_position_rate_4
+    ,finish_position_rate_5
+    ,win_odds_2
+    ,win_odds_3
+    ,win_odds_4
+    ,win_odds_5
+    ,win_popularity_2
+    ,win_popularity_3
+    ,win_popularity_4
+    ,win_popularity_5
+    ,popularity_rate_2
+    ,popularity_rate_3
+    ,popularity_rate_4
+    ,popularity_rate_5
+    ,upside_rate_2
+    ,upside_rate_3
+    ,upside_rate_4
+    ,upside_rate_5
+    ,finish_time_2
+    ,finish_time_3
+    ,finish_time_4
+    ,finish_time_5
+    ,last_3f_2
+    ,last_3f_3
+    ,last_3f_4
+    ,last_3f_5
+    ,last_3f_rank_in_race_2
+    ,last_3f_rank_in_race_3
+    ,last_3f_rank_in_race_4
+    ,last_3f_rank_in_race_5
+    ,late_start_2
+    ,late_start_4
+    ,position_fault_4
+    ,position_fault_5
+    ,disadvantage_2
+    ,disadvantage_4
   )
   ,t_h_m_f.* except(
     race_id


### PR DESCRIPTION
## 概要

`feature_query_raw.sql` の最終 SELECT EXCEPT 節に `_2~5` 系個別カラム（約50カラム）を追加し、最終出力から除外します。
直近1走（`_1` 系）と既存の集計量（`mean/ema/max/min`）に情報を集約します。

## 変更内容

### 除外対象カラム（50カラム）
| カテゴリ | 除外カラム |
|---------|-----------|
| IDM | `idm_2`, `idm_3`, `idm_4`, `idm_5` |
| 着順 | `finish_position_2~5` |
| 着順率 | `finish_position_rate_2~5` |
| 単勝人気 | `win_popularity_2~5` |
| 人気率 | `popularity_rate_2~5` |
| アップサイド | `upside_rate_2~5` |
| 単勝オッズ | `win_odds_2~5` |
| 走破タイム | `finish_time_2~5` |
| 上がり3F | `last_3f_2~5`, `last_3f_rank_in_race_2~5` |
| レース名 | `race_name_2~5`（文字列、ML 特徴量として不使用） |
| 特記コード残存分 | `late_start_2/4`, `position_fault_4/5`, `disadvantage_2/4` |

### 保持する設計（中間値として CTE 内に残存）
- `idm_3`: `idm_trend_3`（直近3走トレンド）の計算に使用
- `finish_position_3`: `finish_position_trend_3` の計算に使用
- `race_date_diff_2~5`: `continuous_run_count` の計算に使用

### `avg_finish_position_rate` について
Issue で要求された追加特徴量は、既存の `mean_finish_position_rate`（過去5走着順率の平均）が相当するため新規追加不要。

## モデル精度比較

※ `--skip-feature-pipeline` のため `features.training_data` は旧状態（`_2~5`カラム含む 375カラム）を使用。feature_pipeline 再実行後に `_2~5` が削減される。

### 学習・検証期間

| | 既存モデル | 新モデル |
|---|---|---|
| **学習期間** | 2016-01-05 〜 2025-11-16 (490,965行 / 34,162レース) | 2016-01-05 〜 2025-11-16 (490,965行 / 34,162レース) |
| **検証期間** | 2025-11-22 〜 2026-05-17 (24,049行 / 1,688レース) | 2025-11-22 〜 2026-05-17 (24,049行 / 1,688レース) |

### 精度比較

| 指標 | 既存モデル | 新モデル | 差分 | 判定 (±0.005) |
|---|---|---|---|---|
| **NDCG@3** | 0.5748 | 0.5720 | -0.0029 | ✅ 同等 |
| **AUC** | 0.8133 | 0.8133 | -0.0000 | ✅ 同等 |
| **Recall@3** | 0.5043 | 0.5027 | -0.0016 | ✅ 同等 |

### 総合判定: ✅ マージ可（全指標 ±0.005 以内）

## テスト計画

- [x] `/check-leak` 実施済み — リーク検出なし
  - 過去走 JOIN に `race_date < t_b_r_e.race_date` 条件あり（全5走分）
  - Window 関数は `RANGE BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING` で当日除外
  - 同レース内参照（idm_diff 等）はリーク対象外の相対指標
- [x] `pytest tests/test_features.py` 70件通過
- [x] `compare_features.py` n_trials=50 で精度比較完了（✅ マージ可）

## 本番反映手順

```bash
# feature_pipeline 再実行で _2~5 カラムが削減される
# retrain-and-deploy を実行して本番モデルを更新
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)