### PR TITLE
feat: 当レースの枠番×馬場バイアス交差特徴量の追加（Issue #310）

### DIFF
--- a/src/ml/features/feature_query_raw.sql
+++ b/src/ml/features/feature_query_raw.sql
@@ -733,6 +733,27 @@ with temp_race_horse_count as (
       t_p_r_f.corner1_prev_1 - t_p_r_f.finish_position_1,
       null
     ) as corner1_to_finish_delta_prev_1
+    -- コース取り傾向集計（Issue #310）
+    ,safe_divide(
+      coalesce(t_p_r_f.course_position_prev1, 0) +
+      coalesce(t_p_r_f.course_position_prev2, 0) +
+      coalesce(t_p_r_f.course_position_prev3, 0),
+      nullif(
+        (case when t_p_r_f.course_position_prev1 is not null then 1 else 0 end +
+        case when t_p_r_f.course_position_prev2 is not null then 1 else 0 end +
+        case when t_p_r_f.course_position_prev3 is not null then 1 else 0 end),
+        0)
+    ) as mean_course_position
+    ,safe_divide(
+      coalesce(t_p_r_f.course_position_prev1 * 1.5, 0) +
+      coalesce(t_p_r_f.course_position_prev2 * 1.0, 0) +
+      coalesce(t_p_r_f.course_position_prev3 * 0.5, 0),
+      nullif(
+        (case when t_p_r_f.course_position_prev1 is not null then 1.5 else 0 end +
+        case when t_p_r_f.course_position_prev2 is not null then 1.0 else 0 end +
+        case when t_p_r_f.course_position_prev3 is not null then 0.5 else 0 end),
+        0)
+    ) as ema_course_position
   from
     temp_past_race_features as t_p_r_f
 )
@@ -2777,6 +2798,25 @@ select
     WHEN 5 THEN t_p_r_f.prev5_straight_bias_outermost < 0
     ELSE NULL
   END as prev5_course_bias_disadvantage_flag
+  -- 枠番×馬場バイアス交差特徴量（Issue #310）
+  -- グループ1: 枠順バイアス有利不利スコア
+  ,CASE
+    WHEN t_p_r_f.horse_number_ratio <= 0.25 THEN t_h_m_f.straight_bias_innermost
+    WHEN t_p_r_f.horse_number_ratio <= 0.50 THEN t_h_m_f.straight_bias_inner
+    WHEN t_p_r_f.horse_number_ratio <= 0.75 THEN t_h_m_f.straight_bias_outer
+    ELSE                                          t_h_m_f.straight_bias_outermost
+  END as gate_bias_score
+  ,CASE
+    WHEN t_p_r_f.horse_number_ratio <= 0.25 THEN t_h_m_f.straight_bias_innermost > 0
+    WHEN t_p_r_f.horse_number_ratio <= 0.50 THEN t_h_m_f.straight_bias_inner > 0
+    WHEN t_p_r_f.horse_number_ratio <= 0.75 THEN t_h_m_f.straight_bias_outer > 0
+    ELSE                                          t_h_m_f.straight_bias_outermost > 0
+  END as gate_bias_advantage_flag
+  -- グループ2: 馬場バイアスの強度指標
+  ,t_h_m_f.straight_bias_innermost - t_h_m_f.straight_bias_outermost as straight_bias_range
+  ,ABS(t_h_m_f.straight_bias_innermost - t_h_m_f.straight_bias_outermost) >= 3 as is_strong_bias_race
+  -- グループ3: コース取り傾向 × 当日バイアスの複合リスクスコア
+  ,t_p_r_f.ema_course_position * t_h_m_f.straight_bias_inner as course_position_bias_risk
 from
   temp_past_race_features2 as t_p_r_f
   left join temp_horse_master_feature2 as t_h_m_f

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1425,7 +1425,7 @@ class TestAgeBasedTEFeature:
         """mare_current_age_te が horse_age に応じて正しい年齢帯 TE を選択すること"""
         content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
         final_start = content.rfind("from\n  temp_past_race_features2")
-        section = content[final_start - 5000:final_start]
+        section = content[final_start - 8000:final_start]
         assert "when t_p_r_f.horse_age = 2 then t_m_te.mare_age2_te" in section, \
             "mare_current_age_te の 2歳ケースがありません"
         assert "when t_p_r_f.horse_age = 3 then t_m_te.mare_age3_te" in section, \
