### PR TITLE
feat: 種牡馬・母馬TE集計に条件別出走比率特徴量を追加（Issue #332）

### DIFF
--- a/src/ml/features/feature_query_raw.sql
+++ b/src/ml/features/feature_query_raw.sql
@@ -1526,6 +1526,55 @@ with temp_race_horse_count as (
         range between unbounded preceding and 1 preceding
       ), 0) + 10
     ) as sire_course_type_distance_venue_te
+    -- 出走比率（条件別出走数 / 全出走数、Issue #332）
+    ,safe_divide(
+      count(*) over (
+        partition by sire_name, course_type
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ),
+      count(*) over (
+        partition by sire_name
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      )
+    ) as sire_course_type_run_ratio
+    ,safe_divide(
+      count(*) over (
+        partition by sire_name, venue_code
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ),
+      count(*) over (
+        partition by sire_name
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      )
+    ) as sire_venue_run_ratio
+    ,safe_divide(
+      count(*) over (
+        partition by sire_name, distance_band
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ),
+      count(*) over (
+        partition by sire_name
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      )
+    ) as sire_distance_band_run_ratio
+    ,safe_divide(
+      count(*) over (
+        partition by sire_name, distance
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ),
+      count(*) over (
+        partition by sire_name
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      )
+    ) as sire_distance_run_ratio
     -- 年齢帯別出走数カウント（低頻度マスク用）
     ,coalesce(count(case when age_band = '2yo' then 1 end) over (
       partition by sire_name
@@ -1618,6 +1667,11 @@ with temp_race_horse_count as (
     ,IF(sire_age3_count >= 5, sire_age3_te, NULL) as sire_age3_te
     ,IF(sire_age4_count >= 5, sire_age4_te, NULL) as sire_age4_te
     ,IF(sire_age5plus_count >= 5, sire_age5plus_te, NULL) as sire_age5plus_te
+    -- 出走比率（低頻度マスク適用: sire_count >= 20 と同一条件）
+    ,IF(sire_count >= 20, sire_course_type_run_ratio, NULL) as sire_course_type_run_ratio
+    ,IF(sire_count >= 20, sire_venue_run_ratio, NULL) as sire_venue_run_ratio
+    ,IF(sire_count >= 20, sire_distance_band_run_ratio, NULL) as sire_distance_band_run_ratio
+    ,IF(sire_count >= 20, sire_distance_run_ratio, NULL) as sire_distance_run_ratio
   from temp_sire_te_pre
 )
 
@@ -1856,6 +1910,55 @@ with temp_race_horse_count as (
         range between unbounded preceding and 1 preceding
       ), 0) + 10
     ) as mare_course_type_distance_venue_te
