### PR TITLE
fix: TE低頻度マスク閾値を軸数に応じて段階的に緩和

### DIFF
--- a/src/ml/features/feature_query_raw.sql
+++ b/src/ml/features/feature_query_raw.sql
@@ -1124,7 +1124,8 @@ with temp_race_horse_count as (
   from temp_te_history_base
     cross join temp_global_mean_te as g
 )
-/* 低頻度マスク適用: 騎手の過去出走数 < 20 の場合は全TE値をNULLにする */
+/* 低頻度マスク適用: 1軸は >= 20、2軸複合 >= 5、3軸複合 >= 3
+   組み合わせが細かいほど同条件への出走回数は少なくなるため軸数で閾値を段階的に緩和 */
 ,temp_jockey_te as (
   select
     race_id
@@ -1135,9 +1136,9 @@ with temp_race_horse_count as (
     ,IF(jockey_count >= 20, jockey_distance_band_te, NULL) as jockey_distance_band_te
     ,IF(jockey_count >= 20, jockey_distance_te, NULL) as jockey_distance_te
     ,IF(jockey_count >= 20, jockey_direction_te, NULL) as jockey_direction_te
-    ,IF(jockey_count >= 20, jockey_course_type_venue_te, NULL) as jockey_course_type_venue_te
-    ,IF(jockey_count >= 20, jockey_course_type_distance_te, NULL) as jockey_course_type_distance_te
-    ,IF(jockey_count >= 20, jockey_course_type_distance_venue_te, NULL) as jockey_course_type_distance_venue_te
+    ,IF(jockey_count >= 5, jockey_course_type_venue_te, NULL) as jockey_course_type_venue_te
+    ,IF(jockey_count >= 5, jockey_course_type_distance_te, NULL) as jockey_course_type_distance_te
+    ,IF(jockey_count >= 3, jockey_course_type_distance_venue_te, NULL) as jockey_course_type_distance_venue_te
   from temp_jockey_te_pre
 )
 
@@ -1263,7 +1264,7 @@ with temp_race_horse_count as (
   from temp_te_history_base
     cross join temp_global_mean_te as g
 )
-/* 低頻度マスク適用: 調教師の過去出走数 < 20 の場合は全TE値をNULLにする */
+/* 低頻度マスク適用: 1軸は >= 20、2軸複合 >= 5、3軸複合 >= 3 */
 ,temp_trainer_te as (
   select
     race_id
@@ -1274,9 +1275,9 @@ with temp_race_horse_count as (
     ,IF(trainer_count >= 20, trainer_distance_band_te, NULL) as trainer_distance_band_te
     ,IF(trainer_count >= 20, trainer_distance_te, NULL) as trainer_distance_te
     ,IF(trainer_count >= 20, trainer_direction_te, NULL) as trainer_direction_te
-    ,IF(trainer_count >= 20, trainer_course_type_venue_te, NULL) as trainer_course_type_venue_te
-    ,IF(trainer_count >= 20, trainer_course_type_distance_te, NULL) as trainer_course_type_distance_te
-    ,IF(trainer_count >= 20, trainer_course_type_distance_venue_te, NULL) as trainer_course_type_distance_venue_te
+    ,IF(trainer_count >= 5, trainer_course_type_venue_te, NULL) as trainer_course_type_venue_te
+    ,IF(trainer_count >= 5, trainer_course_type_distance_te, NULL) as trainer_course_type_distance_te
+    ,IF(trainer_count >= 3, trainer_course_type_distance_venue_te, NULL) as trainer_course_type_distance_venue_te
   from temp_trainer_te_pre
 )
 
@@ -1402,7 +1403,7 @@ with temp_race_horse_count as (
   from temp_te_history_base
     cross join temp_global_mean_te as g
 )
-/* 低頻度マスク適用: 種牡馬の過去出走数 < 20 の場合は全TE値をNULLにする */
+/* 低頻度マスク適用: 1軸は >= 20、2軸複合 >= 5、3軸複合 >= 3 */
 ,temp_sire_te as (
   select
     race_id
@@ -1413,9 +1414,9 @@ with temp_race_horse_count as (
     ,IF(sire_count >= 20, sire_distance_band_te, NULL) as sire_distance_band_te
     ,IF(sire_count >= 20, sire_distance_te, NULL) as sire_distance_te
     ,IF(sire_count >= 20, sire_direction_te, NULL) as sire_direction_te
-    ,IF(sire_count >= 20, sire_course_type_venue_te, NULL) as sire_course_type_venue_te
-    ,IF(sire_count >= 20, sire_course_type_distance_te, NULL) as sire_course_type_distance_te
-    ,IF(sire_count >= 20, sire_course_type_distance_venue_te, NULL) as sire_course_type_distance_venue_te
+    ,IF(sire_count >= 5, sire_course_type_venue_te, NULL) as sire_course_type_venue_te
+    ,IF(sire_count >= 5, sire_course_type_distance_te, NULL) as sire_course_type_distance_te
+    ,IF(sire_count >= 3, sire_course_type_distance_venue_te, NULL) as sire_course_type_distance_venue_te
   from temp_sire_te_pre
 )
 
@@ -1845,9 +1846,9 @@ with temp_race_horse_count as (
     ,IF(horse_count >= 5, horse_direction_te, NULL) as horse_direction_te
     ,IF(horse_count >= 5, horse_jockey_te, NULL) as horse_jockey_te
     ,IF(horse_count >= 5, horse_season_te, NULL) as horse_season_te
-    ,IF(horse_count >= 5, horse_course_type_venue_te, NULL) as horse_course_type_venue_te
-    ,IF(horse_count >= 5, horse_course_type_distance_te, NULL) as horse_course_type_distance_te
-    ,IF(horse_count >= 5, horse_course_type_distance_venue_te, NULL) as horse_course_type_distance_venue_te
+    ,IF(horse_count >= 2, horse_course_type_venue_te, NULL) as horse_course_type_venue_te
+    ,IF(horse_count >= 2, horse_course_type_distance_te, NULL) as horse_course_type_distance_te
+    ,IF(horse_count >= 2, horse_course_type_distance_venue_te, NULL) as horse_course_type_distance_venue_te
     ,IF(horse_count >= 5, horse_distance_change_te, NULL) as horse_distance_change_te
     ,IF(horse_count >= 5, horse_weight_carried_change_te, NULL) as horse_weight_carried_change_te
   from temp_horse_te_pre

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -517,55 +517,87 @@ class TestTELowFrequencyMask:
         assert "range between unbounded preceding and 1 preceding" in sire_pre_section
 
     def test_sql_mask_wrapper_applies_if_condition(self):
-        """マスクラッパーCTEが IF(count >= 20, ..., NULL) を適用していること"""
+        """マスクラッパーCTEが単軸 >= 20 の IF 条件を適用していること"""
         content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
-        # 騎手マスク
+        # 騎手マスク（単軸）
         jockey_wrapper_start = content.find("temp_jockey_te as (")
         jockey_wrapper_end = content.find("temp_trainer_te_pre")
         jockey_wrapper = content[jockey_wrapper_start:jockey_wrapper_end]
         assert "IF(jockey_count >= 20, jockey_te, NULL)" in jockey_wrapper
         assert "IF(jockey_count >= 20, jockey_course_type_te, NULL)" in jockey_wrapper
 
-        # 調教師マスク
+        # 調教師マスク（単軸）
         trainer_wrapper_start = content.find("temp_trainer_te as (")
         trainer_wrapper_end = content.find("temp_sire_te_pre")
         trainer_wrapper = content[trainer_wrapper_start:trainer_wrapper_end]
         assert "IF(trainer_count >= 20, trainer_te, NULL)" in trainer_wrapper
 
-        # 種牡馬マスク
+        # 種牡馬マスク（単軸）
         sire_wrapper_start = content.find("temp_sire_te as (")
         sire_wrapper_end = content.find("temp_horse_distance_base")
         sire_wrapper = content[sire_wrapper_start:sire_wrapper_end]
         assert "IF(sire_count >= 20, sire_te, NULL)" in sire_wrapper
 
     def test_sql_mask_threshold_is_20(self):
-        """マスク閾値が 20 であること（変更時に気付けるよう）"""
+        """単軸TEのマスク閾値が 20 であること（変更時に気付けるよう）"""
         content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
         assert "IF(jockey_count >= 20," in content
         assert "IF(trainer_count >= 20," in content
         assert "IF(sire_count >= 20," in content
 
+    def test_sql_combined_te_thresholds_by_axis(self):
+        """複合TE（2軸/3軸）は軸数に応じて閾値が段階的に緩和されていること"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        # 騎手: 2軸 >= 5, 3軸 >= 3
+        jockey_wrapper_start = content.find("temp_jockey_te as (")
+        jockey_wrapper_end = content.find("temp_trainer_te_pre")
+        jockey_wrapper = content[jockey_wrapper_start:jockey_wrapper_end]
+        assert "IF(jockey_count >= 5, jockey_course_type_venue_te, NULL)" in jockey_wrapper
+        assert "IF(jockey_count >= 5, jockey_course_type_distance_te, NULL)" in jockey_wrapper
+        assert "IF(jockey_count >= 3, jockey_course_type_distance_venue_te, NULL)" in jockey_wrapper
+
+        # 調教師: 2軸 >= 5, 3軸 >= 3
+        trainer_wrapper_start = content.find("temp_trainer_te as (")
+        trainer_wrapper_end = content.find("temp_sire_te_pre")
+        trainer_wrapper = content[trainer_wrapper_start:trainer_wrapper_end]
+        assert "IF(trainer_count >= 5, trainer_course_type_venue_te, NULL)" in trainer_wrapper
+        assert "IF(trainer_count >= 3, trainer_course_type_distance_venue_te, NULL)" in trainer_wrapper
+
+        # 種牡馬: 2軸 >= 5, 3軸 >= 3
+        sire_wrapper_start = content.find("temp_sire_te as (")
+        sire_wrapper_end = content.find("temp_horse_distance_base")
+        sire_wrapper = content[sire_wrapper_start:sire_wrapper_end]
+        assert "IF(sire_count >= 5, sire_course_type_venue_te, NULL)" in sire_wrapper
+        assert "IF(sire_count >= 3, sire_course_type_distance_venue_te, NULL)" in sire_wrapper
+
+        # 馬自身: 2軸/3軸 >= 2
+        horse_te_start = content.find(",temp_horse_te as (")
+        horse_te_end = content.find("temp_horse_distance_base")
+        horse_te_section = content[horse_te_start:horse_te_end]
+        assert "IF(horse_count >= 2, horse_course_type_venue_te, NULL)" in horse_te_section
+        assert "IF(horse_count >= 2, horse_course_type_distance_te, NULL)" in horse_te_section
+        assert "IF(horse_count >= 2, horse_course_type_distance_venue_te, NULL)" in horse_te_section
+
     def test_sql_all_9_jockey_te_columns_masked(self):
-        """9つの騎手TE基本特徴量がすべてマスク対象であること"""
+        """9つの騎手TE基本特徴量がすべてマスク対象であること（軸数別閾値）"""
         content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
         jockey_wrapper_start = content.find("temp_jockey_te as (")
         jockey_wrapper_end = content.find("temp_trainer_te_pre")
         jockey_wrapper = content[jockey_wrapper_start:jockey_wrapper_end]
-        expected_columns = [
-            "jockey_te",
-            "jockey_course_type_te",
-            "jockey_venue_te",
-            "jockey_distance_band_te",
-            "jockey_distance_te",
-            "jockey_direction_te",
-            "jockey_course_type_venue_te",
-            "jockey_course_type_distance_te",
-            "jockey_course_type_distance_venue_te",
+        # 単軸（>= 20）
+        single_axis_cols = [
+            "jockey_te", "jockey_course_type_te", "jockey_venue_te",
+            "jockey_distance_band_te", "jockey_distance_te", "jockey_direction_te",
         ]
-        for col in expected_columns:
+        for col in single_axis_cols:
             assert f"IF(jockey_count >= 20, {col}, NULL)" in jockey_wrapper, (
-                f"騎手TE '{col}' のマスク条件が見つかりません"
+                f"騎手TE単軸 '{col}' のマスク条件 (>= 20) が見つかりません"
             )
+        # 2軸（>= 5）
+        assert "IF(jockey_count >= 5, jockey_course_type_venue_te, NULL)" in jockey_wrapper
+        assert "IF(jockey_count >= 5, jockey_course_type_distance_te, NULL)" in jockey_wrapper
+        # 3軸（>= 3）
+        assert "IF(jockey_count >= 3, jockey_course_type_distance_venue_te, NULL)" in jockey_wrapper
 
     def test_sql_final_join_still_references_wrapper_ctes(self):
         """最終SELECTがマスクラッパーCTE（temp_jockey_te等）を参照していること"""


### PR DESCRIPTION
## 問題

複合TE（2軸・3軸）に対して全体出走数での一律閾値を適用していた。例えば：
- 馬が5回出走しても、東京芝2000mへの出走は1回しかない場合が多い
- 同様に騎手が20回騎乗しても、特定の会場×コース×距離の組み合わせは1〜2回のことがある

## 変更内容

TE軸数に応じて閾値を段階的に緩和。`count` は全体での出走/騎乗/産駒出走数（条件別ではない）。

| TE種別 | 全体 / 1軸 | 2軸複合 | 3軸複合 |
|--------|-----------|---------|---------|
| 馬自身 | >= 5（変更なし） | >= 5 → **>= 2** | >= 5 → **>= 2** |
| 騎手・調教師 | >= 20（変更なし） | >= 20 → **>= 5** | >= 20 → **>= 3** |
| 種牡馬 | >= 20（変更なし） | >= 20 → **>= 5** | >= 20 → **>= 3** |
| 母馬 | >= 3（前 PR 設定済み） | >= 3 | >= 3 |

スムージング係数 m=10 により、少数サンプルでも全体平均に引き寄せられるためノイズへの影響は最小限。

## テスト

- `pytest tests/test_features.py` 通過（108 tests passed）
- `test_sql_combined_te_thresholds_by_axis` を新規追加（軸数別閾値の網羅的な検証）
- 既存テスト `test_sql_all_9_jockey_te_columns_masked` を単軸/複合軸の閾値別に更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)