### PR TITLE
fix: SHAPダッシュボードの複勝率・予測順位を最新GCSモデルでリアルタイム計算に統一 (#334)

### DIFF
--- a/src/dashboard/components/shap_explain.py
+++ b/src/dashboard/components/shap_explain.py
@@ -20,9 +20,9 @@ import streamlit as st
 from src.dashboard.feature_labels import to_label
 from src.dashboard.data import (
     VENUE_CODE_TO_NAME,
-    fetch_horse_features,
-    fetch_race_detail,
+    fetch_race_features,
     fetch_race_list,
+    fetch_race_place_odds,
     load_lgbm_ranker_for_shap,
 )
 
@@ -64,23 +64,9 @@ def render(race_date: str) -> None:
         "レース番号", race_numbers, format_func=lambda r: f"{r}R", key="shap_race"
     )
 
-    detail_df = fetch_race_detail(race_date, selected_venue_code, int(selected_race))
-    if detail_df.empty:
-        st.warning("詳細データを取得できませんでした。")
-        return
-
-    horse_options = {
-        f"{int(row['horse_number'])}番 {row['horse_name']} (複勝率 {row['win_place_prob']*100:.1f}%)": int(row["horse_number"])
-        for _, row in detail_df.sort_values("rank_in_race").iterrows()
-    }
-    selected_horse_label = col3.selectbox("馬", list(horse_options.keys()), key="shap_horse")
-    selected_horse_number = horse_options[selected_horse_label]
-
-    selected_horse_row = detail_df[detail_df["horse_number"] == selected_horse_number].iloc[0]
-
     st.divider()
 
-    # ── 2. SHAP計算 ──────────────────────────────────────────────────────
+    # ── 2. モデル読み込み & 全馬リアルタイム計算 ─────────────────────────
     with st.spinner("モデルを読み込み中...（初回のみ時間がかかります）"):
         ranker, feature_names = load_lgbm_ranker_for_shap()
 
@@ -88,24 +74,53 @@ def render(race_date: str) -> None:
         st.error("モデルの読み込みに失敗しました。GCS 上のモデルファイルを確認してください。")
         return
 
-    with st.spinner("特徴量を取得し SHAP 値を計算中..."):
-        horse_df = fetch_horse_features(
-            race_date, selected_venue_code, int(selected_race), selected_horse_number
-        )
+    with st.spinner("全馬の特徴量を取得中..."):
+        race_df = fetch_race_features(race_date, selected_venue_code, int(selected_race))
 
-    if horse_df.empty:
+    if race_df.empty:
         st.warning(
-            "features.training_data に該当馬のデータが見つかりませんでした。"
+            "features.training_data に該当レースのデータが見つかりませんでした。"
             " 特徴量生成バッチが完了しているか確認してください。"
         )
         return
+
+    # 全馬のスコアをリアルタイム計算
+    realtime_df = _compute_realtime_predictions(ranker, feature_names, race_df)
+
+    # 複勝オッズをdaily_oddsから取得してJOIN
+    place_odds_df = fetch_race_place_odds(race_date, selected_venue_code, int(selected_race))
+    if not place_odds_df.empty:
+        realtime_df = realtime_df.merge(
+            place_odds_df[["horse_number", "place_odds_min"]],
+            on="horse_number", how="left",
+        )
+        realtime_df["place_odds"] = realtime_df["place_odds_min"]
+        realtime_df["expected_return"] = (
+            realtime_df["win_place_prob"] * realtime_df["place_odds_min"]
+        ).round(3)
+    else:
+        realtime_df["place_odds"] = float("nan")
+        realtime_df["expected_return"] = float("nan")
+
+    # 馬選択プルダウン（リアルタイム計算値で表示）
+    horse_options = {
+        f"{int(row['horse_number'])}番 {row['horse_name']} (複勝率 {row['win_place_prob']*100:.1f}%)": int(row["horse_number"])
+        for _, row in realtime_df.sort_values("rank_in_race").iterrows()
+    }
+    selected_horse_label = col3.selectbox("馬", list(horse_options.keys()), key="shap_horse")
+    selected_horse_number = horse_options[selected_horse_label]
+
+    selected_horse_row = realtime_df[realtime_df["horse_number"] == selected_horse_number].iloc[0]
+
+    # ── 3. 選択馬のSHAP計算 ──────────────────────────────────────────────
+    horse_df = race_df[race_df["horse_number"] == selected_horse_number]
 
     shap_df, error_msg = _compute_shap(ranker, horse_df, feature_names)
     if shap_df is None:
         st.error(f"SHAP 値の計算に失敗しました。\n\n```\n{error_msg}\n```")
         return
 
