### PR TITLE
feat: 前走コーナー通過順位（全コーナー）・折り合い指標特徴量の追加（Issue #306）

### DIFF
--- a/src/ml/features/feature_query_raw.sql
+++ b/src/ml/features/feature_query_raw.sql
@@ -149,6 +149,10 @@ with temp_race_horse_count as (
     ,r_r_1.finish_time as finish_time_1
     ,r_r_1.last_3f_time as last_3f_1
     ,r_r_1.corner_position_4 as corner_position_1
+    ,r_r_1.corner_position_1 as corner1_prev_1
+    ,r_r_1.corner_position_2 as corner2_prev_1
+    ,r_r_1.corner_position_3 as corner3_prev_1
+    ,r_r_1.corner_position_4 as corner4_prev_1
     ,r_l3f_1.last_3f_rank_in_race as last_3f_rank_in_race_1
     ,SUBSTR(r_r_1.race_id, 1, 2) as venue_code_prev_1
     ,r_r_1.distance as distance_prev_1
@@ -177,6 +181,10 @@ with temp_race_horse_count as (
     ,r_r_2.finish_time as finish_time_2
     ,r_r_2.last_3f_time as last_3f_2
     ,r_r_2.corner_position_4 as corner_position_2
+    ,r_r_2.corner_position_1 as corner1_prev_2
+    ,r_r_2.corner_position_2 as corner2_prev_2
+    ,r_r_2.corner_position_3 as corner3_prev_2
+    ,r_r_2.corner_position_4 as corner4_prev_2
     ,r_l3f_2.last_3f_rank_in_race as last_3f_rank_in_race_2
     -- 3走前のレース結果
     ,r_r_3.race_name as race_name_3
@@ -194,6 +202,10 @@ with temp_race_horse_count as (
     ,r_r_3.finish_time as finish_time_3
     ,r_r_3.last_3f_time as last_3f_3
     ,r_r_3.corner_position_4 as corner_position_3
+    ,r_r_3.corner_position_1 as corner1_prev_3
+    ,r_r_3.corner_position_2 as corner2_prev_3
+    ,r_r_3.corner_position_3 as corner3_prev_3
+    ,r_r_3.corner_position_4 as corner4_prev_3
     ,r_l3f_3.last_3f_rank_in_race as last_3f_rank_in_race_3
     -- 4走前のレース結果
     ,r_r_4.race_name as race_name_4
@@ -586,6 +598,46 @@ with temp_race_horse_count as (
     ) as race_idm_cv
     -- レース内相対指標（馬番の内外位置）
     ,safe_divide(t_p_r_f.horse_number, t_p_r_f.num_horses) as horse_number_ratio
+    -- コーナー通過順変化（折り合い指標, Issue #306）
+    -- 正値 = 前につけて失速、負値 = 後方から押し上げ。直線コース等でcorner1がNULLの場合はNULL
+    ,t_p_r_f.corner4_prev_1 - t_p_r_f.corner1_prev_1 as corner_gain_1to4_prev_1
+    ,t_p_r_f.corner4_prev_2 - t_p_r_f.corner1_prev_2 as corner_gain_1to4_prev_2
+    ,t_p_r_f.corner4_prev_3 - t_p_r_f.corner1_prev_3 as corner_gain_1to4_prev_3
+    ,safe_divide(
+      (coalesce(t_p_r_f.corner4_prev_1 - t_p_r_f.corner1_prev_1, 0)
+       + coalesce(t_p_r_f.corner4_prev_2 - t_p_r_f.corner1_prev_2, 0)
+       + coalesce(t_p_r_f.corner4_prev_3 - t_p_r_f.corner1_prev_3, 0))
+      ,nullif(
+        (case when t_p_r_f.corner1_prev_1 is not null and t_p_r_f.corner4_prev_1 is not null then 1 else 0 end +
+        case when t_p_r_f.corner1_prev_2 is not null and t_p_r_f.corner4_prev_2 is not null then 1 else 0 end +
+        case when t_p_r_f.corner1_prev_3 is not null and t_p_r_f.corner4_prev_3 is not null then 1 else 0 end)
+        , 0)
+    ) as mean_corner_gain_1to4
+    ,safe_divide(
+      (coalesce((t_p_r_f.corner4_prev_1 - t_p_r_f.corner1_prev_1) * 1.5, 0)
+       + coalesce((t_p_r_f.corner4_prev_2 - t_p_r_f.corner1_prev_2) * 1.0, 0)
+       + coalesce((t_p_r_f.corner4_prev_3 - t_p_r_f.corner1_prev_3) * 0.5, 0))
+      ,nullif(
+        (case when t_p_r_f.corner1_prev_1 is not null and t_p_r_f.corner4_prev_1 is not null then 1.5 else 0 end +
+        case when t_p_r_f.corner1_prev_2 is not null and t_p_r_f.corner4_prev_2 is not null then 1.0 else 0 end +
+        case when t_p_r_f.corner1_prev_3 is not null and t_p_r_f.corner4_prev_3 is not null then 0.5 else 0 end)
+        , 0)
+    ) as ema_corner_gain_1to4
+    ,safe_divide(
+      (coalesce(t_p_r_f.corner1_prev_1, 0) + coalesce(t_p_r_f.corner1_prev_2, 0) + coalesce(t_p_r_f.corner1_prev_3, 0))
+      ,nullif(
+        (case when t_p_r_f.corner1_prev_1 is not null then 1 else 0 end +
+        case when t_p_r_f.corner1_prev_2 is not null then 1 else 0 end +
+        case when t_p_r_f.corner1_prev_3 is not null then 1 else 0 end)
+        , 0)
+    ) as mean_corner1_position
+    ,IF(
+      t_p_r_f.corner1_prev_1 is not null
+        and t_p_r_f.finish_position_1 is not null
+        and t_p_r_f.finish_position_1 > 0,
+      t_p_r_f.corner1_prev_1 - t_p_r_f.finish_position_1,
+      null
+    ) as corner1_to_finish_delta_prev_1
   from
     temp_past_race_features as t_p_r_f
 )

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1126,3 +1126,89 @@ class TestCareerDistanceFeature:
         flags_section = content[flags_start:flags_end]
         assert "from temp_horse_distance_base" in flags_section, \
             "temp_career_distance_flags が temp_horse_distance_base を参照していません"
+
+
+class TestCornerPositionFeature:
+    """前走コーナー通過順位（全コーナー）・折り合い指標のテスト（Issue #306）"""
+
+    def test_sql_has_raw_corner_columns_prev1(self):
+        """前走（prev_1）の全4コーナー通過順が定義されていること"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        prf_start = content.find("temp_past_race_features as (")
+        prf2_start = content.find("temp_past_race_features2 as (")
+        prf_section = content[prf_start:prf2_start]
+        for col in ["corner1_prev_1", "corner2_prev_1", "corner3_prev_1", "corner4_prev_1"]:
+            assert col in prf_section, f"temp_past_race_features に '{col}' が見つかりません"
+
+    def test_sql_has_raw_corner_columns_prev2(self):
+        """2走前（prev_2）の全4コーナー通過順が定義されていること"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        prf_start = content.find("temp_past_race_features as (")
+        prf2_start = content.find("temp_past_race_features2 as (")
+        prf_section = content[prf_start:prf2_start]
+        for col in ["corner1_prev_2", "corner2_prev_2", "corner3_prev_2", "corner4_prev_2"]:
+            assert col in prf_section, f"temp_past_race_features に '{col}' が見つかりません"
+
+    def test_sql_has_raw_corner_columns_prev3(self):
+        """3走前（prev_3）の全4コーナー通過順が定義されていること"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        prf_start = content.find("temp_past_race_features as (")
+        prf2_start = content.find("temp_past_race_features2 as (")
+        prf_section = content[prf_start:prf2_start]
+        for col in ["corner1_prev_3", "corner2_prev_3", "corner3_prev_3", "corner4_prev_3"]:
+            assert col in prf_section, f"temp_past_race_features に '{col}' が見つかりません"
+
+    def test_sql_has_corner_gain_features_in_prf2(self):
+        """折り合い指標（corner_gain_1to4_prev_N）が temp_past_race_features2 に定義されていること"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        prf2_start = content.find("temp_past_race_features2 as (")
+        horse_master_start = content.find("temp_horse_master_feature as (")
+        prf2_section = content[prf2_start:horse_master_start]
+        for col in ["corner_gain_1to4_prev_1", "corner_gain_1to4_prev_2", "corner_gain_1to4_prev_3"]:
+            assert col in prf2_section, f"temp_past_race_features2 に '{col}' が見つかりません"
+
+    def test_sql_has_aggregate_corner_features_in_prf2(self):
+        """集計折り合い指標が temp_past_race_features2 に定義されていること"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        prf2_start = content.find("temp_past_race_features2 as (")
+        horse_master_start = content.find("temp_horse_master_feature as (")
+        prf2_section = content[prf2_start:horse_master_start]
+        for col in [
+            "mean_corner_gain_1to4",
+            "ema_corner_gain_1to4",
+            "mean_corner1_position",
+            "corner1_to_finish_delta_prev_1",
+        ]:
+            assert col in prf2_section, f"temp_past_race_features2 に '{col}' が見つかりません"
+
+    def test_sql_corner4_uses_r_r_corner_position_4(self):
+        """corner4_prev_N は r_r_N.corner_position_4 を参照していること（既存データと整合）"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        prf_start = content.find("temp_past_race_features as (")
+        prf2_start = content.find("temp_past_race_features2 as (")
+        prf_section = content[prf_start:prf2_start]
+        assert "r_r_1.corner_position_4 as corner4_prev_1" in prf_section, \
+            "corner4_prev_1 が r_r_1.corner_position_4 を参照していません"
+        assert "r_r_2.corner_position_4 as corner4_prev_2" in prf_section, \
+            "corner4_prev_2 が r_r_2.corner_position_4 を参照していません"
+        assert "r_r_3.corner_position_4 as corner4_prev_3" in prf_section, \
+            "corner4_prev_3 が r_r_3.corner_position_4 を参照していません"
+
+    def test_sql_corner_gain_null_when_corner1_null(self):
+        """corner_gain_1to4_prev_N は corner1が NULL の場合 NULL になること（直線コース対応）"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        prf2_start = content.find("temp_past_race_features2 as (")
+        horse_master_start = content.find("temp_horse_master_feature as (")
+        prf2_section = content[prf2_start:horse_master_start]
+        # 分母にcorner1 is not null条件があることを確認（直線コース除外）
+        assert "corner1_prev_1 is not null and t_p_r_f.corner4_prev_1 is not null" in prf2_section, \
+            "mean_corner_gain_1to4 の分母に corner1/corner4 null チェックがありません"
+
+    def test_sql_corner1_to_finish_delta_excludes_invalid_finish(self):
+        """corner1_to_finish_delta_prev_1 は finish_position=0（取消/失格）を除外すること"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        prf2_start = content.find("temp_past_race_features2 as (")
+        horse_master_start = content.find("temp_horse_master_feature as (")
+        prf2_section = content[prf2_start:horse_master_start]
+        assert "finish_position_1 > 0" in prf2_section, \
+            "corner1_to_finish_delta_prev_1 が finish_position=0 を除外していません"


### PR DESCRIPTION
## 概要

2026年オークスのスターアニスが「スタートから折り合いを欠き、道中ずっとハミを噛み直線でスタミナ切れ12着」という事例を受け、過去走の折り合い傾向を捕捉する特徴量を追加。

Closes #306

---

## 実装内容

### Step 1: 前走1〜3走分の全4コーナー通過順（12列）

`temp_past_race_features` に追加（既存の `corner_position_N` はEXCEPT済み）:

| 特徴量名 | 内容 |
|----------|------|
| `corner1_prev_1〜3` | 各走前の1コーナー通過順 |
| `corner2_prev_1〜3` | 各走前の2コーナー通過順 |
| `corner3_prev_1〜3` | 各走前の3コーナー通過順 |
| `corner4_prev_1〜3` | 各走前の4コーナー通過順（既存データと同じ） |

### Step 2 & 3: 折り合い指標（7特徴量）

`temp_past_race_features2` に追加:

| 特徴量名 | 型 | 定義 |
|----------|----|------|
| `corner_gain_1to4_prev_1` | INT64 | 前走: 4コーナー通過順 − 1コーナー通過順 |
| `corner_gain_1to4_prev_2` | INT64 | 2走前の同指標 |
| `corner_gain_1to4_prev_3` | INT64 | 3走前の同指標 |
| `mean_corner_gain_1to4` | FLOAT64 | 前走〜3走前の単純平均 |
| `ema_corner_gain_1to4` | FLOAT64 | 指数加重平均（ウェイト: 1.5/1.0/0.5） |
| `mean_corner1_position` | FLOAT64 | 1コーナー通過順の平均（スタート気性傾向） |
| `corner1_to_finish_delta_prev_1` | INT64 | 前走1コーナー通過順 − 着順（正値 = 先行失速） |

### 命名の整理

- 既存 `corner_position_1〜5` は「何走前か」を示す番号（EXCEPT済み）
- 今回追加は `cornerN_prev_M`（コーナー番号 × 走前番号）で名前衝突なし

### データリーク対策

- 全データは `r_r_N.race_date < t_b_r_e.race_date` のJOIN条件で過去走のみ参照
- 直線コース（corner1=NULL）では `corner_gain` が自然にNULL → LightGBMが欠損として扱う
- 取消・失格馬（finish_position=0）は `corner1_to_finish_delta_prev_1` の計算から除外

---

## モデル精度比較

> ※ `--skip-feature-pipeline` で既存 BQ データを使用。新19特徴量の実効果は本番反映後に確認。

### モデル別 学習・検証期間

| | 既存モデル | 新モデル |
|---|---|---|
| **学習期間** | 2016-01-05 〜 2025-11-16（443,607行 / 29,298レース） | 2016-01-05 〜 2025-11-24（444,532行 / 29,358レース） |
| **検証期間** | 2025-11-22 〜 2026-05-17（21,630行 / 1,502レース） | 2025-11-29 〜 2026-05-24（21,708行 / 1,509レース） |

### 精度比較（同一検証データ: 2025-11-29 〜 2026-05-24）

| 指標 | 既存モデル | 新モデル | 差分 | 判定（±0.005） |
|---|---|---|---|---|
| **NDCG@3** | 0.5700 | 0.5671 | -0.0029 | ✅ 同等 |
| **AUC** | 0.8122 | 0.8121 | -0.0002 | ✅ 同等 |
| **Recall@3** | 0.5045 | 0.5030 | -0.0016 | ✅ 同等 |

### 総合判定: ✅ マージ可（全指標が合格基準を満たす）

---

## テスト計画

- [x] `/check-leak` 実施済み: データリーク検出なし
  - `r_r_N.race_date < t_b_r_e.race_date` のJOIN境界確認済み
  - 直線コースのNULL処理確認済み
  - 取消・失格馬（finish_position=0）の除外確認済み
- [x] `pytest tests/test_features.py` 通過（99件、`TestCornerPositionFeature` 8件追加）