@@ -1621,3 +1621,94 @@ class TestCourseBiasFeature:
         for n in range(2, 6):
             assert f"prev{n}_course_bias_disadvantage_flag" in content, \
                 f"最終 SELECT に prev{n}_course_bias_disadvantage_flag がありません"
+
+
+class TestGateBiasFeature:
+    """枠番×馬場バイアス交差特徴量のテスト（Issue #310）"""
+
+    def test_sql_gate_bias_score_in_final_select(self):
+        """gate_bias_score が最終 SELECT に存在すること"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        assert "gate_bias_score" in content, \
+            "最終 SELECT に gate_bias_score がありません"
+
+    def test_sql_gate_bias_advantage_flag_in_final_select(self):
+        """gate_bias_advantage_flag が最終 SELECT に存在すること"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        assert "gate_bias_advantage_flag" in content, \
+            "最終 SELECT に gate_bias_advantage_flag がありません"
+
+    def test_sql_gate_bias_score_zone_thresholds(self):
+        """gate_bias_score の CASE WHEN がゾーン境界（0.25 / 0.50 / 0.75）で切り替わること"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        assert "horse_number_ratio <= 0.25" in content, \
+            "gate_bias_score に 0.25（内側ゾーン）の閾値がありません"
+        assert "horse_number_ratio <= 0.50" in content, \
+            "gate_bias_score に 0.50（内中ゾーン）の閾値がありません"
+        assert "horse_number_ratio <= 0.75" in content, \
+            "gate_bias_score に 0.75（外中ゾーン）の閾値がありません"
+
+    def test_sql_gate_bias_score_uses_all_four_zones(self):
+        """gate_bias_score が innermost / inner / outer / outermost の4ゾーンを参照すること"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        for col in ["straight_bias_innermost", "straight_bias_inner",
+                    "straight_bias_outer", "straight_bias_outermost"]:
+            assert f"t_h_m_f.{col}" in content, \
+                f"gate_bias_score が t_h_m_f.{col} を参照していません"
+
+    def test_sql_straight_bias_range_in_final_select(self):
+        """straight_bias_range が最終 SELECT に存在すること"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        assert "straight_bias_range" in content, \
+            "最終 SELECT に straight_bias_range がありません"
+        assert "straight_bias_innermost - t_h_m_f.straight_bias_outermost" in content, \
+            "straight_bias_range の計算式（innermost - outermost）が正しくありません"
+
+    def test_sql_is_strong_bias_race_in_final_select(self):
+        """is_strong_bias_race が最終 SELECT に存在すること"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        assert "is_strong_bias_race" in content, \
+            "最終 SELECT に is_strong_bias_race がありません"
+        assert ">= 3" in content, \
+            "is_strong_bias_race の閾値（ABS >= 3）がありません"
+
+    def test_sql_mean_course_position_in_prf2_cte(self):
+        """mean_course_position が temp_past_race_features2 に定義されていること"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        prf2_start = content.find("temp_past_race_features2 as (")
+        hm_start = content.find("temp_horse_master_feature as (")
+        section = content[prf2_start:hm_start]
+        assert "mean_course_position" in section, \
+            "temp_past_race_features2 に mean_course_position がありません"
+        assert "course_position_prev1" in section, \
+            "mean_course_position が course_position_prev1 を参照していません"
+
+    def test_sql_ema_course_position_in_prf2_cte(self):
+        """ema_course_position が temp_past_race_features2 に定義され、重み付け集計になっていること"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        prf2_start = content.find("temp_past_race_features2 as (")
+        hm_start = content.find("temp_horse_master_feature as (")
+        section = content[prf2_start:hm_start]
+        assert "ema_course_position" in section, \
+            "temp_past_race_features2 に ema_course_position がありません"
+        assert "1.5" in section and "0.5" in section, \
+            "ema_course_position に前走ウェイト（1.5）または3走前ウェイト（0.5）がありません"
+
+    def test_sql_course_position_bias_risk_in_final_select(self):
+        """course_position_bias_risk が最終 SELECT に存在すること"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        assert "course_position_bias_risk" in content, \
+            "最終 SELECT に course_position_bias_risk がありません"
+        assert "ema_course_position * t_h_m_f.straight_bias_inner" in content, \
+            "course_position_bias_risk の計算式（ema_course_position × straight_bias_inner）が正しくありません"
+
+    def test_sql_course_position_uses_only_past_races(self):
+        """当レースの course_position は使用せず、過去走（r_r_1 等）のみ参照していること"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        prf_start = content.find("temp_past_race_features as (")
+        prf2_start = content.find("temp_past_race_features2 as (")
+        section = content[prf_start:prf2_start]
+        assert "r_r_1.course_position" in section, \
+            "前走の course_position（r_r_1.course_position）が見つかりません"
+        assert "h_r.course_position" not in section, \
+            "当レース（h_r.course_position）がリークしています"


### PR DESCRIPTION
## 概要

Issue #310 の実装。馬番と当日馬場バイアスの交差項、およびコース取り傾向×バイアスの複合リスクスコアを追加。

## 追加特徴量（7本）

### グループ1: 枠順バイアス有利不利スコア
| 特徴量 | 型 | 定義 |
|--------|-----|------|
| `gate_bias_score` | INT64 | 馬番比率ゾーン（≤0.25/0.50/0.75/1.0）に対応する `straight_bias_*` 値 |
| `gate_bias_advantage_flag` | BOOL | `gate_bias_score > 0`（当日バイアスで有利な枠かどうか） |

### グループ2: 馬場バイアス強度指標
| 特徴量 | 型 | 定義 |
|--------|-----|------|
| `straight_bias_range` | INT64 | `straight_bias_innermost - straight_bias_outermost`（内外差） |
| `is_strong_bias_race` | BOOL | `ABS(straight_bias_range) >= 3` |

### グループ3: コース取り傾向集計（temp_past_race_features2）
| 特徴量 | 型 | 定義 |
|--------|-----|------|
| `mean_course_position` | FLOAT64 | 前走〜3走前の `course_position` の単純平均 |
| `ema_course_position` | FLOAT64 | 重み付き平均（prev1×1.5 / prev2×1.0 / prev3×0.5） |
| `course_position_bias_risk` | FLOAT64 | `ema_course_position × straight_bias_inner` |

## モデル比較

### 学習・検証期間

| | 既存モデル | 新モデル |
|---|---|---|
| **学習期間** | 2016-01-05 〜 2025-11-16 (443,607行 / 29,298レース) | 2016-01-05 〜 2025-11-30 (445,074行 / 29,396レース) |
| **検証期間** | 2025-11-22 〜 2026-05-17 (21,630行 / 1,502レース) | 2025-12-06 〜 2026-05-31 (21,852行 / 1,517レース) |

### 精度比較

| 指標 | 既存モデル | 新モデル | 差分 | 判定（±0.005） |
|---|---|---|---|---|
| **NDCG@3** | 0.5701 | 0.5655 | -0.0047 | ✅ 同等 |
| **AUC** | 0.8118 | 0.8123 | +0.0005 | ✅ 改善 |
| **Recall@3** | 0.5031 | 0.5002 | -0.0029 | ✅ 同等 |

### 総合判定: ✅ マージ可（全指標 ±0.005 以内）

※ 比較は `--skip-feature-pipeline`（既存 features.training_data 使用）。新特徴量は features.training_data 再生成後の再学習で反映される。

## テスト計画

- [x] `/check-leak` 実施済み（リーク検出なし）
- [x] `TestGateBiasFeature` 10件追加
  - ゾーン境界（0.25/0.50/0.75）での切り替え確認
  - 4ゾーン（innermost/inner/outer/outermost）の参照確認
  - `straight_bias_range` / `is_strong_bias_race` の計算式確認
  - `mean_course_position` / `ema_course_position` の CTE 所属確認
  - `course_position_bias_risk` の計算式確認
  - 当レース `h_r.course_position` が混入していないことを確認
- [x] 既存テスト含む全146件 pytest 通過

## データリーク対策

- `gate_bias_score` / `straight_bias_range` 等: `venue_info.straight_bias_*` は当日朝公開の予想値。問題なし
- `course_position_prev1/2/3`: 過去走の確定データ。当レース自身の `course_position` は未使用

## 本番反映手順

1. `features.training_data` 再生成（特徴量パイプライン実行）
2. `/retrain-and-deploy` で新モデル学習・デプロイ

Closes #310