-    # ── 3. 結果表示 ─────────────────────────────────────────────────────
+    # ── 4. 結果表示 ─────────────────────────────────────────────────────
     _render_horse_header(selected_horse_row, selected_venue_name, int(selected_race))
     _render_waterfall(shap_df, top_n=20)
     _render_shap_table(shap_df)
@@ -114,6 +129,39 @@ def render(race_date: str) -> None:
 # ---------------------------------------------------------------------------
 # 内部関数
 # ---------------------------------------------------------------------------
+
+def _compute_realtime_predictions(ranker, feature_names: list[str], race_df: pd.DataFrame) -> pd.DataFrame:
+    """
+    レース全馬の pred_score・win_place_prob・rank_in_race をリアルタイム計算する。
+
+    Returns:
+        horse_number / horse_name / pred_score / win_place_prob / rank_in_race を持つ DataFrame
+    """
+    from src.models.predict import _scores_to_place_prob
+
+    available = [f for f in feature_names if f in race_df.columns]
+    if not available:
+        result = race_df[["horse_number", "horse_name"]].copy()
+        result["pred_score"] = float("nan")
+        result["win_place_prob"] = float("nan")
+        result["rank_in_race"] = range(1, len(result) + 1)
+        return result
+
+    X = race_df[available].copy()
+    for col in X.select_dtypes(include=["object", "category"]).columns:
+        X[col] = pd.factorize(X[col])[0].astype(float)
+    X_np = X.to_numpy(dtype=float, na_value=0.0)
+
+    scores = ranker.model.predict(X_np)
+
+    probs = _scores_to_place_prob(scores, n_places=3)
+
+    result = race_df[["horse_number", "horse_name"]].copy()
+    result["pred_score"] = scores
+    result["win_place_prob"] = probs
+    result["rank_in_race"] = pd.Series(scores).rank(ascending=False, method="min").astype(int).values
+    return result.reset_index(drop=True)
+
 
 def _compute_shap(ranker, horse_df: pd.DataFrame, feature_names: list[str]):
     """

--- a/src/dashboard/data.py
+++ b/src/dashboard/data.py
@@ -406,6 +406,67 @@ def fetch_horse_features(
         return pd.DataFrame()
 
 
+@st.cache_data(ttl=3600)
+def fetch_race_features(
+    race_date: str,
+    venue_code: str,
+    race_number: int,
+) -> pd.DataFrame:
+    """
+    features.training_data から指定レースの全馬特徴量を取得する。
+    """
+    project_id = get_project_id()
+    if not project_id:
+        return pd.DataFrame()
+    try:
+        client = _get_bq_client()
+        query = f"""
+        SELECT *
+        FROM `{project_id}.features.training_data`
+        WHERE race_date = '{race_date}'
+          AND venue_code = '{venue_code}'
+          AND race_number = {race_number}
+        ORDER BY horse_number
+        """
+        return client.query(query).to_dataframe()
+    except Exception as e:
+        logger.warning(f"race_features 取得失敗: {e}")
+        return pd.DataFrame()
+
+
+@st.cache_data(ttl=300)
+def fetch_race_place_odds(
+    race_date: str,
+    venue_code: str,
+    race_number: int,
+) -> pd.DataFrame:
+    """
+    predictions.daily_odds から指定レースの複勝オッズを取得する。
+    horse_number をキーとして place_odds_min を返す。
+    """
+    project_id = get_project_id()
+    if not project_id:
+        return pd.DataFrame()
+    try:
+        client = _get_bq_client()
+        query = f"""
+        SELECT
+            o.horse_number,
+            o.place_odds_min
+        FROM `{project_id}.predictions.daily_odds` o
+        JOIN `{project_id}.raw.race_info` r
+            ON o.race_id = r.race_id
+        WHERE o.race_date = '{race_date}'
+          AND r.venue_code = '{venue_code}'
+          AND r.race_number = {race_number}
+        ORDER BY o.horse_number
+        """
+        return client.query(query).to_dataframe()
+    except Exception as e:
+        logger.warning(f"race_place_odds 取得失敗: {e}")
+        return pd.DataFrame()
+
+
 def get_available_dates(days_back: int = 30) -> list[str]:
     """
     過去 N 日間で予測データが存在する日付リストを返す

