### PR TITLE
feat: train.pyに--use-feature-sqlオプションを追加（Issue #328）

### DIFF
--- a/src/models/train.py
+++ b/src/models/train.py
@@ -25,6 +25,7 @@ import yaml
 from google.cloud import bigquery, storage
 from sklearn.metrics import roc_auc_score
 
+from src.ml.features.feature_pipeline import FeaturePipeline
 from src.models.lgbm_ranker import LGBMRanker, LGBMRankerConfig
 from src.models.tuning import run_tuning, save_best_params
 
@@ -107,6 +108,50 @@ def fetch_training_data(
     df = client.query(query).to_dataframe()
     df = df.sort_values(["race_date", "race_id", "horse_number"]).reset_index(drop=True)
     logger.info(f"Fetched {len(df)} rows, {len(df.columns)} columns")
+    return df
+
+
+def fetch_training_data_from_sql(
+    project_id: str,
+    start_date: str,
+    end_date: str,
+) -> pd.DataFrame:
+    """
+    feature_query_raw.sql を直接実行して学習データを取得する（predict.py と同じ方式）
+
+    features.training_data テーブルへの依存を排除し、SQL変更を即時反映したい場合に使用する。
+    SQLと学習データの特徴量セット乖離（Issue #328）を防ぐ。
+
+    Args:
+        project_id: GCPプロジェクトID
+        start_date: 取得開始日 (YYYY-MM-DD)
+        end_date: 取得終了日 (YYYY-MM-DD)
+
+    Returns:
+        finish_position ラベル付きのDataFrame
+    """
+    pipeline = FeaturePipeline(project_id)
+    feature_sql = pipeline.generate_query(start_date, end_date)
+
+    client = bigquery.Client(project=project_id)
+    logger.info(
+        f"Fetching training data via feature_query_raw.sql ({start_date} ~ {end_date})..."
+    )
+    df = client.query(feature_sql).to_dataframe()
+    df = df.sort_values(["race_date", "race_id", "horse_number"]).reset_index(drop=True)
+    logger.info(f"Fetched {len(df)} rows, {len(df.columns)} columns from SQL")
+
+    # finish_position を raw.race_results から JOIN（features.training_data 方式と統一）
+    finish_query = f"""
+    SELECT race_id, horse_number, finish_position
+    FROM `{project_id}.raw.race_results`
+    WHERE race_date BETWEEN '{start_date}' AND '{end_date}'
+    """
+    finish_df = client.query(finish_query).to_dataframe()
+    df = df.merge(finish_df, on=["race_id", "horse_number"], how="left")
+    logger.info(
+        f"finish_position JOIN: {df['finish_position'].notna().sum()}/{len(df)} rows with label"
+    )
     return df
 
 
@@ -363,6 +408,9 @@ def train_pipeline(
     tune: bool = False,
     n_trials: int | None = None,
     tune_timeout: int | None = None,
+    use_feature_sql: bool = False,
+    start_date: str | None = None,
+    end_date: str | None = None,
 ) -> dict:
     """
     学習パイプラインを実行する
@@ -376,6 +424,10 @@ def train_pipeline(
         tune: ハイパーパラメータ調整を実行するか
         n_trials: Optuna の trial 数（Noneの場合は config から取得）
         tune_timeout: チューニングのタイムアウト秒数（Noneの場合は config から取得）
+        use_feature_sql: feature_query_raw.sql を直接実行して学習データを取得する（Issue #328対応）
+                         True にすると features.training_data テーブルへの依存を排除できる
+        start_date: use_feature_sql=True 時の取得開始日 (YYYY-MM-DD)
+        end_date: use_feature_sql=True 時の取得終了日 (YYYY-MM-DD, デフォルト: 実行日)
 
     Returns:
         学習結果の辞書
@@ -385,11 +437,20 @@ def train_pipeline(
     gcs_config = config["gcs"]
 
     # 1. データ取得
-    df = fetch_training_data(
-        project_id=project_id,
-        dataset=data_config["dataset"],
-        table=data_config["table"],
-    )
+    if use_feature_sql:
+        sql_end = end_date or execution_date.isoformat()
+        sql_start = start_date or "2019-01-01"
+        df = fetch_training_data_from_sql(
+            project_id=project_id,
+            start_date=sql_start,
+            end_date=sql_end,
+        )
+    else:
+        df = fetch_training_data(
+            project_id=project_id,
+            dataset=data_config["dataset"],
+            table=data_config["table"],
+        )
 
     # 2. データ分割
     train_df, valid_df, predict_df = split_train_valid_predict(
@@ -592,6 +653,24 @@ def main():
         help="チューニングのタイムアウト秒数（デフォルト: config から取得）",
     )
     parser.add_argument("--verbose", "-v", action="store_true", help="詳細ログ")
+    parser.add_argument(
+        "--use-feature-sql",
+        action="store_true",
+        help=(
+            "features.training_data テーブルの代わりに feature_query_raw.sql を直接実行して"
+            "学習データを取得する（Issue #328: SQLと学習データの特徴量セット乖離を防ぐ）"
+        ),
+    )
+    parser.add_argument(
+        "--start-date",
+        default=None,
+        help="--use-feature-sql 時の取得開始日 (YYYY-MM-DD, デフォルト: 2019-01-01)",
+    )
+    parser.add_argument(
+        "--end-date",
+        default=None,
+        help="--use-feature-sql 時の取得終了日 (YYYY-MM-DD, デフォルト: 実行日)",
+    )
 
     args = parser.parse_args()
 
@@ -617,6 +696,9 @@ def main():
         tune=args.tune,
         n_trials=args.n_trials,
         tune_timeout=args.tune_timeout,
+        use_feature_sql=args.use_feature_sql,
+        start_date=args.start_date,
+        end_date=args.end_date,
     )
 
     print("\n" + "=" * 60)

--- a/src/models/train.py
+++ b/src/models/train.py
@@ -439,7 +439,7 @@ def train_pipeline(
     # 1. データ取得
     if use_feature_sql:
         sql_end = end_date or execution_date.isoformat()
-        sql_start = start_date or "2019-01-01"
+        sql_start = start_date or "2016-01-01"
         df = fetch_training_data_from_sql(
             project_id=project_id,
             start_date=sql_start,
@@ -664,7 +664,7 @@ def main():
     parser.add_argument(
         "--start-date",
         default=None,
-        help="--use-feature-sql 時の取得開始日 (YYYY-MM-DD, デフォルト: 2019-01-01)",
+        help="--use-feature-sql 時の取得開始日 (YYYY-MM-DD, デフォルト: 2016-01-01)",
     )
     parser.add_argument(
         "--end-date",

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -450,7 +450,7 @@ class TestTrainPipeline:
 
         mock_fetch_sql.assert_called_once_with(
             project_id="test-project",
-            start_date="2019-01-01",
+            start_date="2016-01-01",
             end_date=execution_date.isoformat(),
         )
 

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -15,6 +15,7 @@ import yaml
 from src.models.train import (
     compute_week_boundaries,
     evaluate_predictions,
+    fetch_training_data_from_sql,
     load_config,
     prepare_features,
     split_train_valid_predict,
@@ -404,6 +405,70 @@ class TestTrainPipeline:
             assert result["predict_rows"] > 0
             assert result["num_features"] > 0
             assert Path(result["model_path"]).exists()
+
+    @patch("src.models.train.fetch_training_data_from_sql")
+    def test_train_pipeline_use_feature_sql(self, mock_fetch_sql, mock_config, mock_training_df):
+        """use_feature_sql=True の場合、fetch_training_data_from_sql が呼ばれること（Issue #328）"""
+        mock_fetch_sql.return_value = mock_training_df
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = train_pipeline(
+                project_id="test-project",
+                execution_date=datetime.date(2026, 2, 13),
+                config=mock_config,
+                output_dir=tmpdir,
+                skip_gcs_upload=True,
+                use_feature_sql=True,
+                start_date="2025-01-01",
+                end_date="2026-02-13",
+            )
+
+        mock_fetch_sql.assert_called_once_with(
+            project_id="test-project",
+            start_date="2025-01-01",
+            end_date="2026-02-13",
+        )
+        assert "metrics" in result
+
+    @patch("src.models.train.fetch_training_data_from_sql")
+    def test_train_pipeline_use_feature_sql_default_dates(
+        self, mock_fetch_sql, mock_config, mock_training_df
+    ):
+        """use_feature_sql=True かつ start_date/end_date 省略時にデフォルト日付が使われること"""
+        mock_fetch_sql.return_value = mock_training_df
+
+        execution_date = datetime.date(2026, 2, 13)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            train_pipeline(
+                project_id="test-project",
+                execution_date=execution_date,
+                config=mock_config,
+                output_dir=tmpdir,
+                skip_gcs_upload=True,
+                use_feature_sql=True,
+            )
+
+        mock_fetch_sql.assert_called_once_with(
+            project_id="test-project",
+            start_date="2019-01-01",
+            end_date=execution_date.isoformat(),
+        )
+
+    @patch("src.models.train.fetch_training_data")
+    def test_train_pipeline_default_uses_bq_table(self, mock_fetch, mock_config, mock_training_df):
+        """use_feature_sql=False（デフォルト）の場合は fetch_training_data が呼ばれること"""
+        mock_fetch.return_value = mock_training_df
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            train_pipeline(
+                project_id="test-project",
+                execution_date=datetime.date(2026, 2, 13),
+                config=mock_config,
+                output_dir=tmpdir,
+                skip_gcs_upload=True,
+            )
+
+        mock_fetch.assert_called_once()
 
     @patch("src.models.train.fetch_training_data")
     def test_train_pipeline_with_tuning(self, mock_fetch, mock_config, mock_training_df):


### PR DESCRIPTION
## Summary

- `fetch_training_data_from_sql()` を新規追加：`feature_query_raw.sql` を直接実行して学習データを取得する（`predict.py` と同じ方式）
- `train_pipeline()` に `use_feature_sql` / `start_date` / `end_date` パラメータを追加
- `main()` に `--use-feature-sql` / `--start-date` / `--end-date` CLI 引数を追加
- テスト3件追加（`test_train_pipeline_use_feature_sql`, `test_train_pipeline_use_feature_sql_default_dates`, `test_train_pipeline_default_uses_bq_table`）

## 背景（Issue #328）

PR #299（2026-05-21）で `feature_query_raw.sql` の最終 SELECT に `EXCEPT(...)` を追加し gain=0 特徴量85件を除去した。しかし本番モデル `lgbm_ranker_20260602.txt` は古い `features.training_data` テーブル（EXCEPT 前のカラムを含む）で学習されていたため、推論時に85特徴量不足 WARNING が発生していた。

今回の修正で `--use-feature-sql` を指定することで `features.training_data` テーブルへの依存を排除し、同じ SQL で学習・推論できるようになる。これにより SQL 変更後に同様の乖離が再発しない。

## 使用方法

```bash
# features.training_data の代わりに feature_query_raw.sql を使って再学習
.venv/bin/python src/models/train.py \
  --project-id keiba-prediction-1768734113 \
  --use-feature-sql \
  --start-date 2019-01-01 \
  --end-date 2026-06-06
```

## Test plan

- [x] `tests/test_train.py` 19件全パス
- [ ] 上記コマンドで推論実行後に WARNING が出ないことを確認（本番 BQ 接続が必要）

## 関連

- Issue #328
- PR #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)