### PR TITLE
fix: TE集計ベースCTE（temp_te_history_raw）から障害レースを除外する（Issue #331）

### DIFF
--- a/src/ml/features/feature_query_raw.sql
+++ b/src/ml/features/feature_query_raw.sql
@@ -1080,7 +1080,9 @@ with temp_race_horse_count as (
     left join `{project_id}`.raw.race_results as r_r
       on h_r.race_id = r_r.race_id
       and h_r.horse_number = r_r.horse_number
-  where r_r.finish_position > 0 or r_r.race_id is null
+  where
+    (r_r.finish_position > 0 or r_r.race_id is null)
+    and coalesce(r_i.course_type, '') != 'obstacle'
 )
 ,temp_te_history_base as (
   select

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -208,6 +208,20 @@ class TestSQLTemplate:
             "temp_te_history_base で finish_position > 0 フィルタが見つかりません"
         )
 
+    def test_sql_te_history_raw_excludes_obstacle_races(self):
+        """temp_te_history_raw が障害レースを除外していること（Issue #331）"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        # コメント行をスキップして実際のCTE定義を検索
+        raw_start = content.find(",temp_te_history_raw as (")
+        raw_end = content.find(",temp_te_history_base as (", raw_start + 1)
+        te_raw_section = content[raw_start:raw_end]
+        assert "!= 'obstacle'" in te_raw_section, (
+            "temp_te_history_raw に障害レース除外条件 (!= 'obstacle') がありません"
+        )
+        assert "course_type" in te_raw_section, (
+            "temp_te_history_raw に course_type フィルタが見つかりません"
+        )
+
     def test_sql_te_history_base_joins_required_tables(self):
         """TE履歴ベースが必要なテーブルをJOINしていること（Issue #270）"""
         content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
@@ -1053,7 +1067,7 @@ class TestRaceExclusionFilter:
         """temp_base_race_entries / temp_horse_master_feature / temp_mare_race_base に除外フィルタが含まれること"""
         content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
         assert content.count("race_class != 'A1'") == 2, "新馬戦除外が2箇所にあるべき"
-        assert content.count("!= 'obstacle'") == 3, "障害戦除外が3箇所にあるべき（base/horse_master/mare_race_base）"
+        assert content.count("!= 'obstacle'") == 4, "障害戦除外が4箇所にあるべき（base/horse_master/mare_race_base/te_history_raw）"
         assert content.count("num_horses) > 7") == 2, "少頭数除外が2箇所にあるべき"
         assert content.count("venue_code = '04' and r_i.distance = 1000 and r_i.direction = 'straight'") == 2, "新潟直線除外が2箇所にあるべき"
 


### PR DESCRIPTION
## 概要

TE（Target Encoding）の全カテゴリ集計ベースとなる `temp_te_history_raw` CTE のWHERE句に障害レース除外条件を追加しました。

## 変更内容

`src/ml/features/feature_query_raw.sql` のL.1083付近を修正:

```sql
-- 変更前
where r_r.finish_position > 0 or r_r.race_id is null

-- 変更後
where
  (r_r.finish_position > 0 or r_r.race_id is null)
  and coalesce(r_i.course_type, '') != 'obstacle'
```

この1行の追加により、以下の全TEカテゴリに自動的に適用されます:
- `temp_jockey_te_pre` / `temp_jockey_te`（騎手TE）
- `temp_trainer_te_pre` / `temp_trainer_te`（調教師TE）
- `temp_sire_te_pre` / `temp_sire_te`（種牡馬TE）
- `temp_mare_te_pre` / `temp_mare_te`（母馬TE）
- `temp_horse_te_pre` / `temp_horse_te`（馬自身TE）

## モデル別 学習・検証期間

| | 既存モデル | 新モデル |
|---|---|---|
| **学習期間** | 2016-01-05 〜 2025-11-30（474,770行 / 29,396レース） | 2016-01-05 〜 2025-11-30（474,770行 / 29,396レース） |
| **検証期間** | 2025-12-06 〜 2026-05-31（22,291行 / 1,549レース） | 2025-12-06 〜 2026-05-31（22,291行 / 1,549レース） |

## 精度比較

| 指標 | 既存モデル | 新モデル | 差分 | 判定（±0.005） |
|---|---|---|---|---|
| **NDCG@3** | 0.5679 | 0.5677 | -0.0001 | ✅ 同等 |
| **AUC** | 0.8136 | 0.8134 | -0.0002 | ✅ 同等 |
| **Recall@3** | 0.5048 | 0.5025 | -0.0023 | ✅ 同等 |

## 総合判定

**✅ マージ可（全指標が合格基準 ±0.005 以内）**

## テスト計画

- [x] `/check-leak` 実施済み（リーク検出なし）
- [x] `pytest tests/test_features.py` 通過（176件）
  - `test_sql_te_history_raw_excludes_obstacle_races` を新規追加
  - `test_sql_exclusion_filters_applied_to_both_ctes` の期待件数を 3 → 4 に更新
- [x] `scripts/compare_features.py` によるモデル精度比較実施済み

## 参考

BQで確認した障害レースの混入件数（修正前）:
| course_type | 件数 | 割合 |
|---|---|---|
| turf | 234,932件 | 47.1% |
| dirt | 248,645件 | 49.9% |
| obstacle | 14,884件 | **3.0%（混入中 → 修正で除外）** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)