### PR TITLE
fix: 母馬産駒TE の低頻度マスク閾値を 10 → 3 に緩和

### DIFF
--- a/src/ml/features/feature_query_raw.sql
+++ b/src/ml/features/feature_query_raw.sql
@@ -1650,15 +1650,15 @@ with temp_race_horse_count as (
   select
     race_id
     ,horse_number
-    ,IF(mare_count >= 10, mare_te, NULL) as mare_te
-    ,IF(mare_count >= 10, mare_course_type_te, NULL) as mare_course_type_te
-    ,IF(mare_count >= 10, mare_venue_te, NULL) as mare_venue_te
-    ,IF(mare_count >= 10, mare_distance_band_te, NULL) as mare_distance_band_te
-    ,IF(mare_count >= 10, mare_distance_te, NULL) as mare_distance_te
-    ,IF(mare_count >= 10, mare_direction_te, NULL) as mare_direction_te
-    ,IF(mare_count >= 10, mare_course_type_venue_te, NULL) as mare_course_type_venue_te
-    ,IF(mare_count >= 10, mare_course_type_distance_te, NULL) as mare_course_type_distance_te
-    ,IF(mare_count >= 10, mare_course_type_distance_venue_te, NULL) as mare_course_type_distance_venue_te
+    ,IF(mare_count >= 3, mare_te, NULL) as mare_te
+    ,IF(mare_count >= 3, mare_course_type_te, NULL) as mare_course_type_te
+    ,IF(mare_count >= 3, mare_venue_te, NULL) as mare_venue_te
+    ,IF(mare_count >= 3, mare_distance_band_te, NULL) as mare_distance_band_te
+    ,IF(mare_count >= 3, mare_distance_te, NULL) as mare_distance_te
+    ,IF(mare_count >= 3, mare_direction_te, NULL) as mare_direction_te
+    ,IF(mare_count >= 3, mare_course_type_venue_te, NULL) as mare_course_type_venue_te
+    ,IF(mare_count >= 3, mare_course_type_distance_te, NULL) as mare_course_type_distance_te
+    ,IF(mare_count >= 3, mare_course_type_distance_venue_te, NULL) as mare_course_type_distance_venue_te
   from temp_mare_te_pre
 )
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1256,13 +1256,13 @@ class TestMareFeature:
             "temp_mare_te_pre の partition by に dam_name がありません"
 
     def test_sql_mare_te_low_frequency_mask(self):
-        """temp_mare_te が産駒数 < 10 の母馬を NULL マスクすること（#293 準拠）"""
+        """temp_mare_te が産駒数 < 3 の母馬を NULL マスクすること（緩和: 10→3）"""
         content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
         mare_te_start = content.find("temp_mare_te as (")
         horse_te_pre_start = content.find("temp_horse_te_pre as (")
         section = content[mare_te_start:horse_te_pre_start]
-        assert "mare_count >= 10" in section, \
-            "temp_mare_te に産駒数 < 10 の NULL マスク（>= 10）がありません"
+        assert "mare_count >= 3" in section, \
+            "temp_mare_te に産駒数 < 3 の NULL マスク（>= 3）がありません"
 
     def test_sql_mare_placed_max_distance_diff_sign(self):
         """mare_placed_max_distance_diff は「当レース距離 − 母馬好走最長距離」であること（正値 = 超過）"""


### PR DESCRIPTION
## 変更内容

Issue #307（PR #314）で実装した母馬産駒 TE の低頻度マスク閾値を緩和。

| | 変更前 | 変更後 |
|--|--------|--------|
| `mare_count` 閾値 | >= 10（産駒10頭出走以上） | >= 3（産駒3頭出走以上） |

## 理由

- 産駒10頭という閾値は厳しすぎる（それなりに活躍した繁殖牝馬でないと到達しない）
- スムージング係数 m=10 により、産駒3頭でも全体平均に大きく引き寄せられるためノイズ影響は小さい
- 他の閾値（騎手/調教師/種牡馬 >= 20、馬自身 >= 5）は問題なし

## テスト

- `pytest tests/test_features.py` 通過（107 tests passed）
- `test_sql_mare_te_low_frequency_mask` を `>= 3` に更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)