--- a/tests/test_dashboard_data.py
+++ b/tests/test_dashboard_data.py
@@ -235,3 +235,79 @@ class TestVenueMapping:
         assert BET_TYPE_LABELS["wide"] == "ワイド"
         assert BET_TYPE_LABELS["umaren"] == "馬連"
         assert BET_TYPE_LABELS["sanrenpuku"] == "三連複"
+
+
+class TestFetchRaceFeatures:
+    """fetch_race_features のテスト"""
+
+    def test_returns_all_horses_in_race(self):
+        mock_df = pd.DataFrame({
+            "race_date": ["2026-03-15"] * 3,
+            "venue_code": ["09"] * 3,
+            "race_number": [5] * 3,
+            "horse_number": [1, 2, 3],
+            "horse_name": ["馬A", "馬B", "馬C"],
+            "feat_0": [1.0, 2.0, 3.0],
+        })
+
+        with patch("src.dashboard.data._get_bq_client") as mock_client_fn:
+            mock_client = MagicMock()
+            mock_client.query.return_value.to_dataframe.return_value = mock_df
+            mock_client_fn.return_value = mock_client
+
+            from src.dashboard import data as dash_data
+            dash_data.fetch_race_features.clear()
+            result = dash_data.fetch_race_features("2026-03-15", "09", 5)
+
+        assert len(result) == 3
+        assert list(result["horse_number"]) == [1, 2, 3]
+
+    def test_returns_empty_on_error(self):
+        with patch("src.dashboard.data._get_bq_client") as mock_client_fn:
+            mock_client_fn.side_effect = Exception("BQ error")
+
+            from src.dashboard import data as dash_data
+            dash_data.fetch_race_features.clear()
+            result = dash_data.fetch_race_features("2026-03-15", "09", 5)
+
+        assert result.empty
+
+    def test_returns_empty_when_no_project_id(self):
+        with patch("src.dashboard.data.get_project_id", return_value=""):
+            from src.dashboard import data as dash_data
+            dash_data.fetch_race_features.clear()
+            result = dash_data.fetch_race_features("2026-03-15", "09", 5)
+
+        assert result.empty
+
+
+class TestFetchRacePlaceOdds:
+    """fetch_race_place_odds のテスト"""
+
+    def test_returns_place_odds_per_horse(self):
+        mock_df = pd.DataFrame({
+            "horse_number": [1, 2, 3],
+            "place_odds_min": [2.5, 4.0, 6.0],
+        })
+
+        with patch("src.dashboard.data._get_bq_client") as mock_client_fn:
+            mock_client = MagicMock()
+            mock_client.query.return_value.to_dataframe.return_value = mock_df
+            mock_client_fn.return_value = mock_client
+
+            from src.dashboard import data as dash_data
+            dash_data.fetch_race_place_odds.clear()
+            result = dash_data.fetch_race_place_odds("2026-03-15", "09", 5)
+
+        assert len(result) == 3
+        assert result.iloc[0]["place_odds_min"] == pytest.approx(2.5)
+
+    def test_returns_empty_on_error(self):
+        with patch("src.dashboard.data._get_bq_client") as mock_client_fn:
+            mock_client_fn.side_effect = Exception("BQ error")
+
+            from src.dashboard import data as dash_data
+            dash_data.fetch_race_place_odds.clear()
+            result = dash_data.fetch_race_place_odds("2026-03-15", "09", 5)
+
+        assert result.empty

--- a/tests/test_shap_explain.py
+++ b/tests/test_shap_explain.py
@@ -188,3 +188,81 @@ class TestFetchHorseFeatures:
             result = dash_data.fetch_horse_features("2026-03-15", "09", 5, 3)
 
         assert result.empty
