### PR TITLE
feat: キャリア最長・最短距離フラグ特徴量の追加（Issue #305）

### DIFF
--- a/src/ml/features/feature_query_raw.sql
+++ b/src/ml/features/feature_query_raw.sql
@@ -1718,6 +1718,46 @@ with temp_race_horse_count as (
     cross join temp_global_mean_te as g
 )
 
+/* キャリア最長・最短距離フラグ特徴量（Issue #305）
+   COUNT DISTINCT をウィンドウ関数化するため、まず (horse_id, distance) の初出フラグを付与 */
+,temp_career_distance_flags as (
+  select
+    *
+    ,case
+      when row_number() over (
+        partition by horse_id, distance
+        order by unix_date(race_date), race_id
+      ) = 1 then 1 else 0
+    end as is_first_at_distance
+    ,case
+      when is_top3 = 1 and row_number() over (
+        partition by horse_id, distance, is_top3
+        order by unix_date(race_date), race_id
+      ) = 1 then 1 else 0
+    end as is_first_placed_at_distance
+  from temp_horse_distance_base
+)
+
+/* キャリア距離集計（当レース除外: RANGE BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING） */
+,temp_career_distance as (
+  select
+    race_id
+    ,horse_number
+    ,horse_id
+    ,max(distance) over w as career_max_distance_so_far
+    ,min(distance) over w as career_min_distance_so_far
+    ,sum(is_first_at_distance) over w as career_distance_count
+    ,max(case when is_top3 = 1 then distance end) over w as placed_max_distance_so_far
+    ,min(case when is_top3 = 1 then distance end) over w as placed_min_distance_so_far
+    ,sum(is_first_placed_at_distance) over w as placed_distance_count
+  from temp_career_distance_flags
+  window w as (
+    partition by horse_id
+    order by unix_date(race_date)
+    range between unbounded preceding and 1 preceding
+  )
+)
+
 /* 調教本追切データ (raw.cha_data から) */
 ,temp_training as (
   select
@@ -1974,6 +2014,20 @@ select
   ,t_h_d_te.distance_top1_finish_rate
   ,t_h_d_te.distance_rate_diff
   -- new_distance_flag: gain=0 のため除去（Issue #296）
+  -- キャリア最長・最短距離フラグ（グループ1: 全出走, Issue #305）
+  ,t_p_r_f.distance > t_c_d.career_max_distance_so_far as is_career_max_distance
+  ,t_p_r_f.distance - t_c_d.career_max_distance_so_far as career_max_distance_diff
+  ,t_p_r_f.distance < t_c_d.career_min_distance_so_far as is_career_min_distance
+  ,t_p_r_f.distance - t_c_d.career_min_distance_so_far as career_min_distance_diff
+  ,t_c_d.career_max_distance_so_far - t_c_d.career_min_distance_so_far as career_distance_range
+  ,t_c_d.career_distance_count
+  -- キャリア最長・最短距離フラグ（グループ2: 3着以内レースのみ, Issue #305）
+  ,t_p_r_f.distance > t_c_d.placed_max_distance_so_far as is_beyond_placed_max_distance
+  ,t_p_r_f.distance - t_c_d.placed_max_distance_so_far as placed_max_distance_diff
+  ,t_p_r_f.distance < t_c_d.placed_min_distance_so_far as is_below_placed_min_distance
+  ,t_p_r_f.distance - t_c_d.placed_min_distance_so_far as placed_min_distance_diff
+  ,t_c_d.placed_max_distance_so_far - t_c_d.placed_min_distance_so_far as placed_distance_range
+  ,t_c_d.placed_distance_count
   -- 調教本追切特徴量 (CHAファイル由来)
   ,t_cha.cha_training_index
   ,t_cha.training_last_3f
@@ -2007,3 +2061,6 @@ from
   left join temp_training as t_cha
     on t_p_r_f.race_id = t_cha.race_id
     and t_p_r_f.horse_number = t_cha.horse_number
+  left join temp_career_distance as t_c_d
+    on t_p_r_f.race_id = t_c_d.race_id
+    and t_p_r_f.horse_number = t_c_d.horse_number

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1042,3 +1042,87 @@ class TestHorseTEFeature:
         assert "'summer'" in base_section, "season に 'summer' がありません"
         assert "'autumn'" in base_section, "season に 'autumn' がありません"
         assert "'winter'" in base_section, "season に 'winter' がありません"
+
+
+class TestCareerDistanceFeature:
+    """キャリア最長・最短距離フラグ特徴量のテスト（Issue #305）"""
+
+    def test_sql_has_career_distance_ctes(self):
+        """temp_career_distance_flags と temp_career_distance CTE が存在すること"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        assert "temp_career_distance_flags as (" in content, "temp_career_distance_flags が見つかりません"
+        assert "temp_career_distance as (" in content, "temp_career_distance が見つかりません"
+
+    def test_sql_career_distance_uses_range_1_preceding(self):
+        """temp_career_distance が RANGE BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING を使用していること"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        cte_start = content.find("temp_career_distance as (")
+        cte_end = content.find("temp_training as (")
+        cte_section = content[cte_start:cte_end]
+        assert "range between unbounded preceding and 1 preceding" in cte_section, \
+            "temp_career_distance に当日除外の RANGE BETWEEN 句がありません"
+
+    def test_sql_career_distance_group1_columns_in_final_select(self):
+        """グループ1（全出走）の6特徴量が最終SELECTに含まれること"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        final_select_start = content.rfind("select")
+        final_section = content[final_select_start:]
+        group1_columns = [
+            "is_career_max_distance",
+            "career_max_distance_diff",
+            "is_career_min_distance",
+            "career_min_distance_diff",
+            "career_distance_range",
+            "career_distance_count",
+        ]
+        for col in group1_columns:
+            assert col in final_section, f"最終SELECT に '{col}' が見つかりません"
+
+    def test_sql_career_distance_group2_columns_in_final_select(self):
+        """グループ2（3着以内）の6特徴量が最終SELECTに含まれること"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        final_select_start = content.rfind("select")
+        final_section = content[final_select_start:]
+        group2_columns = [
+            "is_beyond_placed_max_distance",
+            "placed_max_distance_diff",
+            "is_below_placed_min_distance",
+            "placed_min_distance_diff",
+            "placed_distance_range",
+            "placed_distance_count",
+        ]
+        for col in group2_columns:
+            assert col in final_section, f"最終SELECT に '{col}' が見つかりません"
+
+    def test_sql_final_join_includes_career_distance(self):
+        """最終SELECTが temp_career_distance を LEFT JOIN していること"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        assert "left join temp_career_distance as t_c_d" in content, \
+            "最終SELECTに temp_career_distance の LEFT JOIN がありません"
+
+    def test_sql_placed_null_handling(self):
+        """好走実績ゼロの馬は NULL になること（CASE WHEN is_top3=1 THEN distance END で自然に NULL）"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        cte_start = content.find("temp_career_distance as (")
+        cte_end = content.find("temp_training as (")
+        cte_section = content[cte_start:cte_end]
+        assert "case when is_top3 = 1 then distance end" in cte_section, \
+            "好走実績ゼロの馬を NULL にする CASE WHEN が見つかりません"
+
+    def test_sql_career_distance_no_current_race_data(self):
+        """temp_career_distance_flags が is_first_at_distance フラグを含むこと"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        flags_start = content.find("temp_career_distance_flags as (")
+        flags_end = content.find("temp_career_distance as (")
+        flags_section = content[flags_start:flags_end]
+        assert "is_first_at_distance" in flags_section, "is_first_at_distance フラグがありません"
+        assert "is_first_placed_at_distance" in flags_section, "is_first_placed_at_distance フラグがありません"
+
+    def test_sql_career_distance_based_on_horse_distance_base(self):
+        """temp_career_distance_flags が temp_horse_distance_base を参照していること"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        flags_start = content.find("temp_career_distance_flags as (")
+        flags_end = content.find("temp_career_distance as (")
+        flags_section = content[flags_start:flags_end]
+        assert "from temp_horse_distance_base" in flags_section, \
+            "temp_career_distance_flags が temp_horse_distance_base を参照していません"


### PR DESCRIPTION
## 概要

スターアニス（2026年オークス1番人気12着大敗）等の事例から、馬個体の距離経験履歴を捕捉できていない問題を解決。  
「この馬がこれまで走ったことのない距離への初挑戦かどうか」を12特徴量でモデル化する。

Closes #305

---

## 実装内容

### 新規CTE

| CTE名 | 役割 |
|-------|------|
| `temp_career_distance_flags` | `(horse_id, distance)` ペアの初出フラグを付与（COUNT DISTINCT のウィンドウ関数代替） |
| `temp_career_distance` | `RANGE BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING` で当日除外集計 |

### 追加特徴量（12個）

**グループ1: 全出走レースを対象**

| 特徴量名 | 型 | 定義 |
|----------|----|------|
| `is_career_max_distance` | BOOL | 当レース距離 > キャリア最長距離（NULL = 初出走） |
| `career_max_distance_diff` | INT64 | 当レース距離 − キャリア最長距離 |
| `is_career_min_distance` | BOOL | 当レース距離 < キャリア最短距離 |
| `career_min_distance_diff` | INT64 | 当レース距離 − キャリア最短距離 |
| `career_distance_range` | INT64 | 最長距離 − 最短距離（距離適応の幅） |
| `career_distance_count` | INT64 | 経験した距離の種類数 |

**グループ2: 3着以内レースのみを対象**

| 特徴量名 | 型 | 定義 |
|----------|----|------|
| `is_beyond_placed_max_distance` | BOOL | 当レース距離 > 好走時の最長距離（NULL = 好走実績なし） |
| `placed_max_distance_diff` | INT64 | 当レース距離 − 好走時の最長距離 |
| `is_below_placed_min_distance` | BOOL | 当レース距離 < 好走時の最短距離 |
| `placed_min_distance_diff` | INT64 | 当レース距離 − 好走時の最短距離 |
| `placed_distance_range` | INT64 | 好走時の最長 − 最短距離 |
| `placed_distance_count` | INT64 | 好走した距離の種類数 |

### データリーク対策
- `RANGE BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING`（unix_date基準）で当日・同日レースを完全除外
- `temp_horse_distance_base` 起点（#284修正と同方針）で当日予測エントリも含める
- 好走実績ゼロの馬は `CASE WHEN is_top3 = 1 THEN distance END` で自然にNULL → LightGBMが欠損として扱う

---

## モデル精度比較

> ※ `--skip-feature-pipeline` で既存 BQ データを使用。新12特徴量の実効果は本番反映後に確認。

### モデル別 学習・検証期間

| | 既存モデル | 新モデル |
|---|---|---|
| **学習期間** | 2016-01-05 〜 2025-11-16（443,607行 / 29,298レース） | 2016-01-05 〜 2025-11-24（444,532行 / 29,358レース） |
| **検証期間** | 2025-11-22 〜 2026-05-17（21,630行 / 1,502レース） | 2025-11-29 〜 2026-05-24（21,708行 / 1,509レース） |

### 精度比較（同一検証データ: 2025-11-29 〜 2026-05-24）

| 指標 | 既存モデル | 新モデル | 差分 | 判定（±0.005） |
|---|---|---|---|---|
| **NDCG@3** | 0.5700 | 0.5654 | -0.0046 | ✅ 同等 |
| **AUC** | 0.8122 | 0.8125 | +0.0003 | ✅ 改善 |
| **Recall@3** | 0.5045 | 0.4996 | -0.0049 | ✅ 同等 |

### 総合判定: ✅ マージ可（全指標が合格基準を満たす）

---

## テスト計画

- [x] `/check-leak` 実施済み: データリーク検出なし
  - `RANGE BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING` で当日除外確認済み
  - `is_top3` は過去走の確定結果のみ参照
- [x] `pytest tests/test_features.py` 通過（91件、`TestCareerDistanceFeature` 8件追加）