+    -- 出走比率（条件別出走数 / 全出走数、Issue #332）
+    ,safe_divide(
+      count(*) over (
+        partition by dam_name, course_type
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ),
+      count(*) over (
+        partition by dam_name
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      )
+    ) as mare_course_type_run_ratio
+    ,safe_divide(
+      count(*) over (
+        partition by dam_name, venue_code
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ),
+      count(*) over (
+        partition by dam_name
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      )
+    ) as mare_venue_run_ratio
+    ,safe_divide(
+      count(*) over (
+        partition by dam_name, distance_band
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ),
+      count(*) over (
+        partition by dam_name
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      )
+    ) as mare_distance_band_run_ratio
+    ,safe_divide(
+      count(*) over (
+        partition by dam_name, distance
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      ),
+      count(*) over (
+        partition by dam_name
+        order by unix_date(race_date)
+        range between unbounded preceding and 1 preceding
+      )
+    ) as mare_distance_run_ratio
     -- 年齢帯別出走数カウント（低頻度マスク用）
     ,coalesce(count(case when age_band = '2yo' then 1 end) over (
       partition by dam_name
@@ -1948,6 +2051,11 @@ with temp_race_horse_count as (
     ,IF(mare_age3_count >= 5, mare_age3_te, NULL) as mare_age3_te
     ,IF(mare_age4_count >= 5, mare_age4_te, NULL) as mare_age4_te
     ,IF(mare_age5plus_count >= 5, mare_age5plus_te, NULL) as mare_age5plus_te
+    -- 出走比率（低頻度マスク適用: mare_count >= 3 と同一条件）
+    ,IF(mare_count >= 3, mare_course_type_run_ratio, NULL) as mare_course_type_run_ratio
+    ,IF(mare_count >= 3, mare_venue_run_ratio, NULL) as mare_venue_run_ratio
+    ,IF(mare_count >= 3, mare_distance_band_run_ratio, NULL) as mare_distance_band_run_ratio
+    ,IF(mare_count >= 3, mare_distance_run_ratio, NULL) as mare_distance_run_ratio
   from temp_mare_te_pre
 )
 
@@ -2584,6 +2692,11 @@ select
     when t_p_r_f.horse_age = 4 then t_s_te.sire_age4_te - t_s_te.sire_te
     else t_s_te.sire_age5plus_te - t_s_te.sire_te
   end as sire_age_vs_career_diff
+  -- 種牡馬産駒出走比率（Issue #332）
+  ,t_s_te.sire_course_type_run_ratio
+  ,t_s_te.sire_venue_run_ratio
+  ,t_s_te.sire_distance_band_run_ratio
+  ,t_s_te.sire_distance_run_ratio
   -- 馬自身TE
   ,t_h_te.horse_te
   ,t_h_te.horse_course_type_te
@@ -2716,6 +2829,11 @@ select
     when t_p_r_f.horse_age = 4 then t_m_te.mare_age4_te - t_m_te.mare_te
     else t_m_te.mare_age5plus_te - t_m_te.mare_te
   end as mare_age_vs_career_diff
+  -- 母馬産駒出走比率（Issue #332）
+  ,t_m_te.mare_course_type_run_ratio
+  ,t_m_te.mare_venue_run_ratio
+  ,t_m_te.mare_distance_band_run_ratio
+  ,t_m_te.mare_distance_run_ratio
   -- 母馬自身の早熟・晩成性（カテゴリC）
   ,t_m_s.mare_early_career_place_rate
   ,t_m_s.mare_late_career_place_rate
@@ -3574,6 +3692,10 @@ select * replace (
   coalesce(sire_current_age_te, percentile_cont(sire_current_age_te, 0.5) over (partition by race_id), 0.22) as sire_current_age_te,
   coalesce(sire_precocity_diff, percentile_cont(sire_precocity_diff, 0.5) over (partition by race_id), 0.0) as sire_precocity_diff,
   coalesce(sire_age_vs_career_diff, percentile_cont(sire_age_vs_career_diff, 0.5) over (partition by race_id), 0.0) as sire_age_vs_career_diff,
+  coalesce(sire_course_type_run_ratio, percentile_cont(sire_course_type_run_ratio, 0.5) over (partition by race_id), 0.5) as sire_course_type_run_ratio,
+  coalesce(sire_venue_run_ratio, percentile_cont(sire_venue_run_ratio, 0.5) over (partition by race_id), 0.0) as sire_venue_run_ratio,
+  coalesce(sire_distance_band_run_ratio, percentile_cont(sire_distance_band_run_ratio, 0.5) over (partition by race_id), 0.25) as sire_distance_band_run_ratio,
+  coalesce(sire_distance_run_ratio, percentile_cont(sire_distance_run_ratio, 0.5) over (partition by race_id), 0.0) as sire_distance_run_ratio,
   coalesce(horse_te, percentile_cont(horse_te, 0.5) over (partition by race_id), 0.22) as horse_te,
   coalesce(horse_course_type_te, percentile_cont(horse_course_type_te, 0.5) over (partition by race_id), 0.22) as horse_course_type_te,
   coalesce(horse_venue_te, percentile_cont(horse_venue_te, 0.5) over (partition by race_id), 0.22) as horse_venue_te,
@@ -3623,6 +3745,10 @@ select * replace (
   coalesce(mare_current_age_te, percentile_cont(mare_current_age_te, 0.5) over (partition by race_id), 0.22) as mare_current_age_te,
   coalesce(mare_precocity_diff, percentile_cont(mare_precocity_diff, 0.5) over (partition by race_id), 0.0) as mare_precocity_diff,
   coalesce(mare_age_vs_career_diff, percentile_cont(mare_age_vs_career_diff, 0.5) over (partition by race_id), 0.0) as mare_age_vs_career_diff,
+  coalesce(mare_course_type_run_ratio, percentile_cont(mare_course_type_run_ratio, 0.5) over (partition by race_id), 0.5) as mare_course_type_run_ratio,
+  coalesce(mare_venue_run_ratio, percentile_cont(mare_venue_run_ratio, 0.5) over (partition by race_id), 0.0) as mare_venue_run_ratio,
+  coalesce(mare_distance_band_run_ratio, percentile_cont(mare_distance_band_run_ratio, 0.5) over (partition by race_id), 0.25) as mare_distance_band_run_ratio,
+  coalesce(mare_distance_run_ratio, percentile_cont(mare_distance_run_ratio, 0.5) over (partition by race_id), 0.0) as mare_distance_run_ratio,
   -- 過去走特徴量（デビュー馬・初出走条件の馬でNULLになる列）: 同一レース内中央値 → フォールバック0
   coalesce(idm_1, percentile_cont(idm_1, 0.5) over (partition by race_id), 0) as idm_1,
   coalesce(finish_position_1, percentile_cont(finish_position_1, 0.5) over (partition by race_id), 0) as finish_position_1,

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -2070,3 +2070,126 @@ class TestNullImputation:
         content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
         assert "from temp_final_raw" in content, \
             "最終SELECT の FROM が temp_final_raw を参照していません"
+
+
+class TestRunRatioFeature:
+    """条件別出走比率特徴量（Issue #332）のテスト
+
+    種牡馬・母馬TE集計に、条件別出走数 / 全出走数 の比率特徴量を追加する。
+    """
+
+    def test_sql_sire_run_ratio_in_te_pre(self):
+        """temp_sire_te_pre に sire_*_run_ratio 列が存在すること"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        sire_pre_start = content.find("temp_sire_te_pre as (")
+        sire_pre_end = content.find("temp_sire_te as (")
+        section = content[sire_pre_start:sire_pre_end]
+        for col in [
+            "sire_course_type_run_ratio",
+            "sire_venue_run_ratio",
+            "sire_distance_band_run_ratio",
+            "sire_distance_run_ratio",
+        ]:
+            assert col in section, f"temp_sire_te_pre に '{col}' が見つかりません"
+
+    def test_sql_mare_run_ratio_in_te_pre(self):
+        """temp_mare_te_pre に mare_*_run_ratio 列が存在すること"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        mare_pre_start = content.find("temp_mare_te_pre as (")
+        mare_pre_end = content.find("temp_mare_te as (")
+        section = content[mare_pre_start:mare_pre_end]
+        for col in [
+            "mare_course_type_run_ratio",
+            "mare_venue_run_ratio",
+            "mare_distance_band_run_ratio",
+            "mare_distance_run_ratio",
+        ]:
+            assert col in section, f"temp_mare_te_pre に '{col}' が見つかりません"
+
+    def test_sql_sire_run_ratio_uses_safe_divide(self):
+        """sire_course_type_run_ratio が safe_divide を使用していること"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        sire_pre_start = content.find("temp_sire_te_pre as (")
+        sire_pre_end = content.find("temp_sire_te as (")
+        section = content[sire_pre_start:sire_pre_end]
+        assert "sire_course_type_run_ratio" in section
+        # safe_divide と run_ratio が同じ CTE に存在すること
+        assert "safe_divide(" in section
+        assert "partition by sire_name, course_type" in section
+
+    def test_sql_sire_run_ratio_masked_in_te(self):
+        """temp_sire_te が sire_count >= 20 でマスクを適用していること"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        sire_te_start = content.find("temp_sire_te as (")
+        sire_te_end = content.find("temp_horse_distance_base")
+        section = content[sire_te_start:sire_te_end]
+        for col in [
+            "sire_course_type_run_ratio",
+            "sire_venue_run_ratio",
+            "sire_distance_band_run_ratio",
+            "sire_distance_run_ratio",
+        ]:
+            assert f"IF(sire_count >= 20, {col}, NULL)" in section, (
+                f"temp_sire_te に '{col}' の低頻度マスク（>= 20）が見つかりません"
+            )
+
+    def test_sql_mare_run_ratio_masked_in_te(self):
+        """temp_mare_te が mare_count >= 3 でマスクを適用していること"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        mare_te_start = content.find("temp_mare_te as (")
+        mare_te_end = content.find("temp_horse_te_pre as (")
+        section = content[mare_te_start:mare_te_end]
+        for col in [
+            "mare_course_type_run_ratio",
+            "mare_venue_run_ratio",
+            "mare_distance_band_run_ratio",
+            "mare_distance_run_ratio",
+        ]:
+            assert f"IF(mare_count >= 3, {col}, NULL)" in section, (
+                f"temp_mare_te に '{col}' の低頻度マスク（>= 3）が見つかりません"
+            )
+
+    def test_sql_run_ratio_in_final_select(self):
+        """最終SELECTに sire_*_run_ratio / mare_*_run_ratio が含まれていること"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        for col in [
+            "sire_course_type_run_ratio",
+            "sire_venue_run_ratio",
+            "sire_distance_band_run_ratio",
+            "sire_distance_run_ratio",
+            "mare_course_type_run_ratio",
+            "mare_venue_run_ratio",
+            "mare_distance_band_run_ratio",
+            "mare_distance_run_ratio",
+        ]:
+            assert f"t_s_te.{col}" in content or f"t_m_te.{col}" in content, (
+                f"最終SELECT に '{col}' の参照が見つかりません"
+            )
+
+    def test_sql_run_ratio_null_imputation(self):
+        """run_ratio 列が NULL補完ブロックに含まれていること"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        for col in [
+            "sire_course_type_run_ratio",
+            "sire_venue_run_ratio",
+            "sire_distance_band_run_ratio",
+            "sire_distance_run_ratio",
+            "mare_course_type_run_ratio",
+            "mare_venue_run_ratio",
+            "mare_distance_band_run_ratio",
+            "mare_distance_run_ratio",
+        ]:
+            pattern = f"percentile_cont({col}, 0.5) over (partition by race_id)"
+            assert pattern in content, (
+                f"'{col}' の PERCENTILE_CONT NULL補完が見つかりません"
+            )
+
+    def test_sql_sire_run_ratio_uses_preceding_window(self):
+        """sire run_ratio が 1 preceding ウィンドウを使用していること（データリーク防止）"""
+        content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
+        sire_pre_start = content.find("temp_sire_te_pre as (")
+        sire_pre_end = content.find("temp_sire_te as (")
+        section = content[sire_pre_start:sire_pre_end]
+        # run_ratio セクションに 1 preceding が含まれること
+        assert "sire_course_type_run_ratio" in section
+        assert "range between unbounded preceding and 1 preceding" in section


### PR DESCRIPTION
## 概要

Issue #332 の実装。種牡馬・母馬 Target Encoding に「条件別出走比率」8特徴量を追加する。

### 追加特徴量（計8列）

| カラム名 | 意味 |
|---------|------|
| `sire_course_type_run_ratio` | 父馬産駒の芝・ダートへの出走傾向 |
| `sire_venue_run_ratio` | 父馬産駒の当該競馬場への出走傾向 |
| `sire_distance_band_run_ratio` | 父馬産駒の当該距離帯への出走傾向 |
| `sire_distance_run_ratio` | 父馬産駒の当該距離への出走傾向 |
| `mare_course_type_run_ratio` | 母馬産駒の芝・ダートへの出走傾向 |
| `mare_venue_run_ratio` | 母馬産駒の当該競馬場への出走傾向 |
| `mare_distance_band_run_ratio` | 母馬産駒の当該距離帯への出走傾向 |
| `mare_distance_run_ratio` | 母馬産駒の当該距離への出走傾向 |

### 実装

- `temp_sire_te_pre` / `temp_mare_te_pre`: `safe_divide(条件別count, 全体count)` で計算
- `temp_sire_te` / `temp_mare_te`: 既存低頻度マスク適用（sire >= 20 / mare >= 3）
- 最終 SELECT: `t_s_te.*_run_ratio` / `t_m_te.*_run_ratio` として参照
- NULL補完: `coalesce(値, race_id中央値, フォールバック)` の3段階補完

---

## モデル別 学習・検証期間

| | 既存モデル | 新モデル |
|---|---|---|
| **学習期間** | 2016-01-05 〜 2025-11-30 (474,770行 / 29,396レース) | 2016-01-05 〜 2025-11-30 (474,770行 / 29,396レース) |
| **検証期間** | 2025-12-06 〜 2026-05-31 (22,291行 / 1,549レース) | 2025-12-06 〜 2026-05-31 (22,291行 / 1,549レース) |

## 精度比較

| 指標 | 既存モデル | 新モデル | 差分 | 判定（±0.005） |
|---|---|---|---|---|
| **NDCG@3** | 0.5679 | 0.5714 | +0.0035 | ✅ 改善 |
| **AUC** | 0.8136 | 0.8141 | +0.0005 | ✅ 改善 |
| **Recall@3** | 0.5048 | 0.5065 | +0.0017 | ✅ 改善 |

**総合判定: ✅ マージ可（全指標が合格基準を満たす）**

---

## テスト計画

- [x] `/check-leak` 実施済み — リーク検出なし（全 window 関数に `1 preceding` 境界）
- [x] `pytest tests/test_features.py` 通過（184件）
- [x] `TestRunRatioFeature` クラス（8件）を新規追加
  - CTE への追加確認
  - `safe_divide` + `1 preceding` ウィンドウ使用確認
  - 低頻度マスク（sire >= 20 / mare >= 3）確認
  - 最終 SELECT への参照確認
  - NULL補完ブロックへの追加確認

Closes #332