+
+
+class TestComputeRealtimePredictions:
+    """_compute_realtime_predictions のテスト"""
+
+    def _make_race_df(self, n: int = 5):
+        return pd.DataFrame({
+            "horse_number": list(range(1, n + 1)),
+            "horse_name": [f"馬{i}" for i in range(1, n + 1)],
+            **{f"feat_{i}": [float(j) for j in range(n)] for i in range(3)},
+        })
+
+    def test_returns_required_columns(self):
+        from src.dashboard.components.shap_explain import _compute_realtime_predictions
+
+        feature_names = ["feat_0", "feat_1", "feat_2"]
+        race_df = self._make_race_df(5)
+        ranker = MagicMock()
+        ranker.model.predict.return_value = np.array([0.9, 0.7, 0.5, 0.3, 0.1])
+
+        result = _compute_realtime_predictions(ranker, feature_names, race_df)
+
+        assert {"horse_number", "horse_name", "pred_score", "win_place_prob", "rank_in_race"}.issubset(result.columns)
+        assert len(result) == 5
+
+    def test_rank_is_assigned_by_descending_score(self):
+        from src.dashboard.components.shap_explain import _compute_realtime_predictions
+
+        feature_names = ["feat_0"]
+        race_df = pd.DataFrame({
+            "horse_number": [1, 2, 3],
+            "horse_name": ["馬A", "馬B", "馬C"],
+            "feat_0": [1.0, 2.0, 3.0],
+        })
+        ranker = MagicMock()
+        ranker.model.predict.return_value = np.array([0.3, 0.8, 0.5])
+
+        result = _compute_realtime_predictions(ranker, feature_names, race_df)
+
+        horse2 = result[result["horse_number"] == 2].iloc[0]
+        horse1 = result[result["horse_number"] == 1].iloc[0]
+        assert horse2["rank_in_race"] == 1  # スコア最大
+        assert horse1["rank_in_race"] == 3  # スコア最小
+
+    def test_win_place_prob_sums_to_n_places(self):
+        """win_place_prob の合計が min(3, 出走頭数) になる"""
+        from src.dashboard.components.shap_explain import _compute_realtime_predictions
+
+        feature_names = ["feat_0"]
+        race_df = pd.DataFrame({
+            "horse_number": list(range(1, 9)),
+            "horse_name": [f"馬{i}" for i in range(1, 9)],
+            "feat_0": [float(i) for i in range(8)],
+        })
+        ranker = MagicMock()
+        ranker.model.predict.return_value = np.array([0.9, 0.8, 0.7, 0.4, 0.3, 0.2, 0.1, 0.05])
+
+        result = _compute_realtime_predictions(ranker, feature_names, race_df)
+
+        assert result["win_place_prob"].sum() == pytest.approx(3.0, abs=1e-6)
+
+    def test_returns_nan_scores_when_no_features_available(self):
+        """モデル特徴量が race_df に存在しない場合は NaN を返す"""
+        from src.dashboard.components.shap_explain import _compute_realtime_predictions
+
+        feature_names = ["model_feat_A", "model_feat_B"]
+        race_df = pd.DataFrame({
+            "horse_number": [1, 2],
+            "horse_name": ["馬A", "馬B"],
+            "unrelated_col": [1.0, 2.0],
+        })
+        ranker = MagicMock()
+
+        result = _compute_realtime_predictions(ranker, feature_names, race_df)
+
+        assert len(result) == 2
+        assert result["pred_score"].isna().all()
+        assert result["win_place_prob"].isna().all()


### PR DESCRIPTION
## Summary

- `fetch_race_features()` を `data.py` に追加: `features.training_data` から指定レースの全馬特徴量を一括取得
- `fetch_race_place_odds()` を `data.py` に追加: `predictions.daily_odds` から複勝オッズをレース単位で取得
- `_compute_realtime_predictions()` を `shap_explain.py` に追加: 最新GCSモデルで全馬の `pred_score`・`win_place_prob`・`rank_in_race` をリアルタイム計算
- `shap_explain.py` の `render()` を修正: `daily_predictions` 参照をやめ、リアルタイム計算値でヘッダー・馬選択プルダウンを表示

## 背景

`daily_predictions` はAM8時の自動予測保存値のため、その後モデルが更新されると SHAP 計算（最新モデル）とヘッダー（旧モデル保存値）が乖離する問題があった。本PRにより両者が最新GCSモデルで統一される。

## 変更なし仕様

- `features.training_data` を使う点（変更なし）
- GCS最新モデルを使う点（変更なし）
- SHAPウォーターフォールの計算ロジック（変更なし）
- `daily_predictions` は投資戦略・馬券購入フローでは引き続き使用（スコープ外）

## Test plan

- [x] `_compute_realtime_predictions`: 必須カラム確認・スコア降順ランク・win_place_prob合計値・特徴量なし時NaN の4テスト追加
- [x] `fetch_race_features`: 正常系・BQエラー・project_id空 の3テスト追加
- [x] `fetch_race_place_odds`: 正常系・BQエラー の2テスト追加
- [x] 既存テスト30件全通過（計30件→30件）

🤖 Generated with [Claude Code](https://claude.com/claude-code)