### PR TITLE
feat: 馬自身TEに距離変化・斤量変化・季節の集計区分を追加（Issue #303）

### DIFF
--- a/src/ml/features/feature_query_raw.sql
+++ b/src/ml/features/feature_query_raw.sql
@@ -876,14 +876,17 @@ with temp_race_horse_count as (
   where finish_position > 0
 )
 
-/* TE計算の元となる全期間の騎手・調教師・種牡馬実績履歴（当日同日レースは除外）
+/* TE計算の元となる全期間の騎手・調教師・種牡馬・馬自身実績履歴（当日同日レースは除外）
    horse_results を起点にすることで、race_results にまだ存在しない当日予測レースも含める。
    window関数の RANGE BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING が当日行を除外するため
-   学習時の分布に影響しない。 */
-,temp_te_history_base as (
+   学習時の分布に影響しない。
+   2段階構成: temp_te_history_raw (JOIN) → temp_te_history_base (LAG計算で前走比較カラム追加) */
+,temp_te_history_raw as (
   select
     h_r.race_id
     ,h_r.horse_number
+    ,h_r.horse_id
+    ,h_r.weight_carried
     ,r_i.race_date
     ,r_i.course_type
     ,r_i.venue_code
@@ -908,6 +911,41 @@ with temp_race_horse_count as (
       on h_r.race_id = r_r.race_id
       and h_r.horse_number = r_r.horse_number
   where r_r.finish_position > 0 or r_r.race_id is null
+)
+,temp_te_history_base as (
+  select
+    race_id
+    ,horse_number
+    ,horse_id
+    ,race_date
+    ,course_type
+    ,venue_code
+    ,distance
+    ,distance_band
+    ,direction
+    ,jockey_code
+    ,trainer_code
+    ,sire_name
+    ,is_top3
+    ,case
+      when extract(month from race_date) in (3, 4, 5)  then 'spring'
+      when extract(month from race_date) in (6, 7, 8)  then 'summer'
+      when extract(month from race_date) in (9, 10, 11) then 'autumn'
+      else 'winter'
+    end as season
+    ,case
+      when lag(distance) over (partition by horse_id order by race_date) is null then null
+      when distance > lag(distance) over (partition by horse_id order by race_date) then 'extension'
+      when distance < lag(distance) over (partition by horse_id order by race_date) then 'shortening'
+      else 'same'
+    end as distance_change_type
+    ,case
+      when lag(weight_carried) over (partition by horse_id order by race_date) is null then null
+      when weight_carried > lag(weight_carried) over (partition by horse_id order by race_date) then 'increase'
+      when weight_carried < lag(weight_carried) over (partition by horse_id order by race_date) then 'decrease'
+      else 'same'
+    end as weight_carried_change_type
+  from temp_te_history_raw
 )
 
 /* 騎手 Target Encoding（累積3着以内率、スムージング係数m=10、同日除外）
@@ -1327,6 +1365,197 @@ with temp_race_horse_count as (
   from temp_sire_te_pre
 )
 
+/* 馬自身 Target Encoding（累積3着以内率、スムージング係数m=10、同日除外）
+   出走数 < 5 の馬は全TE値をNULLとして扱う（若馬・低頻度の情報ノイズ除去） */
+,temp_horse_te_pre as (
+  select
+    race_id
+    ,horse_number
+    ,coalesce(count(*) over (
+      partition by horse_id
+      order by unix_date(race_date)
+      range between unbounded preceding and 1 preceding
+    ), 0) as horse_count
+    ,safe_divide(
+      coalesce(sum(is_top3) over (
+        partition by horse_id
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10 * g.global_top3_rate,
+      coalesce(count(*) over (
+        partition by horse_id
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10
+    ) as horse_te
+    ,safe_divide(
+      coalesce(sum(is_top3) over (
+        partition by horse_id, course_type
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10 * g.global_top3_rate,
+      coalesce(count(*) over (
+        partition by horse_id, course_type
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10
+    ) as horse_course_type_te
+    ,safe_divide(
+      coalesce(sum(is_top3) over (
+        partition by horse_id, venue_code
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10 * g.global_top3_rate,
+      coalesce(count(*) over (
+        partition by horse_id, venue_code
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10
+    ) as horse_venue_te
+    ,safe_divide(
+      coalesce(sum(is_top3) over (
+        partition by horse_id, distance_band
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10 * g.global_top3_rate,
+      coalesce(count(*) over (
+        partition by horse_id, distance_band
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10
+    ) as horse_distance_band_te
+    ,safe_divide(
+      coalesce(sum(is_top3) over (
+        partition by horse_id, distance
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10 * g.global_top3_rate,
+      coalesce(count(*) over (
+        partition by horse_id, distance
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10
+    ) as horse_distance_te
+    ,safe_divide(
+      coalesce(sum(is_top3) over (
+        partition by horse_id, direction
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10 * g.global_top3_rate,
+      coalesce(count(*) over (
+        partition by horse_id, direction
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10
+    ) as horse_direction_te
+    ,safe_divide(
+      coalesce(sum(is_top3) over (
+        partition by horse_id, jockey_code
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10 * g.global_top3_rate,
+      coalesce(count(*) over (
+        partition by horse_id, jockey_code
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10
+    ) as horse_jockey_te
+    ,safe_divide(
+      coalesce(sum(is_top3) over (
+        partition by horse_id, season
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10 * g.global_top3_rate,
+      coalesce(count(*) over (
+        partition by horse_id, season
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10
+    ) as horse_season_te
+    ,safe_divide(
+      coalesce(sum(is_top3) over (
+        partition by horse_id, course_type, venue_code
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10 * g.global_top3_rate,
+      coalesce(count(*) over (
+        partition by horse_id, course_type, venue_code
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10
+    ) as horse_course_type_venue_te
+    ,safe_divide(
+      coalesce(sum(is_top3) over (
+        partition by horse_id, course_type, distance
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10 * g.global_top3_rate,
+      coalesce(count(*) over (
+        partition by horse_id, course_type, distance
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10
+    ) as horse_course_type_distance_te
+    ,safe_divide(
+      coalesce(sum(is_top3) over (
+        partition by horse_id, course_type, distance, venue_code
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10 * g.global_top3_rate,
+      coalesce(count(*) over (
+        partition by horse_id, course_type, distance, venue_code
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10
+    ) as horse_course_type_distance_venue_te
+    ,safe_divide(
+      coalesce(sum(is_top3) over (
+        partition by horse_id, distance_change_type
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10 * g.global_top3_rate,
+      coalesce(count(*) over (
+        partition by horse_id, distance_change_type
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10
+    ) as horse_distance_change_te
+    ,safe_divide(
+      coalesce(sum(is_top3) over (
+        partition by horse_id, weight_carried_change_type
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10 * g.global_top3_rate,
+      coalesce(count(*) over (
+        partition by horse_id, weight_carried_change_type
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ), 0) + 10
+    ) as horse_weight_carried_change_te
+  from temp_te_history_base
+    cross join temp_global_mean_te as g
+)
+/* 低頻度マスク適用: 馬の過去出走数 < 5 の場合は全TE値をNULLにする（若馬・低頻度の情報ノイズ除去） */
+,temp_horse_te as (
+  select
+    race_id
+    ,horse_number
+    ,IF(horse_count >= 5, horse_te, NULL) as horse_te
+    ,IF(horse_count >= 5, horse_course_type_te, NULL) as horse_course_type_te
+    ,IF(horse_count >= 5, horse_venue_te, NULL) as horse_venue_te
+    ,IF(horse_count >= 5, horse_distance_band_te, NULL) as horse_distance_band_te
+    ,IF(horse_count >= 5, horse_distance_te, NULL) as horse_distance_te
+    ,IF(horse_count >= 5, horse_direction_te, NULL) as horse_direction_te
+    ,IF(horse_count >= 5, horse_jockey_te, NULL) as horse_jockey_te
+    ,IF(horse_count >= 5, horse_season_te, NULL) as horse_season_te
+    ,IF(horse_count >= 5, horse_course_type_venue_te, NULL) as horse_course_type_venue_te
+    ,IF(horse_count >= 5, horse_course_type_distance_te, NULL) as horse_course_type_distance_te
+    ,IF(horse_count >= 5, horse_course_type_distance_venue_te, NULL) as horse_course_type_distance_venue_te
+    ,IF(horse_count >= 5, horse_distance_change_te, NULL) as horse_distance_change_te
+    ,IF(horse_count >= 5, horse_weight_carried_change_te, NULL) as horse_weight_carried_change_te
+  from temp_horse_te_pre
+)
+
 /* 馬の距離帯別・距離別 TE 計算の元データ
    horse_results を起点にすることで、race_results にまだ存在しない当日予測レースも含める。 */
 ,temp_horse_distance_base as (
@@ -1708,6 +1937,33 @@ select
   ,t_s_te.sire_course_type_venue_te - t_s_te.sire_te as sire_course_type_venue_te_diff
   ,t_s_te.sire_course_type_distance_te - t_s_te.sire_te as sire_course_type_distance_te_diff
   ,t_s_te.sire_course_type_distance_venue_te - t_s_te.sire_te as sire_course_type_distance_venue_te_diff
+  -- 馬自身TE
+  ,t_h_te.horse_te
+  ,t_h_te.horse_course_type_te
+  ,t_h_te.horse_venue_te
+  ,t_h_te.horse_distance_band_te
+  ,t_h_te.horse_distance_te
+  ,t_h_te.horse_direction_te
+  ,t_h_te.horse_jockey_te
+  ,t_h_te.horse_season_te
+  ,t_h_te.horse_course_type_venue_te
+  ,t_h_te.horse_course_type_distance_te
+  ,t_h_te.horse_course_type_distance_venue_te
+  ,t_h_te.horse_distance_change_te
+  ,t_h_te.horse_weight_carried_change_te
+  -- 馬自身TE差分（条件別TE − 全体TE）
+  ,t_h_te.horse_course_type_te - t_h_te.horse_te as horse_course_type_te_diff
+  ,t_h_te.horse_venue_te - t_h_te.horse_te as horse_venue_te_diff
+  ,t_h_te.horse_distance_band_te - t_h_te.horse_te as horse_distance_band_te_diff
+  ,t_h_te.horse_distance_te - t_h_te.horse_te as horse_distance_te_diff
+  ,t_h_te.horse_direction_te - t_h_te.horse_te as horse_direction_te_diff
+  ,t_h_te.horse_jockey_te - t_h_te.horse_te as horse_jockey_te_diff
+  ,t_h_te.horse_season_te - t_h_te.horse_te as horse_season_te_diff
+  ,t_h_te.horse_course_type_venue_te - t_h_te.horse_te as horse_course_type_venue_te_diff
+  ,t_h_te.horse_course_type_distance_te - t_h_te.horse_te as horse_course_type_distance_te_diff
+  ,t_h_te.horse_course_type_distance_venue_te - t_h_te.horse_te as horse_course_type_distance_venue_te_diff
+  ,t_h_te.horse_distance_change_te - t_h_te.horse_te as horse_distance_change_te_diff
+  ,t_h_te.horse_weight_carried_change_te - t_h_te.horse_te as horse_weight_carried_change_te_diff
   -- 距離帯別特徴量
   ,t_h_db_te.distance_band_top3_finish_rate
   ,t_h_db_te.distance_band_top1_finish_rate
@@ -1739,6 +1995,9 @@ from
   left join temp_sire_te as t_s_te
     on t_p_r_f.race_id = t_s_te.race_id
     and t_p_r_f.horse_number = t_s_te.horse_number
+  left join temp_horse_te as t_h_te
+    on t_p_r_f.race_id = t_h_te.race_id
+    and t_p_r_f.horse_number = t_h_te.horse_number
   left join temp_horse_distance_band_te as t_h_db_te
     on t_p_r_f.race_id = t_h_db_te.race_id
     and t_p_r_f.horse_number = t_h_db_te.horse_number

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -955,3 +955,90 @@ class TestRaceExclusionFilter:
         """新潟直線1000m除外が venue_code・distance・direction の AND 条件であること"""
         content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
         assert "not (r_i.venue_code = '04' and r_i.distance = 1000 and r_i.direction = 'straight')" in content, "新潟直線1000m除外の複合条件が見つかりません"
+
+
+class TestHorseTEFeature:
+    """馬自身 Target Encoding 特徴量のテスト（Issue #303）"""
+
+    def test_sql_has_temp_horse_te_ctes(self):
+        """temp_horse_te_pre と temp_horse_te CTE が存在すること"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        assert "temp_horse_te_pre" in content, "temp_horse_te_pre が見つかりません"
+        assert "temp_horse_te as (" in content, "temp_horse_te が見つかりません"
+
+    def test_sql_te_history_base_has_required_columns(self):
+        """temp_te_history_base に horse_id / season / distance_change_type / weight_carried_change_type が含まれること"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        # temp_te_history_raw から temp_jockey_te_pre までの範囲を確認
+        base_start = content.find("temp_te_history_raw as (")
+        jockey_start = content.find("temp_jockey_te_pre")
+        base_section = content[base_start:jockey_start]
+        assert "horse_id" in base_section, "temp_te_history_base に horse_id がありません"
+        assert "season" in base_section, "temp_te_history_base に season がありません"
+        assert "distance_change_type" in base_section, "temp_te_history_base に distance_change_type がありません"
+        assert "weight_carried_change_type" in base_section, "temp_te_history_base に weight_carried_change_type がありません"
+
+    def test_sql_distance_change_type_definition(self):
+        """distance_change_type が extension / shortening / same の3値で定義されること"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        base_start = content.find("temp_te_history_base as (")
+        base_end = content.find("temp_te_history_raw")
+        # 逆順検索で実際のtemp_te_history_baseのLAG定義部分を取得
+        base_section = content[base_end:base_end + 3000]
+        assert "'extension'" in base_section, "distance_change_type に 'extension' がありません"
+        assert "'shortening'" in base_section, "distance_change_type に 'shortening' がありません"
+        assert "'same'" in base_section, "distance_change_type に 'same' がありません"
+
+    def test_sql_weight_carried_change_type_definition(self):
+        """weight_carried_change_type が increase / decrease / same の3値で定義されること"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        base_section_start = content.find("temp_te_history_base as (")
+        base_section = content[base_section_start:base_section_start + 3000]
+        assert "'increase'" in base_section, "weight_carried_change_type に 'increase' がありません"
+        assert "'decrease'" in base_section, "weight_carried_change_type に 'decrease' がありません"
+
+    def test_sql_horse_te_columns_in_final_select(self):
+        """horse_te および全12条件別TE差分カラムが最終SELECTに含まれること"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        final_select_start = content.rfind("select")
+        final_section = content[final_select_start:]
+        expected_columns = [
+            "horse_te",
+            "horse_course_type_te_diff",
+            "horse_venue_te_diff",
+            "horse_distance_band_te_diff",
+            "horse_distance_te_diff",
+            "horse_direction_te_diff",
+            "horse_jockey_te_diff",
+            "horse_season_te_diff",
+            "horse_course_type_venue_te_diff",
+            "horse_course_type_distance_te_diff",
+            "horse_course_type_distance_venue_te_diff",
+            "horse_distance_change_te_diff",
+            "horse_weight_carried_change_te_diff",
+        ]
+        for col in expected_columns:
+            assert col in final_section, f"最終SELECT に '{col}' が見つかりません"
+
+    def test_sql_horse_te_mask_threshold_is_5(self):
+        """馬自身TE のマスク閾値が 5 であること（騎手・調教師の20より低い）"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        wrapper_start = content.find("temp_horse_te as (")
+        wrapper_end = content.find("temp_horse_distance_base")
+        wrapper_section = content[wrapper_start:wrapper_end]
+        assert "IF(horse_count >= 5, horse_te, NULL)" in wrapper_section, "馬TEマスク閾値が 5 ではありません"
+
+    def test_sql_final_join_includes_horse_te(self):
+        """最終SELECTが temp_horse_te を LEFT JOIN していること"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        assert "left join temp_horse_te as t_h_te" in content, "最終SELECTに temp_horse_te の LEFT JOIN がありません"
+
+    def test_sql_season_definition(self):
+        """季節定義が spring / summer / autumn / winter の4値であること"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        base_section_start = content.find("temp_te_history_base as (")
+        base_section = content[base_section_start:base_section_start + 2000]
+        assert "'spring'" in base_section, "season に 'spring' がありません"
+        assert "'summer'" in base_section, "season に 'summer' がありません"
+        assert "'autumn'" in base_section, "season に 'autumn' がありません"
+        assert "'winter'" in base_section, "season に 'winter' がありません"


### PR DESCRIPTION
## 概要

Issue #303 の実装。馬自身 Target Encoding（`horse_id` 軸）に以下の集計区分を追加した。

- 距離延長/短縮時の複勝率（`horse_distance_change_te`）
- 斤量増加/減少時の複勝率（`horse_weight_carried_change_te`）
- 季節別の複勝率（`horse_season_te`）
- 馬×コース種別・競馬場・距離帯・距離・進行方向・騎手・複合軸

## 変更内容

### SQL（`src/ml/features/feature_query_raw.sql`）

1. `temp_te_history_base` を2段階構成に変更
   - `temp_te_history_raw`: JOINのみ（`horse_id`, `weight_carried` を追加）
   - `temp_te_history_base`: LAGで変化フラグと季節を導出
     - `distance_change_type`: extension / shortening / same（前走距離比較）
     - `weight_carried_change_type`: increase / decrease / same（前走斤量比較）
     - `season`: spring / summer / autumn / winter

2. `temp_horse_te_pre` + `temp_horse_te` CTE 新規追加（`temp_sire_te` の後）
   - horse_id 軸の全13軸 TE（スムージング m=10 / 当日除外）
   - 低頻度マスク: `horse_count >= 5`（騎手・調教師の20より低く設定）

3. 最終 SELECT に 25 特徴量追加（条件別TE 13本 + 差分 12本）

### テスト（`tests/test_features.py`）

`TestHorseTEFeature` クラスを追加（8件）
- CTE 存在確認
- `distance_change_type` / `weight_carried_change_type` / `season` の定義検証
- 最終SELECT への出力確認
- マスク閾値 >= 5 の確認

## モデル精度比較

| | 既存モデル | 新モデル |
|---|---|---|
| **学習期間** | 2016-01-05 〜 2025-11-16 (490,965行) | 同左 |
| **検証期間** | 2025-11-22 〜 2026-05-17 (24,049行) | 同左 |

| 指標 | 既存モデル | 新モデル | 差分 | 判定（±0.005） |
|---|---|---|---|---|
| NDCG@3 | 0.5713 | 0.5688 | -0.0024 | ✅ 同等 |
| AUC | 0.8121 | 0.8121 | +0.0001 | ✅ 改善 |
| Recall@3 | 0.5036 | 0.5013 | -0.0023 | ✅ 同等 |

**総合判定: ✅ マージ可**

> `--skip-feature-pipeline` のため既存の features.training_data（348特徴量）で評価。新特徴量の実効確認は retrain-and-deploy 時に行う。

## テスト計画

- [x] `/check-leak` 実施済み（リーク検出なし）
  - `distance`・`weight_carried` は出馬表確定情報（発走前）
  - 全TE Window関数は `1 PRECEDING` で当日除外済み
- [x] `pytest tests/test_features.py tests/test_backtest_strategy.py tests/test_netkeiba_scraper.py` 189件全パス

Closes #303