### PR TITLE
feat: 母馬特徴量カバレッジ向上 - pedigree.dam_id から horse_results 名前マッチに変更（Issue #325）

### DIFF
--- a/src/ml/features/feature_query_raw.sql
+++ b/src/ml/features/feature_query_raw.sql
@@ -1775,12 +1775,13 @@ with temp_race_horse_count as (
   from temp_sire_te_pre
 )
 
-/* 母馬（繁殖牝馬）競走実績特徴量（Issue #307）
-   カテゴリA: pedigree.dam_id 経由で母馬自身の実績を集計
-   dam_id IS NULL（外国産馬等）の場合は全カラム NULL で対応 */
+/* 母馬（繁殖牝馬）競走実績特徴量（Issue #307 / Issue #325修正）
+   pedigree.dam_id 経由から horse_results.horse_name = horse_master.dam_name への直接JOINに変更。
+   horse_master 未収録の古い繁殖牝馬（2005〜2015年頃現役）も horse_results 経由で実績取得できる。
+   同名馬が複数存在する場合は出走数最多の馬を母馬として選択する。 */
 ,temp_mare_race_base as (
   select
-    p.horse_id
+    h_m.horse_id
     ,ri_d.course_type
     ,ri_d.venue_code
     ,case
@@ -1793,17 +1794,35 @@ with temp_race_horse_count as (
     ,ri_d.distance
     ,case when rr_d.finish_position between 1 and 3 then 1 else 0 end as is_top3
     ,date_diff(ri_d.race_date, hm_d.birth_date, year) as horse_age_at_race
-  from `{project_id}`.raw.pedigree as p
+  from `{project_id}`.raw.horse_master as h_m
+  join (
+    /* 同名馬が複数存在する場合は出走数最多の馬を母馬として採用 */
+    select
+      horse_name
+      ,horse_id
+      ,row_number() over (
+        partition by horse_name
+        order by race_count desc, horse_id
+      ) as rn
+    from (
+      select horse_name, horse_id, count(*) as race_count
+      from `{project_id}`.raw.horse_results
+      where horse_name is not null
+      group by horse_name, horse_id
+    )
+  ) as dam_id_lookup
+    on dam_id_lookup.horse_name = h_m.dam_name
+    and dam_id_lookup.rn = 1
   join `{project_id}`.raw.horse_results as hr_d
-    on hr_d.horse_id = p.dam_id
+    on hr_d.horse_id = dam_id_lookup.horse_id
   join `{project_id}`.raw.race_results as rr_d
     on rr_d.race_id = hr_d.race_id
     and rr_d.horse_number = hr_d.horse_number
   join `{project_id}`.raw.race_info as ri_d
     on ri_d.race_id = hr_d.race_id
-  join `{project_id}`.raw.horse_master as hm_d
-    on hm_d.horse_id = p.dam_id
-  where p.dam_id is not null
+  left join `{project_id}`.raw.horse_master as hm_d
+    on hm_d.horse_id = dam_id_lookup.horse_id
+  where h_m.dam_name is not null
     and rr_d.finish_position > 0
     and ri_d.course_type != 'obstacle'
 )

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1363,7 +1363,7 @@ class TestMareFeature:
         section = content[mare_base_start:mare_stats_start]
         assert "!= 'obstacle'" in section, "temp_mare_race_base に障害戦除外フィルタがありません"
         assert "finish_position > 0" in section, "temp_mare_race_base に finish_position > 0 フィルタがありません"
-        assert "dam_id is not null" in section, "temp_mare_race_base に dam_id not null フィルタがありません"
+        assert "dam_name is not null" in section, "temp_mare_race_base に dam_name not null フィルタがありません"
 
     def test_sql_mare_race_base_joins_on_horse_number(self):
         """temp_mare_race_base が race_results を horse_number でも JOIN すること（クロスJOIN防止）"""
@@ -1554,13 +1554,13 @@ class TestAgeBasedTEFeature:
             "mare_precocity_index の計算式が正しくありません"
 
     def test_sql_mare_race_base_joins_horse_master_for_birth_date(self):
-        """temp_mare_race_base が horse_master を dam_id でJOINして birth_date を取得すること"""
+        """temp_mare_race_base が dam_id_lookup を使って horse_results を JOIN して birth_date を取得すること"""
         content = SQL_TEMPLATE_PATH.read_text(encoding="utf-8")
         mare_base_start = content.find("temp_mare_race_base as (")
         mare_stats_start = content.find("temp_mare_stats as (")
         section = content[mare_base_start:mare_stats_start]
-        assert "hm_d.horse_id = p.dam_id" in section, \
-            "temp_mare_race_base に horse_master の dam_id JOIN がありません"
+        assert "dam_id_lookup" in section, \
+            "temp_mare_race_base に dam_id_lookup サブクエリがありません"
         assert "horse_age_at_race" in section, \
             "temp_mare_race_base に horse_age_at_race がありません"
 


### PR DESCRIPTION
## 概要

`temp_mare_race_base` CTE の母馬解決ロジックを `pedigree.dam_id` 経由から `horse_results.horse_name = horse_master.dam_name` の直接JOINに変更する。

## 変更内容

### `src/ml/features/feature_query_raw.sql`
- `temp_mare_race_base` CTE を変更:
  - **変更前**: `raw.pedigree` の `dam_id` で `horse_results` を JOIN（pedigree テーブルの整合性に依存）
  - **変更後**: `horse_master.dam_name` でデdup済み `dam_id_lookup` を生成し、`horse_results` を直接 JOIN

### `tests/test_features.py`
- `test_sql_mare_race_base_filters_obstacle`: `"dam_id is not null"` → `"dam_name is not null"` に更新
- `test_sql_mare_race_base_joins_horse_master_for_birth_date`: `"hm_d.horse_id = p.dam_id"` → `"dam_id_lookup"` の存在確認に更新

## 精度改善

母馬TE特徴量の解決率が向上：
- **変更前**: 11.5%（31,481件中 3,620件）— pedigree.dam_id は古い繁殖牝馬（2005-2015年活躍）が未登録
- **変更後**: 22.8%（31,481件中 7,175件）— horse_results の horse_name マッチで対象を拡大

## テスト結果

```
230 passed in 1.20s
```